### PR TITLE
docs: add Major features section to ROADMAP

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -35,6 +35,16 @@ The roadmap reflects what's shipped, what's in-flight, and what's planned. Open 
 - [ ] ReadTheDocs hosting
 - [ ] NumFOCUS Sponsored Project application
 
+## Major features — leveling up
+
+Ambitious, high-impact work that takes AquaScope to the next level. These are [`major feature`](https://github.com/Rekin226/aquascope/labels/major%20feature) · `help wanted` — larger than a weekend, mentorship available. Comment on the issue to discuss scope before starting.
+
+- [ ] Conceptual rainfall-runoff model (GR4J) + auto-calibration with NSE/KGE ([#52](https://github.com/Rekin226/aquascope/issues/52)) — *keystone: feeds #53 and #56*
+- [ ] Prediction in Ungauged Basins — regionalize signatures/parameters ([#53](https://github.com/Rekin226/aquascope/issues/53))
+- [ ] Declarative, reproducible study runner `aquascope run study.yaml` with provenance ([#54](https://github.com/Rekin226/aquascope/issues/54))
+- [ ] Plugin architecture — third-party collectors & methodologies via entry points ([#55](https://github.com/Rekin226/aquascope/issues/55))
+- [ ] Large-sample CAMELS benchmark — automated accuracy report ([#56](https://github.com/Rekin226/aquascope/issues/56))
+
 ## Good first issues — up for grabs
 
 Newcomers welcome. Just comment to claim one, then follow the [contributor ladder](CONTRIBUTING.md) (`good first issue` → `good second issue` → area owner).
@@ -43,7 +53,7 @@ Newcomers welcome. Just comment to claim one, then follow the [contributor ladde
 - [ ] Colorblind-safe plot palette in `viz/styles.py` ([#41](https://github.com/Rekin226/aquascope/issues/41))
 - [ ] Edge-case tests for baseflow separation ([#42](https://github.com/Rekin226/aquascope/issues/42))
 
-**Ready for more?** The [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) tier: UKIH baseflow method ([#43](https://github.com/Rekin226/aquascope/issues/43)), Mann-Kendall trend test + Sen's slope ([#44](https://github.com/Rekin226/aquascope/issues/44)), flow-duration-curve slope + runoff ratio ([#45](https://github.com/Rekin226/aquascope/issues/45)).
+**Ready for more?** The [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) tier: Mann-Kendall trend test + Sen's slope ([#44](https://github.com/Rekin226/aquascope/issues/44)) and flow-duration-curve slope + runoff ratio ([#45](https://github.com/Rekin226/aquascope/issues/45)). _(UKIH baseflow #43 — ✅ shipped in #48.)_
 
 ## How to influence the roadmap
 


### PR DESCRIPTION
## What

Adds a **Major features — leveling up** section to `ROADMAP.md` surfacing the new `major feature` issues:

- #52 Conceptual rainfall-runoff (GR4J) + calibration *(keystone)*
- #53 Prediction in Ungauged Basins
- #54 Declarative `aquascope run study.yaml` runner
- #55 Plugin architecture (entry points)
- #56 Large-sample CAMELS benchmark

Also marks UKIH baseflow (#43) as shipped in #48 and tidies the good-second list.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
