### PR TITLE
Added India WRIS river water level collector

### DIFF
--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -22,6 +22,9 @@ import sys
 from datetime import date
 from pathlib import Path
 
+#----------------------------------------------------------
+from aquascope.collectors.india_wris import IndiaWRISCollector
+
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s  %(levelname)-8s  %(name)s — %(message)s",
@@ -104,6 +107,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         "eu_wfd": lambda: EUWFDCollector(),
         "japan_mlit": lambda: JapanMLITCollector(),
         "korea_wamis": lambda: KoreaWAMISCollector(),
+        "india_wris": lambda: IndiaWRISCollector(),
     }
 
     if source not in collector_map:

--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -5,6 +5,7 @@ from aquascope.collectors.base import BaseCollector
 from aquascope.collectors.copernicus import CopernicusCollector
 from aquascope.collectors.eu_wfd import EUWFDCollector
 from aquascope.collectors.gemstat import GEMStatCollector
+from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.japan_mlit import JapanMLITCollector
 from aquascope.collectors.korea_wamis import KoreaWAMISCollector
 from aquascope.collectors.openmeteo import OpenMeteoCollector
@@ -42,4 +43,5 @@ __all__ = [
     "USGSCollector",
     "WaPORCollector",
     "WQPCollector",
+    "IndiaWRISCollector",
 ]

--- a/aquascope/collectors/india_wris.py
+++ b/aquascope/collectors/india_wris.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.schemas.water_data import (
+    DataSource,
+    GeoLocation,
+    WaterLevelReading,
+)
+from aquascope.utils.http_client import CachedHTTPClient, RateLimiter
+
+logger = logging.getLogger(__name__)
+
+BASE_URL = "https://indiawris.gov.in"
+
+
+class IndiaWRISCollector(BaseCollector):
+    """Collector for India WRIS river water level data."""
+
+    name = "india_wris"
+
+    def __init__(
+        self,
+        client: CachedHTTPClient | None = None,
+    ):
+        super().__init__(
+            client
+            or CachedHTTPClient(
+                base_url=BASE_URL,
+                rate_limiter=RateLimiter(
+                    max_calls=25,
+                    period_seconds=60,
+                ),
+            )
+        )
+
+    def fetch_raw(
+        self,
+        state_name: str,
+        district_name: str,
+        agency_name: str,
+        startdate: str,
+        enddate: str,
+        page: int = 0,
+        size: int = 100,
+        **kwargs,
+    ) -> list[dict]:
+
+        data = self.client.post_json(
+            "/Dataset/River Water Level",
+            params={
+                "stateName": state_name,
+                "districtName": district_name,
+                "agencyName": agency_name,
+                "startdate": startdate,
+                "enddate": enddate,
+                "download": False,
+                "page": page,
+                "size": size,
+            },
+        )
+
+        return data.get("data", [])
+
+    def normalise(
+        self,
+        raw: list[dict],
+    ) -> Sequence[WaterLevelReading]:
+
+        readings = []
+
+        for row in raw:
+            try:
+                readings.append(
+                    WaterLevelReading(
+                        source=DataSource.INDIA_WRIS,
+                        station_id=row["stationCode"],
+                        station_name=row["stationName"],
+                        location=GeoLocation(
+                            latitude=row["latitude"],
+                            longitude=row["longitude"],
+                        ),
+                        reading_datetime=datetime.fromisoformat(
+                            row["dataTime"]
+                        ),
+                        water_level=float(row["dataValue"]),
+                        unit=row.get("unit", "m"),
+                        remark=row.get("description"),
+                    )
+                )
+
+            except (KeyError, ValueError, TypeError) as exc:
+                logger.debug(
+                    "Skipping India WRIS record: %s",
+                    exc,
+                )
+
+        return readings

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -35,6 +35,7 @@ class DataSource(str, Enum):
     TAIWAN_WRA_FHY = "taiwan_wra_fhy"
     TAIWAN_WRA_IOT = "taiwan_wra_iot"
     TAIWAN_DATAGOV = "taiwan_datagov"
+    INDIA_WRIS = "india_wris"
 
 
 class GeoLocation(BaseModel):

--- a/aquascope/utils/http_client.py
+++ b/aquascope/utils/http_client.py
@@ -194,6 +194,29 @@ class CachedHTTPClient:
 
         raise RuntimeError(f"All {self.retries} attempts failed for {url}") from last_exc
 
+
+    def post_json(
+        self,
+        path: str,
+        params: dict | None = None,
+        headers: dict | None = None,) -> Any:
+        if path.startswith(("http://", "https://")):
+            url = path
+        else:
+            url = f"{self.base_url}/{path.lstrip('/')}" if self.base_url else path
+
+        if self.rate_limiter:
+            self.rate_limiter.wait_if_needed()
+
+        resp = self._client.post(
+            url,
+            params=params,
+            headers=headers,
+        )
+
+        resp.raise_for_status()
+        return self._parse_response_json(resp)
+
     def close(self) -> None:
         self._client.close()
 
@@ -202,3 +225,5 @@ class CachedHTTPClient:
 
     def __exit__(self, *args):
         self.close()
+
+

--- a/tests/test_collectors/test_india_wris.py
+++ b/tests/test_collectors/test_india_wris.py
@@ -1,0 +1,29 @@
+from aquascope.collectors.india_wris import IndiaWRISCollector
+from aquascope.schemas.water_data import DataSource
+
+
+def test_normalise():
+    raw = [
+        {
+            "stationCode": "Asga",
+            "stationName": "Asga",
+            "latitude": 16.9139,
+            "longitude": 73.6,
+            "dataValue": 0.62,
+            "dataTime": "2017-06-01T08:30:00",
+            "unit": "m",
+            "description": "MANUAL-Water Level by Staff Gauge (0)",
+        }
+    ]
+
+    collector = IndiaWRISCollector()
+    records = collector.normalise(raw)
+
+    assert len(records) == 1
+
+    record = records[0]
+
+    assert record.source == DataSource.INDIA_WRIS
+    assert record.station_id == "Asga"
+    assert record.water_level == 0.62
+    assert record.unit == "m"


### PR DESCRIPTION


## Changes

- Added `IndiaWRISCollector`
- Added `INDIA_WRIS` to `DataSource`
- Added HTTP POST support via `CachedHTTPClient.post_json()`
- Registered collector in `aquascope.collectors.__init__`
- Registered collector in CLI `collector_map`
- Added unit tests for India WRIS normalization

## Data Source

India Water Resources Information System (India WRIS)

Endpoint used:

POST /Dataset/River Water Level

## Example Fields Mapped

| India WRIS | AquaScope |
|------------|-----------|
| stationCode | station_id |
| stationName | station_name |
| latitude/longitude | GeoLocation |
| dataTime | reading_datetime |
| dataValue | water_level |
| unit | unit |
| description | remark |

## Testing

```bash
ruff check aquascope/ tests/
pytest tests/test_collectors/test_india_wris.py -v
pytest
```






Closes #11