### PR TITLE
docs: contributor recognition (all-contributors) + contributor ladder

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,16 @@ Thank you for your interest in contributing to AquaScope! This project aims to b
 - Want to add your country's water data? See the pinned [**Data sources wanted**](https://github.com/Rekin226/aquascope/issues/11) meta-issue.
 - **To claim an issue**, just comment on it (e.g. "I'd like to work on this"). A maintainer will assign it to you — outside contributors can't self-assign, so the comment is how we hand it over. This avoids two people doing the same work.
 
+### The contributor ladder
+
+We'd love for you to stick around past your first PR, so there's a clear path to grow:
+
+1. **First PR** — start with a [`good first issue`](https://github.com/Rekin226/aquascope/labels/good%20first%20issue). Scoped, self-contained, clear acceptance criteria.
+2. **Ready for more** — graduate to a [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue): a slightly larger, self-contained piece (a new method, a new module) that builds on what you just learned. When we merge your first PR, we'll usually point you straight at one that fits.
+3. **Area owner** — after a few PRs in one area (agriculture, hydrology, collectors, ...), we'll invite you to help **triage and review** issues there. This is how contributors become maintainers.
+
+Every merged PR is also credited in [CONTRIBUTORS.md](CONTRIBUTORS.md) and the README, code, tests, docs, data, and translations all count. If you want to take on more, just say so on any issue or in [Discussions](https://github.com/Rekin226/aquascope/discussions).
+
 ## Ways to Contribute
 
 ### 1. Add a New Data Source Collector

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,37 @@
+# Contributors
+
+AquaScope is built by the global water and agriculture research community. **Every merged pull request earns a spot here**, code, tests, docs, data collectors, translations, bug reports, and reviews all count.
+
+The canonical, visible list lives in the [Contributors section of the README](README.md#-contributors). This file explains how recognition works and what the emoji keys mean.
+
+## How you get added
+
+1. Open a PR (see [CONTRIBUTING.md](CONTRIBUTING.md)).
+2. When it merges, a maintainer adds you to the Contributors table in the README, with an emoji for the kind of contribution.
+3. That's it. There is no minimum, your first merged PR puts you on the board.
+
+We follow the [all-contributors](https://allcontributors.org/) spec, which recognizes **every** kind of contribution, not just code.
+
+## Contribution key
+
+| Emoji | Meaning |
+| :---: | :--- |
+| 💻 | Code |
+| ⚠️ | Tests |
+| 📖 | Documentation |
+| 🔌 | Data source collector |
+| 🐛 | Bug reports / fixes |
+| 🌍 | Translation / i18n |
+| 👀 | Review |
+| 🎨 | Design / visualization |
+| 🚧 | Maintenance |
+
+## The contributor ladder
+
+We want contributors to stay and grow, not disappear after one PR. There's a clear path:
+
+1. **First PR** — pick a [`good first issue`](https://github.com/Rekin226/aquascope/labels/good%20first%20issue). Scoped, self-contained, clear acceptance criteria.
+2. **Ready for more** — graduate to a [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue): a slightly larger, self-contained piece (a new method, a new module) that builds on what you just learned. When we merge your first PR, we'll usually point you at one that fits.
+3. **Area owner** — after a few PRs in one area (e.g. agriculture, hydrology, collectors), we'll invite you to help **triage and review** issues in that area. This is how contributors become maintainers.
+
+If you've landed a couple of PRs and want to take on more responsibility, just say so on any issue or in [Discussions](https://github.com/Rekin226/aquascope/discussions), we'd love to have you.

--- a/README.md
+++ b/README.md
@@ -325,6 +325,30 @@ Browse the [full issue list](https://github.com/Rekin226/aquascope/issues) or vo
 
 See [CONTRIBUTING.md](CONTRIBUTING.md), the [adding a data source](docs/guides/adding_data_source.md) guide, and the [adding a methodology](docs/guides/adding_methodology.md) guide.
 
+### 🪜 The contributor ladder
+
+We want contributors to grow, not vanish after one PR. There's a clear path: start with a [`good first issue`](https://github.com/Rekin226/aquascope/labels/good%20first%20issue), then graduate to a [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) (a bigger self-contained piece that builds on what you learned), and after a few PRs in one area we'll invite you to help triage and review. See [CONTRIBUTORS.md](CONTRIBUTORS.md) for details.
+
+## 🙌 Contributors
+
+Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRIBUTORS.md#contribution-key)):
+
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Rekin226"><img src="https://github.com/Rekin226.png?size=100" width="100px;" alt="Abdoul Rachid Ouedraogo"/><br /><sub><b>Abdoul Rachid Ouedraogo</b></sub></a><br />💻 📖 🚧</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/vaishnavidesai09"><img src="https://github.com/vaishnavidesai09.png?size=100" width="100px;" alt="Vaishnavi Desai"/><br /><sub><b>Vaishnavi Desai</b></sub></a><br />🔌</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Karthick03219"><img src="https://github.com/Karthick03219.png?size=100" width="100px;" alt="Karthick"/><br /><sub><b>Karthick</b></sub></a><br />💻</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/sagiB74"><img src="https://github.com/sagiB74.png?size=100" width="100px;" alt="sagiB74"/><br /><sub><b>sagiB74</b></sub></a><br />⚠️</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/laishettikarthik-tech"><img src="https://github.com/laishettikarthik-tech.png?size=100" width="100px;" alt="Karthik Laishetti"/><br /><sub><b>Karthik Laishetti</b></sub></a><br />💻 🐛</td>
+    </tr>
+  </tbody>
+</table>
+<!-- ALL-CONTRIBUTORS-LIST:END -->
+
+Your first merged PR puts you on this board, every kind of contribution counts. See [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ## 📜 Citation
 
 If you use AquaScope in your research, please cite:

--- a/README.md
+++ b/README.md
@@ -162,12 +162,13 @@ eto = penman_monteith_daily(
 # Crop water requirement for maize from planting through harvest
 cwr = crop_water_requirement(eto_series, crop="maize", planting_date=date(2026, 4, 1))
 
-# Soil water balance with auto-irrigation triggers
+# Soil water balance with auto-irrigation triggers — returns a daily DataFrame
 soil    = SoilProperties(field_capacity=0.30, wilting_point=0.15, root_depth=1.0)
 balance = SoilWaterBalance(soil).auto_irrigate(
-    etc=cwr.etc, precip=precip_series, efficiency=0.7,
+    cwr["etc"], precip_series, efficiency=0.7,
 )
-print(balance.total_irrigation_mm, balance.deficit_days)
+print(balance["irrigation_mm"].sum())             # total irrigation applied (mm)
+print(int(balance["irrigation_trigger"].sum()))   # number of deficit days
 ```
 
 ### 5. AI methodology recommender


### PR DESCRIPTION
## Why

Most of our contributors do one PR and disappear. The biggest lever against that is a visible **path to grow** plus **public credit**. This adds both, no code changes.

## What

- **`CONTRIBUTORS.md`** (new): recognition policy (every merged PR earns a spot, all contribution types count), an emoji key, and the contributor ladder.
- **README** → new **🙌 Contributors** section with an [all-contributors](https://allcontributors.org/)-style table (current 5 contributors), plus a short "contributor ladder" blurb under Contributing.
- **CONTRIBUTING.md** → a **contributor ladder** section under "Finding Something to Work On": `good first issue` → `good second issue` → area owner, so first-PR authors always have a named next step.

This pairs with the new [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) label and issues #43–#45 (the second rung).

## Credits in this PR

@Rekin226 · @vaishnavidesai09 (India WRIS collector) · @Karthick03219 (type annotations) · @sagiB74 (SoilWaterBalance edge-case tests) · @laishettikarthik-tech (irrigation efficiency fix)

## Notes
- Docs-only; no source touched, so lint/test jobs are unaffected.
- Avatars use GitHub's `https://github.com/<user>.png` so the table needs no build step or bot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
