### PR TITLE
chore: add CODEOWNERS (hydrology -> area owner)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# Code owners for AquaScope
+#
+# GitHub auto-requests a review from the listed owner when a PR touches
+# matching paths. See https://docs.github.com/articles/about-code-owners
+#
+# NOTE: A code owner is only auto-requested if they have *write* access to
+# the repo. Entries for read-access collaborators stay dormant until their
+# access is upgraded, so this file is safe to land ahead of time. See
+# MAINTAINERS.md for the area-owner ladder.
+
+# Default owner for anything not matched below.
+*                       @Rekin226
+
+# Area owners (see MAINTAINERS.md).
+/aquascope/hydrology/   @laishettikarthik-tech
+/tests/test_hydrology/  @laishettikarthik-tech


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS`:
- `@Rekin226` as default owner.
- `aquascope/hydrology/` and `tests/test_hydrology/` → `@laishettikarthik-tech` (area owner per MAINTAINERS.md).

## Why now

Code owners are only auto-requested for review when they have **write** access. @laishettikarthik-tech currently has Read, so these entries are **dormant** and harmless. Landing the wiring now means his reviews start getting auto-requested the moment his access is bumped to Write, no extra step later.

Config-only; no source or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
