### PR TITLE
docs: add MAINTAINERS.md with area owners

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We'd love for you to stick around past your first PR, so there's a clear path to
 
 1. **First PR** — start with a [`good first issue`](https://github.com/Rekin226/aquascope/labels/good%20first%20issue). Scoped, self-contained, clear acceptance criteria.
 2. **Ready for more** — graduate to a [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue): a slightly larger, self-contained piece (a new method, a new module) that builds on what you just learned. When we merge your first PR, we'll usually point you straight at one that fits.
-3. **Area owner** — after a few PRs in one area (agriculture, hydrology, collectors, ...), we'll invite you to help **triage and review** issues there. This is how contributors become maintainers.
+3. **Area owner** — after a few PRs in one area (agriculture, hydrology, collectors, ...), we'll invite you to help **triage and review** issues there, and add you to [MAINTAINERS.md](MAINTAINERS.md). This is how contributors become maintainers.
 
 Every merged PR is also credited in [CONTRIBUTORS.md](CONTRIBUTORS.md) and the README, code, tests, docs, data, and translations all count. If you want to take on more, just say so on any issue or in [Discussions](https://github.com/Rekin226/aquascope/discussions).
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,25 @@
+# Maintainers & area owners
+
+AquaScope is maintained by its community. This file records who looks after what, the top rung of the [contributor ladder](CONTRIBUTING.md): contributors who have shipped solid work in an area and now help **review and steward** it.
+
+Area owners are looped in on pull requests touching their area and are trusted to review them. Ownership is earned through contributions, not assigned, and it is always shared: anyone is welcome to contribute to any area.
+
+## Overall maintainer
+
+| Maintainer | Responsibility |
+| :--- | :--- |
+| [@Rekin226](https://github.com/Rekin226) | Project lead, releases, overall direction |
+
+## Area owners
+
+| Area | Owner | Notable work |
+| :--- | :--- | :--- |
+| Hydrology / baseflow | [@laishettikarthik-tech](https://github.com/laishettikarthik-tech) | UKIH smoothed-minima baseflow ([#48](https://github.com/Rekin226/aquascope/pull/48)), irrigation efficiency fix ([#39](https://github.com/Rekin226/aquascope/pull/39)) |
+
+## How to become an area owner
+
+1. Ship a couple of solid PRs in one area (see the [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) tier).
+2. Review a few PRs from others in that area, anyone can review on a public repo, no special access needed.
+3. A maintainer adds you here and starts looping you in on relevant PRs. As trust grows, this can come with write access so your reviews carry weight via `CODEOWNERS`.
+
+Interested? Just say so on any issue or in [Discussions](https://github.com/Rekin226/aquascope/discussions). We would love the help.


### PR DESCRIPTION
## What

Adds `MAINTAINERS.md` formalizing the **area owner** rung of the contributor ladder, and names our first area owner.

- **@laishettikarthik-tech** → Hydrology / baseflow owner (UKIH method #48, irrigation efficiency fix #39).
- Documents how the role is earned (ship → review → get added) and how it can lead to write access via `CODEOWNERS`.
- Links the new file from the CONTRIBUTING ladder.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
