### PR TITLE
fix: prevent irrigation efficiency losses from leaking into deep percolation (#38)

### DIFF
--- a/aquascope/agri/water_balance.py
+++ b/aquascope/agri/water_balance.py
@@ -216,7 +216,7 @@ class SoilWaterBalance:
 
         return pd.DataFrame(rows)
 
-def auto_irrigate(
+    def auto_irrigate(
         self,
         etc_series: pd.Series,
         precip_series: pd.Series,

--- a/aquascope/agri/water_balance.py
+++ b/aquascope/agri/water_balance.py
@@ -216,7 +216,7 @@ class SoilWaterBalance:
 
         return pd.DataFrame(rows)
 
-    def auto_irrigate(
+  def auto_irrigate(
         self,
         etc_series: pd.Series,
         precip_series: pd.Series,
@@ -231,12 +231,21 @@ class SoilWaterBalance:
         precip_series : pandas.Series
             Daily precipitation (mm).
         efficiency : float
-            Irrigation system efficiency (0–1).
+            Irrigation system efficiency (0-1).
 
         Returns
         -------
         pandas.DataFrame
             Daily water balance with ``irrigation_mm`` column.
+
+        Notes
+        -----
+        ``irrigation_mm`` reports the *gross* water applied (water pumped),
+        accounting for conveyance/application efficiency. Only the *net*
+        depth - the amount that actually reaches the root zone, i.e. the
+        depletion being refilled - is passed into :meth:`step`, so
+        conveyance/application losses are not double-counted as
+        ``deep_percolation_mm``.
         """
         import pandas as pd
 
@@ -245,20 +254,24 @@ class SoilWaterBalance:
             etc_val = float(etc_series.loc[idx])
             precip_val = float(precip_series.loc[idx]) if idx in precip_series.index else 0.0
 
-            # Auto-irrigate: if depletion would exceed RAW, apply enough water
-            irrigation = 0.0
+            # Auto-irrigate: if depletion would exceed RAW, refill the root
+            # zone to field capacity. `net_applied` is what reaches the soil
+            # (used in the balance); `gross_applied` is what was pumped
+            # (reported to the user).
+            gross_applied = 0.0
+            net_applied = 0.0
             if self.depletion >= self.raw:
-                # Refill to field capacity
                 net_needed = self.depletion
-                irrigation = net_needed / efficiency if efficiency > 0 else net_needed
+                gross_applied = net_needed / efficiency if efficiency > 0 else net_needed
+                net_applied = net_needed
 
-            status = self.step(etc_val, precipitation=precip_val, irrigation=irrigation)
+            status = self.step(etc_val, precipitation=precip_val, irrigation=net_applied)
             rows.append({
                 "date": idx,
                 "soil_moisture_mm": status.soil_moisture_mm,
                 "depletion_mm": status.depletion_mm,
                 "deep_percolation_mm": status.deep_percolation_mm,
-                "irrigation_mm": round(irrigation, 2),
+                "irrigation_mm": round(gross_applied, 2),
                 "irrigation_trigger": status.irrigation_trigger,
             })
 

--- a/aquascope/agri/water_balance.py
+++ b/aquascope/agri/water_balance.py
@@ -216,7 +216,7 @@ class SoilWaterBalance:
 
         return pd.DataFrame(rows)
 
-  def auto_irrigate(
+def auto_irrigate(
         self,
         etc_series: pd.Series,
         precip_series: pd.Series,

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -365,8 +365,7 @@ class TestSoilWaterBalance:
             swb = SoilWaterBalance(self.soil)
             df = swb.auto_irrigate(etc, precip, efficiency=efficiency)
             applied[efficiency] = df["irrigation_mm"].sum()
-
-        assert applied[0.5] > applied[0.9]
+            assert applied[0.5] > applied[0.9]
         
     def test_deep_percolation_after_heavy_rain(self):
         """DP > 0 when P pushes moisture above FC."""

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -368,7 +368,6 @@ class TestSoilWaterBalance:
 
         assert applied[0.5] > applied[0.9]
         
-
     def test_deep_percolation_after_heavy_rain(self):
         """DP > 0 when P pushes moisture above FC."""
         swb = SoilWaterBalance(self.soil, initial_depletion=5.0)

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -365,7 +365,8 @@ class TestSoilWaterBalance:
             swb = SoilWaterBalance(self.soil)
             df = swb.auto_irrigate(etc, precip, efficiency=efficiency)
             applied[efficiency] = df["irrigation_mm"].sum()
-            assert applied[0.5] > applied[0.9]
+
+        assert applied[0.5] > applied[0.9]
 
     def test_deep_percolation_after_heavy_rain(self):
         """DP > 0 when P pushes moisture above FC."""

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -337,6 +337,38 @@ class TestSoilWaterBalance:
         df = swb.auto_irrigate(etc, precip)
         assert df["irrigation_mm"].sum() > 0
 
+    def test_auto_irrigate_no_deep_percolation_from_efficiency_loss(self):
+        """Application/conveyance losses must not appear as deep percolation.
+
+        Regression test for issue #38: previously, the full gross
+        irrigation (net_needed / efficiency) was passed into step(),
+        so at low efficiency the "extra" water counted as deep
+        percolation even though it never reached the root zone.
+        """
+        n_days = 14
+        etc = _make_daily_series(n_days, 10.0)
+        precip = _make_daily_series(n_days, 0.0)
+
+        for efficiency in (0.9, 0.5):
+            swb = SoilWaterBalance(self.soil)
+            df = swb.auto_irrigate(etc, precip, efficiency=efficiency)
+            assert df["deep_percolation_mm"].sum() == pytest.approx(0.0, abs=0.01)
+
+    def test_auto_irrigate_gross_reflects_efficiency(self):
+        """irrigation_mm (gross applied/pumped) should rise as efficiency drops."""
+        n_days = 14
+        etc = _make_daily_series(n_days, 10.0)
+        precip = _make_daily_series(n_days, 0.0)
+
+        applied = {}
+        for efficiency in (0.9, 0.5):
+            swb = SoilWaterBalance(self.soil)
+            df = swb.auto_irrigate(etc, precip, efficiency=efficiency)
+            applied[efficiency] = df["irrigation_mm"].sum()
+
+        assert applied[0.5] > applied[0.9]
+        
+
     def test_deep_percolation_after_heavy_rain(self):
         """DP > 0 when P pushes moisture above FC."""
         swb = SoilWaterBalance(self.soil, initial_depletion=5.0)

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -366,7 +366,7 @@ class TestSoilWaterBalance:
             df = swb.auto_irrigate(etc, precip, efficiency=efficiency)
             applied[efficiency] = df["irrigation_mm"].sum()
             assert applied[0.5] > applied[0.9]
-        
+
     def test_deep_percolation_after_heavy_rain(self):
         """DP > 0 when P pushes moisture above FC."""
         swb = SoilWaterBalance(self.soil, initial_depletion=5.0)


### PR DESCRIPTION
Closes #38

## What this PR does
- Decouples "water reaching the root zone" (net) from "water pumped" 
  (gross) in auto_irrigate
- Only net_needed (the actual depletion being refilled) is passed to 
  step(), so conveyance/application losses no longer register as 
  deep_percolation
- irrigation_mm still reports the gross applied amount, so low 
  efficiency continues to show more pumped water

## Before
eff=0.5: applied=160.0mm  deep_perc=70.0mm (70mm of efficiency loss 
incorrectly routed through the soil as deep percolation)

## After
eff=0.5: applied=160.0mm  deep_perc=~0mm

## Tests
Added 2 regression tests covering the reproduction case from the issue:
- deep_percolation stays ~0 at low efficiency
- irrigation_mm (gross) still increases as efficiency drops