### PR TITLE
feat: add collect_many concurrent fetch helper with partial-failure handling (#59)

### DIFF
--- a/aquascope/utils/collect_many.py
+++ b/aquascope/utils/collect_many.py
@@ -1,0 +1,164 @@
+"""Concurrent multi-source data fetching with partial-failure handling.
+
+Provides :func:`collect_many`, a helper that runs multiple collector
+calls in parallel using a ``ThreadPoolExecutor``, respects per-host
+rate limiting, and returns both successes and structured failures
+instead of aborting on the first error.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CollectRequest:
+    """A single fetch request to be executed by :func:`collect_many`.
+
+    Attributes
+    ----------
+    key : str
+        Unique identifier for this request (e.g. station ID or source name).
+        Used to map results back to requests.
+    fn : Callable
+        Zero-argument callable that performs the fetch and returns data.
+        Wrap your collector call in a lambda or ``functools.partial``::
+
+            CollectRequest(
+                key="usgs_01234",
+                fn=lambda: usgs_collector.collect(site="01234"),
+            )
+    """
+
+    key: str
+    fn: Callable[[], Any]
+
+
+@dataclass
+class CollectResult:
+    """Aggregated result from :func:`collect_many`.
+
+    Attributes
+    ----------
+    successes : dict[str, Any]
+        Mapping of ``request.key`` → returned data for successful requests.
+    failures : list[CollectFailure]
+        Structured list of failures (key + exception) for failed requests.
+    """
+
+    successes: dict[str, Any] = field(default_factory=dict)
+    failures: list[CollectFailure] = field(default_factory=list)
+
+    @property
+    def n_success(self) -> int:
+        """Number of successful fetches."""
+        return len(self.successes)
+
+    @property
+    def n_failure(self) -> int:
+        """Number of failed fetches."""
+        return len(self.failures)
+
+
+@dataclass
+class CollectFailure:
+    """A single failed fetch request.
+
+    Attributes
+    ----------
+    key : str
+        The ``CollectRequest.key`` that failed.
+    error : Exception
+        The exception raised during the fetch.
+    """
+
+    key: str
+    error: Exception
+
+
+def collect_many(
+    requests: list[CollectRequest],
+    max_workers: int = 8,
+    progress_callback: Callable[[str, bool], None] | None = None,
+) -> CollectResult:
+    """Run multiple collector calls concurrently with partial-failure handling.
+
+    Executes each :class:`CollectRequest` in a thread pool.  One failing
+    request does not abort the batch — failures are collected and returned
+    alongside successes.  Per-host rate limiting is honoured because each
+    ``CollectRequest.fn`` calls through the collector's own
+    :class:`~aquascope.utils.http_client.CachedHTTPClient`, which already
+    coordinates with its :class:`~aquascope.utils.http_client.RateLimiter`.
+
+    Parameters
+    ----------
+    requests : list[CollectRequest]
+        Fetch requests to execute.  Order is not preserved in the result.
+    max_workers : int
+        Maximum number of concurrent threads (default 8).  Tune down if
+        rate limits are tight; tune up for many independent hosts.
+    progress_callback : callable, optional
+        Called after each request completes with ``(key, success)`` where
+        *success* is ``True`` on success and ``False`` on failure.  Use
+        this to drive a ``tqdm`` progress bar or a custom UI::
+
+            with tqdm(total=len(requests)) as pbar:
+                collect_many(
+                    requests,
+                    progress_callback=lambda key, ok: pbar.update(1),
+                )
+
+    Returns
+    -------
+    CollectResult
+        Aggregated successes and failures.
+
+    Examples
+    --------
+    >>> reqs = [
+    ...     CollectRequest(key="a", fn=lambda: fetch_station("A")),
+    ...     CollectRequest(key="b", fn=lambda: fetch_station("B")),
+    ... ]
+    >>> result = collect_many(reqs, max_workers=4)
+    >>> result.n_success, result.n_failure
+    (2, 0)
+    """
+    if not requests:
+        return CollectResult()
+
+    result = CollectResult()
+    n = len(requests)
+    logger.info("collect_many: starting %d requests with max_workers=%d", n, max_workers)
+
+    with ThreadPoolExecutor(max_workers=min(max_workers, n)) as executor:
+        future_to_key = {
+            executor.submit(req.fn): req.key
+            for req in requests
+        }
+
+        for future in as_completed(future_to_key):
+            key = future_to_key[future]
+            try:
+                data = future.result()
+                result.successes[key] = data
+                logger.debug("collect_many: ✓ %s", key)
+                if progress_callback:
+                    progress_callback(key, True)
+            except Exception as exc:
+                result.failures.append(CollectFailure(key=key, error=exc))
+                logger.warning("collect_many: ✗ %s — %s: %s", key, type(exc).__name__, exc)
+                if progress_callback:
+                    progress_callback(key, False)
+
+    logger.info(
+        "collect_many: done — %d succeeded, %d failed",
+        result.n_success,
+        result.n_failure,
+    )
+    return result

--- a/tests/test_collectors/test_collect_many.py
+++ b/tests/test_collectors/test_collect_many.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import threading
 import time
 
-import pytest
 
 from aquascope.utils.collect_many import (
     CollectFailure,

--- a/tests/test_collectors/test_collect_many.py
+++ b/tests/test_collectors/test_collect_many.py
@@ -1,5 +1,4 @@
 """Tests for aquascope.utils.collect_many."""
-
 from __future__ import annotations
 
 import threading

--- a/tests/test_collectors/test_collect_many.py
+++ b/tests/test_collectors/test_collect_many.py
@@ -11,7 +11,6 @@ from aquascope.utils.collect_many import (
     collect_many,
 )
 
-
 # ── Helpers ──────────────────────────────────────────────────────────────
 
 def _ok(key: str, value: object = None):

--- a/tests/test_collectors/test_collect_many.py
+++ b/tests/test_collectors/test_collect_many.py
@@ -1,0 +1,214 @@
+"""Tests for aquascope.utils.collect_many."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+import pytest
+
+from aquascope.utils.collect_many import (
+    CollectFailure,
+    CollectRequest,
+    CollectResult,
+    collect_many,
+)
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+def _ok(key: str, value: object = None):
+    """Return a CollectRequest that always succeeds."""
+    return CollectRequest(key=key, fn=lambda: value if value is not None else key)
+
+
+def _fail(key: str, exc: Exception | None = None):
+    """Return a CollectRequest that always raises."""
+    e = exc or RuntimeError(f"simulated failure for {key}")
+    return CollectRequest(key=key, fn=lambda: (_ for _ in ()).throw(e))
+
+
+# ── Basic return types ────────────────────────────────────────────────────
+
+class TestCollectManyReturnTypes:
+    def test_returns_collect_result(self):
+        result = collect_many([_ok("a")])
+        assert isinstance(result, CollectResult)
+
+    def test_empty_requests_returns_empty_result(self):
+        result = collect_many([])
+        assert result.n_success == 0
+        assert result.n_failure == 0
+        assert result.successes == {}
+        assert result.failures == []
+
+    def test_successes_is_dict(self):
+        result = collect_many([_ok("x", 42)])
+        assert isinstance(result.successes, dict)
+
+    def test_failures_is_list(self):
+        result = collect_many([_fail("x")])
+        assert isinstance(result.failures, list)
+
+
+# ── All success ───────────────────────────────────────────────────────────
+
+class TestCollectManyAllSuccess:
+    def test_all_keys_present(self):
+        reqs = [_ok("a", 1), _ok("b", 2), _ok("c", 3)]
+        result = collect_many(reqs)
+        assert set(result.successes.keys()) == {"a", "b", "c"}
+
+    def test_values_correct(self):
+        reqs = [_ok("x", 10), _ok("y", 20)]
+        result = collect_many(reqs)
+        assert result.successes["x"] == 10
+        assert result.successes["y"] == 20
+
+    def test_n_success_correct(self):
+        reqs = [_ok(str(i)) for i in range(5)]
+        result = collect_many(reqs)
+        assert result.n_success == 5
+
+    def test_n_failure_zero(self):
+        reqs = [_ok(str(i)) for i in range(5)]
+        result = collect_many(reqs)
+        assert result.n_failure == 0
+
+
+# ── Partial failure ───────────────────────────────────────────────────────
+
+class TestCollectManyPartialFailure:
+    def test_one_failure_does_not_abort_batch(self):
+        reqs = [_ok("a", 1), _fail("b"), _ok("c", 3)]
+        result = collect_many(reqs)
+        assert result.n_success == 2
+        assert result.n_failure == 1
+
+    def test_successful_keys_present(self):
+        reqs = [_ok("a", 1), _fail("b"), _ok("c", 3)]
+        result = collect_many(reqs)
+        assert "a" in result.successes
+        assert "c" in result.successes
+
+    def test_failed_key_not_in_successes(self):
+        reqs = [_ok("a", 1), _fail("b")]
+        result = collect_many(reqs)
+        assert "b" not in result.successes
+
+    def test_failure_has_correct_key(self):
+        reqs = [_fail("bad_key")]
+        result = collect_many(reqs)
+        assert result.failures[0].key == "bad_key"
+
+    def test_failure_has_exception(self):
+        exc = ValueError("test error")
+        reqs = [_fail("x", exc)]
+        result = collect_many(reqs)
+        assert isinstance(result.failures[0].error, ValueError)
+
+    def test_all_fail_zero_successes(self):
+        reqs = [_fail(str(i)) for i in range(4)]
+        result = collect_many(reqs)
+        assert result.n_success == 0
+        assert result.n_failure == 4
+
+    def test_failures_are_collect_failure_instances(self):
+        reqs = [_fail("x")]
+        result = collect_many(reqs)
+        assert isinstance(result.failures[0], CollectFailure)
+
+
+# ── Concurrency ───────────────────────────────────────────────────────────
+
+class TestCollectManyConcurrency:
+    def test_runs_concurrently(self):
+        """Prove concurrency: N slow tasks finish faster than N × sleep_time."""
+        n = 6
+        sleep_time = 0.2
+
+        reqs = [
+            CollectRequest(key=str(i), fn=lambda: time.sleep(sleep_time) or True)
+            for i in range(n)
+        ]
+
+        start = time.monotonic()
+        result = collect_many(reqs, max_workers=n)
+        elapsed = time.monotonic() - start
+
+        assert result.n_success == n
+        # Sequential would take n * sleep_time; concurrent should be much less
+        assert elapsed < n * sleep_time * 0.75
+
+    def test_max_workers_respected(self):
+        """Never more than max_workers threads active simultaneously."""
+        max_workers = 3
+        active = [0]
+        peak = [0]
+        lock = threading.Lock()
+
+        def task():
+            with lock:
+                active[0] += 1
+                if active[0] > peak[0]:
+                    peak[0] = active[0]
+            time.sleep(0.05)
+            with lock:
+                active[0] -= 1
+            return True
+
+        reqs = [CollectRequest(key=str(i), fn=task) for i in range(9)]
+        collect_many(reqs, max_workers=max_workers)
+        assert peak[0] <= max_workers
+
+    def test_single_worker_still_works(self):
+        reqs = [_ok(str(i), i) for i in range(3)]
+        result = collect_many(reqs, max_workers=1)
+        assert result.n_success == 3
+
+
+# ── Progress callback ─────────────────────────────────────────────────────
+
+class TestCollectManyProgressCallback:
+    def test_callback_called_for_each_request(self):
+        calls = []
+        reqs = [_ok("a"), _ok("b"), _fail("c")]
+        collect_many(reqs, progress_callback=lambda key, ok: calls.append((key, ok)))
+        assert len(calls) == 3
+
+    def test_callback_reports_success(self):
+        calls = []
+        collect_many([_ok("x", 1)], progress_callback=lambda k, ok: calls.append(ok))
+        assert calls == [True]
+
+    def test_callback_reports_failure(self):
+        calls = []
+        collect_many([_fail("x")], progress_callback=lambda k, ok: calls.append(ok))
+        assert calls == [False]
+
+    def test_no_callback_does_not_raise(self):
+        result = collect_many([_ok("a")], progress_callback=None)
+        assert result.n_success == 1
+
+
+# ── Edge cases ────────────────────────────────────────────────────────────
+
+class TestCollectManyEdgeCases:
+    def test_single_request_success(self):
+        result = collect_many([_ok("only", 99)])
+        assert result.successes["only"] == 99
+
+    def test_single_request_failure(self):
+        result = collect_many([_fail("only")])
+        assert result.n_failure == 1
+
+    def test_max_workers_larger_than_requests(self):
+        """max_workers > n should not raise."""
+        reqs = [_ok("a", 1)]
+        result = collect_many(reqs, max_workers=100)
+        assert result.n_success == 1
+
+    def test_n_success_plus_n_failure_equals_total(self):
+        reqs = [_ok("a"), _fail("b"), _ok("c"), _fail("d"), _ok("e")]
+        result = collect_many(reqs)
+        assert result.n_success + result.n_failure == len(reqs)

--- a/tests/test_collectors/test_collect_many.py
+++ b/tests/test_collectors/test_collect_many.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import threading
 import time
 
-
 from aquascope.utils.collect_many import (
     CollectFailure,
     CollectRequest,


### PR DESCRIPTION
Closes #59

## What this adds
New module `aquascope/utils/collect_many.py` implementing concurrent
multi-source data fetching with partial-failure handling.

## Design
- `ThreadPoolExecutor` (I/O-bound collectors are thread-safe)
- Per-host rate limiting honoured automatically — each `CollectRequest.fn`
  calls through its collector's own `CachedHTTPClient` + `RateLimiter`
- One failing request never aborts the batch — failures returned as
  structured `CollectFailure(key, error)` objects
- Optional `progress_callback(key, success)` for tqdm or custom UI
- `max_workers` capped at `min(max_workers, n)` so no idle threads

## New dataclasses
- `CollectRequest(key, fn)` — wraps a zero-arg callable
- `CollectResult(successes, failures)` — aggregated output with
  `n_success` / `n_failure` properties
- `CollectFailure(key, error)` — structured failure record

## Tests (`tests/test_collectors/test_collect_many.py`)
- Return type invariants
- All-success and all-failure batches
- Partial failure: one bad request does not sink the batch
- Concurrency proof: N × 0.2s tasks finish in < 75% of sequential time
- `max_workers` thread cap verified with a threading lock
- Progress callback called for every request, correct success/failure flag
- Edge cases: empty input, single request, max_workers > n