### PR TITLE
feat: add geojson to collect command's --format option

### DIFF
--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -931,7 +931,7 @@ def main() -> None:
     p_collect.add_argument("--end-date", default=None, help="End date YYYY-MM-DD (openmeteo/copernicus)")
     p_collect.add_argument("--start-year", type=int, default=2000, help="Start year (AQUASTAT)")
     p_collect.add_argument("--end-year", type=int, default=2023, help="End year (AQUASTAT)")
-    p_collect.add_argument("--format", default="json", choices=["json", "csv"], help="Output format")
+    p_collect.add_argument("--format", default="json", choices=["json", "csv", "geojson"], help="Output format")
     p_collect.add_argument("--year", type=int, default=None, help="Year filter (EU WFD)")
     p_collect.add_argument(
         "--water-body-type", default=None,

--- a/aquascope/utils/storage.py
+++ b/aquascope/utils/storage.py
@@ -39,7 +39,7 @@ def save_records(
     prefix : str
         File name prefix.
     fmt : str
-        ``"json"`` or ``"csv"``.
+        ``"json"`` or ``"csv"`` or ``"geojson"``.
 
     Returns
     -------
@@ -62,6 +62,8 @@ def save_records(
             raise ImportError("pandas is required for CSV export.  pip install pandas")  # noqa: B904
         df = pd.DataFrame(dicts)
         df.to_csv(filepath, index=False)
+    elif fmt == "geojson":
+        export_geojson(records, filepath)
     else:
         raise ValueError(f"Unsupported format: {fmt!r}")
 

--- a/tests/test_utils/test_export_formats.py
+++ b/tests/test_utils/test_export_formats.py
@@ -9,7 +9,7 @@ import pandas as pd
 import pytest
 from pydantic import BaseModel
 
-from aquascope.utils.storage import export_geojson
+from aquascope.utils.storage import export_geojson, save_records
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -84,6 +84,16 @@ class TestExportGeoJSON:
         data = json.loads(out.read_text())
         assert data["type"] == "FeatureCollection"
         assert len(data["features"]) == 0
+
+    def test_save_records_geojson(self, tmp_path: Path) -> None:
+        out = save_records(self.records, tmp_path, prefix="test", fmt="geojson")
+        assert out.suffix == ".geojson"
+        assert out.exists()
+        data = json.loads(out.read_text())
+        assert data["type"] == "FeatureCollection"
+        assert len(data["features"]) == 2
+        assert data["features"][0]["geometry"]["type"] == "Point"
+
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?
Adds GeoJSON as a third output format for `aquascope collect`, alongside `json` and `csv`. Running `--format geojson` now exports records as a GeoJSON FeatureCollection for use in QGIS, web maps, etc. The change wires the existing, already-tested `export_geojson()` helper into `save_records()` and adds `geojson` to the `--format` choices — no new serialization logic.

## Why was this PR needed?
The command only supported `json` and `csv`, even though `export_geojson()` already existed. The gap was just wiring: `save_records()` had no `geojson` branch, and `geojson` wasn't in the CLI's `--format` choices, so argparse rejected it.

## What are the relevant issue numbers?
Closes #7

## Verification
- `aquascope collect --source gemstat --format geojson` → valid FeatureCollection (5000 features)
- `aquascope collect --source openmeteo ... --format geojson` → 14 features
- `aquascope collect --help` now lists `--format {json,csv,geojson}`
- `pytest` 825 passed / 1 skipped, `ruff` and scoped `mypy` clean

(Verified with gemstat/openmeteo rather than usgs — the USGS demo key returns HTTP 400 upstream, which is in the collector's network fetch, before the output path this PR touches.)

## Acceptance criteria
- [x] Tests added
- [x] All tests passing
- [x] Follows style guide (ruff/mypy clean)
- [x] No breaking changes

## Note
The existing `export_geojson()` skips records without a `location` rather than emitting `"geometry": null` as the issue described. I kept the existing tested behavior rather than change it here, happy to adjust if you'd prefer.