### PR TITLE
docs: improve CONTRIBUTING (claim flow, local CI steps, first-PR approval note)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,12 @@
 
 Thank you for your interest in contributing to AquaScope! This project aims to be a community-driven resource for water researchers worldwide. Whether you are a hydrologist, environmental engineer, data scientist, or student — your contributions are welcome.
 
+## Finding Something to Work On
+
+- Browse issues labeled [`good first issue`](https://github.com/Rekin226/aquascope/labels/good%20first%20issue) — these are scoped, self-contained, and have clear acceptance criteria.
+- Want to add your country's water data? See the pinned [**Data sources wanted**](https://github.com/Rekin226/aquascope/issues) meta-issue.
+- **To claim an issue**, just comment on it (e.g. "I'd like to work on this"). A maintainer will assign it to you — outside contributors can't self-assign, so the comment is how we hand it over. This avoids two people doing the same work.
+
 ## Ways to Contribute
 
 ### 1. Add a New Data Source Collector
@@ -13,6 +19,9 @@ We want to cover water APIs from every country. To add a new collector:
 3. Map raw API fields to our unified schemas in `aquascope/schemas/water_data.py`.
 4. Add tests in `tests/test_collectors/`.
 5. Document the data source in your module docstring (API URL, required keys, datasets).
+
+The cleanest reference to copy is `aquascope/collectors/usgs.py`, and there's a full walkthrough in
+[`docs/guides/adding_data_source.md`](https://rekin226.github.io/aquascope/guides/adding_data_source/).
 
 ```python
 from aquascope.collectors.base import BaseCollector
@@ -59,7 +68,7 @@ Bug fixes and documentation improvements are always welcome.
 ## Development Setup
 
 ```bash
-# Clone the repo
+# Clone the repo (or your fork)
 git clone https://github.com/Rekin226/aquascope.git
 cd aquascope
 
@@ -70,25 +79,38 @@ source .venv/bin/activate  # Linux/macOS
 
 # Install in editable mode with dev dependencies
 pip install -e ".[dev,all]"
+```
 
-# Run tests
-pytest
+## Before You Push: Make CI Green Locally
 
-# Run linter
+Our CI runs three required checks on every PR: **lint** and **test** on Python 3.10, 3.11, and 3.12. Run them locally first — it's much faster than waiting on CI:
+
+```bash
+# 1. Lint (this is the one that most often trips up first PRs)
 ruff check aquascope/ tests/
 
-# Type checking
-mypy aquascope/ --ignore-missing-imports
+# Auto-fix the easy stuff (import sorting, etc.) before committing:
+ruff check aquascope/ tests/ --fix
+
+# 2. Tests
+pytest
+
+# 3. Type checking — scope it to the file(s) you changed.
+#    The repo has a known backlog of pre-existing mypy findings in other
+#    modules; don't be alarmed by errors outside your change.
+mypy aquascope/path/to/your_file.py --follow-imports=skip --ignore-missing-imports
 ```
+
+> **First-time contributor?** GitHub holds the CI run on your first PR until a maintainer approves it (you'll see checks marked "action required" / pending). This is normal and not a problem with your code — we'll approve it. Running the checks locally as above means it passes first try.
 
 ## Pull Request Guidelines
 
-1. **Fork** the repository and create a feature branch.
+1. **Fork** the repository and create a feature branch (don't work on `main`).
 2. Write tests for new functionality.
-3. Ensure `pytest`, `ruff check`, and `mypy` pass.
+3. Ensure `ruff check`, `pytest`, and (scoped) `mypy` pass locally.
 4. Keep commits atomic and write clear commit messages.
 5. Update documentation if you change public APIs.
-6. Reference related issues in your PR description.
+6. Reference the related issue in your PR description (e.g. `Closes #8`).
 
 ## Code Style
 


### PR DESCRIPTION
Improves `CONTRIBUTING.md` with the practical guidance that has been coming up repeatedly when onboarding new contributors.

## What changed
- **New "Finding Something to Work On" section** — documents the comment-to-claim flow (outside contributors can't self-assign, so a comment is how a maintainer hands the issue over) and links the pinned *Data sources wanted* meta-issue (#11).
- **New "Before You Push: Make CI Green Locally" section** — lists the three required checks (lint + test on 3.10/3.11/3.12), shows `ruff check --fix` for auto-fixable lint (e.g. import sorting), and explains the **first-PR CI approval gate** so contributors don't think their PR is broken when checks sit in "action required".
- **Scoped mypy guidance** — points contributors at `mypy <your_file> --follow-imports=skip --ignore-missing-imports` so the pre-existing repo-wide mypy backlog doesn't scare them off.
- Minor: "don't work on `main`", `Closes #N` example, pointer to `usgs.py` + the adding-a-data-source guide.

Docs-only change; no code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)