### PR TITLE
docs: sync data-source count to 15 across docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ The roadmap reflects what's shipped, what's in-flight, and what's planned. Open 
 
 ## Shipped
 
-- [x] 12 data source collectors (Taiwan, USA, Global, FAO)
+- [x] 15 data source collectors (Taiwan, USA, Global, FAO)
 - [x] 15 data source collectors (Taiwan ×4, USA ×2, Global ×5, FAO ×2, EU, Japan, Korea)
 - [x] Rule-based + LLM methodology recommender (26 methods, OpenAI / Groq / HuggingFace / Ollama)
 - [x] 7 auto-executable analysis pipelines

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,7 +22,7 @@ The most common entry points live in `aquascope.api`:
 
 ## Data collectors
 
-12 unified collectors. Every collector returns records in the same Pydantic schema.
+15 unified collectors. Every collector returns records in the same Pydantic schema.
 
 ::: aquascope.collectors
     options:

--- a/docs/assets/banner.svg
+++ b/docs/assets/banner.svg
@@ -53,7 +53,7 @@
       Water data · Hydrology · Agriculture · AI methodology recommendations
     </text>
     <g font-size="16" fill="#67e8f9">
-      <text x="302" y="232">12 data sources</text>
+      <text x="302" y="232">15 data sources</text>
       <text x="448" y="232">·</text>
       <text x="462" y="232">26 methodologies</text>
       <text x="638" y="232">·</text>

--- a/docs/features.md
+++ b/docs/features.md
@@ -4,7 +4,7 @@ Complete capability reference for AquaScope. For installation and a quick exampl
 
 ---
 
-## Data Collection (12 sources)
+## Data Collection (15 sources)
 
 - **Taiwan** — MOENV water quality, WRA levels/reservoirs, Civil IoT sensors
 - **USA** — USGS streamflow, Water Quality Portal (400+ agencies)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -50,7 +50,7 @@ print(len(records), "records")
 print(records[0])
 ```
 
-Every collector returns records in the **same Pydantic schema**, so downstream analyses don't care where the data came from. Switch `USGSCollector` to `WaporCollector`, `AquastatCollector`, or any of the [12 sources](data_sources.md). The rest of your code stays the same.
+Every collector returns records in the **same Pydantic schema**, so downstream analyses don't care where the data came from. Switch `USGSCollector` to `WaporCollector`, `AquastatCollector`, or any of the [15 sources](data_sources.md). The rest of your code stays the same.
 
 ---
 
@@ -144,7 +144,7 @@ You've now done end-to-end: collect, analyze, diagnose, recommend. The natural n
 - **[Features](features.md)**: the complete capability catalog.
 - **[Methodology matrix](methodology_matrix.md)**: when to use which method, decision-tree style.
 - **[Theory guide](theory.md)**: equations, citations, and decision trees for every method (668 lines, the closest thing AquaScope has to a textbook).
-- **[Data sources](data_sources.md)**: all 12 collectors with endpoint details and API-key requirements.
+- **[Data sources](data_sources.md)**: all 15 collectors with endpoint details and API-key requirements.
 - **[Integration guides](integration_guides/xarray_integration.md)**: interop with xarray, QGIS, R.
 
 Stuck? Check the [FAQ](faq.md), [troubleshooting](troubleshooting.md), or open a [discussion](https://github.com/Rekin226/aquascope/discussions).

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -27,7 +27,7 @@ flowchart TB
     end
 
     subgraph Data["Data Layer"]
-        COL["Collectors · 12 sources<br/>Taiwan · USA · Global · FAO"]
+        COL["Collectors · 15 sources<br/>Taiwan · USA · Global · FAO"]
         SCHEMA["Unified Pydantic Schemas"]
         IO["Scientific I/O<br/>WaterML · HEC · SWMM · NetCDF · HDF5"]
     end

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ pip install "aquascope[all]"       # everything: ML, viz, spatial, dashboard
 | Non-stationary GEV                           |    ✅     |   no    | partial  |          no           |
 | Baseflow separation (Lyne-Hollick, Eckhardt) |    ✅     |   no    |    no    |          no           |
 | FAO-56 Penman–Monteith ET₀ + crop water      |    ✅     |   no    |    no    |          no           |
-| 12 unified data collectors                   |    ✅     |   no    |    no    |       per-source       |
+| 15 unified data collectors                   |    ✅     |   no    |    no    |       per-source       |
 | AI methodology recommender                   |    ✅     |   no    |    no    |          no           |
 | Interactive Streamlit dashboard              |    ✅     |   no    |    no    |          no           |
 | Free, MIT, Python-native                     |    ✅     | partial |    ✅    |        varies         |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: AquaScope
 site_url: https://rekin226.github.io/aquascope/
-site_description: Hydrology toolkit for Python — flood frequency, baseflow, FAO-56 crop water, AI methodology recommender, 12 data sources
+site_description: Hydrology toolkit for Python — flood frequency, baseflow, FAO-56 crop water, AI methodology recommender, 15 data sources
 site_author: Rekin226
 repo_url: https://github.com/Rekin226/aquascope
 repo_name: Rekin226/aquascope


### PR DESCRIPTION
Updates stale "12 sources/collectors" references to **15** so the docs match the README and the shipped code.

[PR #14](https://github.com/Rekin226/aquascope/pull/14) exposed 5 additional collectors (AQUASTAT, EU WFD, Japan MLIT, Korea WAMIS, WaPOR), bringing the unified total to 15. The README and ROADMAP already said 15, but these files still said 12:

- `ROADMAP.md`
- `mkdocs.yml` (site description)
- `docs/assets/banner.svg`
- `docs/api.md`
- `docs/features.md`
- `docs/getting_started.md` (×2)
- `docs/guides/architecture.md`
- `docs/index.md` (comparison table)

9 single-token changes, no prose rewrites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)