### PR TITLE
docs(paper): update JOSS paper to v0.6.0, reposition statement of need

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,10 @@ abstract: >-
   single, coherent interface to 19 global water data sources and
   implements 26 hydrological, statistical, and agri-water methods.
 authors:
-  - name: AquaScope Contributors
-    website: https://github.com/Rekin226/aquascope/graphs/contributors
+  - family-names: Ouedraogo
+    given-names: Abdoul Rachid
+    orcid: "https://orcid.org/0000-0002-4616-4153"
+    affiliation: "National Central University, Taiwan"
 version: 0.6.0
 date-released: "2026-06-26"
 license: MIT
@@ -40,7 +42,9 @@ references:
       Aggregation, Hydrological Analysis, and AI-Powered Research
       Methodology Recommendations
     authors:
-      - name: AquaScope Contributors
+      - family-names: Ouedraogo
+        given-names: Abdoul Rachid
+        orcid: "https://orcid.org/0000-0002-4616-4153"
     journal: Journal of Open Source Software
     status: submitted
     year: 2025
@@ -48,8 +52,9 @@ preferred-citation:
   type: software
   title: AquaScope
   authors:
-    - name: AquaScope Contributors
-      website: https://github.com/Rekin226/aquascope/graphs/contributors
+    - family-names: Ouedraogo
+      given-names: Abdoul Rachid
+      orcid: "https://orcid.org/0000-0002-4616-4153"
   version: 0.6.0
   date-released: "2026-06-26"
   license: MIT

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ abstract: >-
   single, coherent interface to 19 global water data sources and
   implements 26 hydrological, statistical, and agri-water methods.
 authors:
-  - family-names: Ouedraogo
+  - family-names: Ouédraogo
     given-names: Abdoul Rachid
     orcid: "https://orcid.org/0000-0002-4616-4153"
     affiliation: "National Central University, Taiwan"
@@ -42,7 +42,7 @@ references:
       Aggregation, Hydrological Analysis, and AI-Powered Research
       Methodology Recommendations
     authors:
-      - family-names: Ouedraogo
+      - family-names: Ouédraogo
         given-names: Abdoul Rachid
         orcid: "https://orcid.org/0000-0002-4616-4153"
     journal: Journal of Open Source Software
@@ -52,7 +52,7 @@ preferred-citation:
   type: software
   title: AquaScope
   authors:
-    - family-names: Ouedraogo
+    - family-names: Ouédraogo
       given-names: Abdoul Rachid
       orcid: "https://orcid.org/0000-0002-4616-4153"
   version: 0.6.0

--- a/paper.bib
+++ b/paper.bib
@@ -224,3 +224,36 @@
   pages   = {526--534},
   doi     = {10.1029/TR027i004p00526}
 }
+
+@article{Perrin2003,
+  author  = {Perrin, Charles and Michel, Claude and Andr{\'e}assian, Vazken},
+  title   = {Improvement of a parsimonious model for streamflow simulation},
+  journal = {Journal of Hydrology},
+  year    = {2003},
+  volume  = {279},
+  number  = {1--4},
+  pages   = {275--289},
+  doi     = {10.1016/S0022-1694(03)00225-7}
+}
+
+@article{Nash1970,
+  author  = {Nash, J. E. and Sutcliffe, J. V.},
+  title   = {River flow forecasting through conceptual models part I --- A discussion of principles},
+  journal = {Journal of Hydrology},
+  year    = {1970},
+  volume  = {10},
+  number  = {3},
+  pages   = {282--290},
+  doi     = {10.1016/0022-1694(70)90255-6}
+}
+
+@article{Gupta2009,
+  author  = {Gupta, Hoshin V. and Kling, Harald and Yilmaz, Koray K. and Martinez, Guillermo F.},
+  title   = {Decomposition of the mean squared error and {NSE} performance criteria: Implications for improving hydrological modelling},
+  journal = {Journal of Hydrology},
+  year    = {2009},
+  volume  = {377},
+  number  = {1--2},
+  pages   = {80--91},
+  doi     = {10.1016/j.jhydrol.2009.08.003}
+}

--- a/paper.md
+++ b/paper.md
@@ -16,22 +16,25 @@ authors:
 affiliations:
   - name: Independent Researchers
     index: 1
-date: 2 July 2025
+date: 26 June 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-AquaScope is an open-source Python toolkit (v0.3.0, MIT license) that unifies water
-data collection from 12 global sources, comprehensive hydrological and statistical
+AquaScope is an open-source Python toolkit (v0.6.0, MIT license) that unifies water
+data collection from 19 global sources, comprehensive hydrological and statistical
 analysis, agricultural water management, and AI-powered research methodology
 recommendations into a single, coherent package. It addresses a persistent challenge
 in water resources research: the fragmentation of data access, analytical methods, and
 tooling across disparate software ecosystems. AquaScope normalises heterogeneous data
-into unified Pydantic schemas, provides over 40 analytical methods spanning flood
+into unified Pydantic schemas, provides over 40 analytical methods spanning conceptual
+rainfall-runoff modelling (GR4J with NSE/KGE/log-NSE auto-calibration), flood
 frequency analysis, baseflow separation, extreme value theory, and FAO-56
 evapotranspiration, and includes a knowledge-base-driven AI engine that recommends
-appropriate research methodologies based on dataset characteristics. The toolkit is
+appropriate research methodologies based on dataset characteristics. Unlike existing
+unified data clients, which focus on United States services, AquaScope's collectors
+span East and South Asia, Europe, and global FAO/UN sources. The toolkit is
 available at <https://github.com/Rekin226/aquascope>.
 
 # Statement of Need
@@ -55,45 +58,62 @@ data characteristics. Multivariate dependence modelling requires copula families
 [@Nelsen2006] with appropriate selection criteria. Each of these methods is often
 available only in specialised packages with incompatible interfaces.
 
-Existing open-source tools address subsets of these needs. Packages such as
-`hydrostats` provide statistical metrics for streamflow comparison, `HydroTools`
-offers access to select U.S. hydrological data services, and `pySTEPS` focuses on
-probabilistic precipitation nowcasting. However, no single toolkit integrates
-multi-source data collection, a comprehensive hydrological analysis suite, agricultural
-water management, advanced statistical and machine learning methods, and intelligent
-methodology guidance.
+Existing open-source tools address subsets of these needs. The HyRiver suite
+(`pygeohydro`, `pynhd`, `py3dep`) provides excellent, well-maintained access to United
+States hydrological services and returns analysis-ready `xarray` and `geopandas`
+objects; `dataretrieval` wraps USGS and multi-agency U.S. services; `hydrostats`
+provides streamflow comparison metrics; and `pySTEPS` focuses on probabilistic
+precipitation nowcasting. Two gaps remain. First, the mature unified-access clients are
+**United States-centric**: a researcher working in Taiwan, Japan, Korea, India, the
+European Union, or with global FAO/UN datasets must still assemble bespoke clients.
+Second, no single toolkit couples multi-source data collection with a comprehensive
+hydrological analysis suite, agricultural water management, advanced statistical and
+machine-learning methods, and intelligent methodology guidance.
 
-AquaScope fills this gap by providing an end-to-end workflow—from raw data ingestion
-through analysis to methodology recommendation—in a single, well-tested Python package
-with a unified API. It targets hydrologists, environmental engineers, agricultural
-scientists, and water resources researchers who need to combine data from multiple
-sources and apply appropriate analytical methods without assembling a patchwork of
-incompatible tools.
+AquaScope addresses both. Its 19 collectors span East and South Asia (Taiwan MOENV and
+WRA networks, Japan MLIT, Korea WAMIS, India WRIS), Europe (EU Water Framework
+Directive), the United States (USGS, Water Quality Portal), and global providers
+(GEMStat, Open-Meteo, Copernicus, UN SDG 6, FAO AQUASTAT and WaPOR). On top of this it
+provides an end-to-end workflow, from raw data ingestion through analysis to methodology
+recommendation, in a single, well-tested Python package with a unified API. It targets
+hydrologists, environmental engineers, agricultural scientists, and water resources
+researchers, particularly those working outside the United States, who need to combine
+data from multiple sources and apply appropriate analytical methods without assembling a
+patchwork of incompatible tools.
 
 # Key Features
 
-## Data Aggregation from 12 Global Sources
+## Data Aggregation from 19 Global Sources
 
-AquaScope implements collectors for 12 water data sources, each subclassing a common
+AquaScope implements collectors for 19 water data sources, each subclassing a common
 `BaseCollector` and normalising responses into shared Pydantic schemas
 (`WaterQualitySample`, `WaterLevelReading`, `ReservoirStatus`, `SDG6Indicator`). The
-supported sources are: USGS NWIS [@USGS_NWIS], Taiwan MOENV, Taiwan WRA, Taiwan Civil
-IoT (SensorThings API), UN SDG 6, GEMStat (covering 170+ countries), the Water
-Quality Portal (aggregating 400+ U.S. agencies), Open-Meteo, Copernicus CDS (ERA5
-reanalysis and climate projections), FAO AQUASTAT (country-level water withdrawal),
-and FAO WaPOR (satellite evapotranspiration). An `httpx`-based HTTP client
-[@HTTPX2024] provides caching, automatic retries with exponential backoff, and rate
-limiting across all collectors.
+supported sources span Asia (Taiwan MOENV, Taiwan WRA water-level and reservoir
+networks, Taiwan WRA FHY, Taiwan WRA IoT groundwater, Taiwan Civil IoT via the OGC
+SensorThings API, Taiwan data.gov.tw, Japan MLIT, Korea WAMIS, India WRIS), Europe (EU
+Water Framework Directive), the United States (USGS NWIS [@USGS_NWIS]; the Water
+Quality Portal, aggregating 400+ U.S. agencies), and global providers (GEMStat,
+covering 170+ countries; UN SDG 6; Open-Meteo; Copernicus CDS ERA5 reanalysis and
+climate projections; FAO AQUASTAT country-level water withdrawal; FAO WaPOR satellite
+evapotranspiration). Most sources share the unified `water_data` schema, while
+aggregate or gridded sources (AQUASTAT, SDG 6, WaPOR) use purpose-built record types
+that match their data shape. A shared `httpx`-based HTTP client [@HTTPX2024] provides
+caching, automatic retries with exponential backoff, and rate limiting across all
+collectors.
 
 ## Hydrological Analysis Suite
 
-The hydrology module implements flood frequency analysis using Generalised Extreme
-Value (GEV), Log-Pearson Type III (LP3), and Gumbel distributions, with L-moment
-parameter estimation [@Hosking1997] and Bulletin 17C procedures including EMA for
-censored data [@England2019]. Non-stationary GEV models with time-varying parameters
-[@Coles2001] and regional frequency analysis with discordancy and heterogeneity
-measures are also supported. Baseflow separation uses the Lyne–Hollick [@Lyne1979]
-and Eckhardt [@Eckhardt2005] recursive digital filters. Additional capabilities
+The hydrology module implements the GR4J conceptual rainfall-runoff model
+[@Perrin2003] with parameter auto-calibration against Nash–Sutcliffe Efficiency (NSE)
+[@Nash1970], Kling–Gupta Efficiency (KGE) [@Gupta2009], and log-NSE objectives via a
+shared model-evaluation metrics module. Flood frequency analysis uses Generalised
+Extreme Value (GEV), Log-Pearson Type III (LP3), and Gumbel distributions, with
+L-moment parameter estimation [@Hosking1997] and Bulletin 17C procedures including EMA
+for censored data [@England2019]. Non-stationary GEV models with time-varying
+parameters [@Coles2001] and regional frequency analysis with discordancy and
+heterogeneity measures are also supported. Baseflow separation uses the Lyne–Hollick
+[@Lyne1979] and Eckhardt [@Eckhardt2005] recursive digital filters and the UK Institute
+of Hydrology (UKIH) smoothed-minima method. Additional capabilities
 include flow duration curves with Weibull plotting positions, recession analysis,
 22 hydrological signatures (magnitude, variability, timing, flashiness), and
 power-law rating curve fitting with shift detection. Diagnostic tools include Q-Q
@@ -158,7 +178,8 @@ software.
 Sixteen plot functions cover time-series, box plots, heatmaps, spatial maps (via
 Folium), flow duration curves, and hydrographs. Diagnostic panels provide Q-Q, P-P,
 and return level plots for distribution fitting validation. An interactive Streamlit
-dashboard with seven pages enables exploratory analysis without writing code.
+dashboard with nine pages, including dedicated Hydrology, Extreme Events, and
+Agricultural Water analysis labs, enables exploratory analysis without writing code.
 Automated Markdown and HTML report generation with embedded figures supports
 reproducible documentation.
 
@@ -188,30 +209,35 @@ visualisation only). A command-line interface exposes 14 commands (`collect`,
 `recommend`, `eda`, `quality`, `run`, `hydro`, `agri`, `forecast`, `plot`, `alerts`,
 `solve`, `dashboard`, `list-methods`, `list-sources`) for scriptable workflows.
 
-The test suite comprises 539 tests across 47 test modules, including validation
+The test suite comprises over 820 tests, including validation
 against the CAMELS large-sample hydrology dataset [@Addor2017] for hydrological
 signature computation. Continuous integration runs tests on Python 3.10–3.12 with
 lint (Ruff) and type checking (mypy).
 
 # Comparison with Existing Tools
 
-| Feature                       | AquaScope | hydrostats | HydroTools | pySTEPS |
-|-------------------------------|:---------:|:----------:|:----------:|:-------:|
-| Multi-source data collection  | 12        | —          | 3          | —       |
-| Unified data schemas          | ✓         | —          | —          | —       |
-| Flood frequency (Bulletin 17C)| ✓         | —          | —          | —       |
-| FAO-56 ET₀ and crop Kc       | ✓         | —          | —          | —       |
-| Copula analysis               | ✓         | —          | —          | —       |
-| Change-point detection        | ✓         | —          | —          | —       |
-| ML/ensemble forecasting       | ✓         | —          | —          | ✓       |
-| AI methodology recommendations| ✓         | —          | —          | —       |
-| Scientific I/O (WaterML, HEC) | ✓         | —          | partial    | —       |
-| Interactive dashboard         | ✓         | —          | —          | —       |
+| Feature                        | AquaScope | HyRiver | dataretrieval | hydrostats | pySTEPS |
+|--------------------------------|:---------:|:-------:|:-------------:|:----------:|:-------:|
+| Multi-source data collection   | 19        | U.S.    | U.S.          | —          | —       |
+| Non-U.S. / global coverage     | ✓         | —       | —             | —          | —       |
+| Unified data schemas           | ✓         | ✓       | —             | —          | —       |
+| Conceptual rainfall-runoff (GR4J)| ✓       | —       | —             | —          | —       |
+| Flood frequency (Bulletin 17C) | ✓         | —       | —             | —          | —       |
+| FAO-56 ET₀ and crop Kc        | ✓         | —       | —             | —          | —       |
+| Copula / change-point analysis | ✓         | —       | —             | —          | —       |
+| ML/ensemble forecasting        | ✓         | —       | —             | —          | ✓       |
+| AI methodology recommendations | ✓         | —       | —             | —          | —       |
+| Scientific I/O (WaterML, HEC)  | ✓         | partial | —             | —          | —       |
+| Interactive dashboard          | ✓         | —       | —             | —          | —       |
 
-AquaScope is unique in combining data aggregation from 12 global sources with a
-comprehensive analytical toolkit and an AI-driven methodology recommendation engine
-in a single package. While individual features may overlap with specialised tools,
-no existing package provides this integrated workflow from data collection through
+The HyRiver suite is the closest comparator for data access and is more mature for
+United States services, returning analysis-ready `xarray`/`geopandas` objects;
+AquaScope is positioned to interoperate with the same scientific-Python objects in a
+forthcoming release. AquaScope is distinguished by combining data aggregation from 19
+global sources, with coverage well beyond the United States, with a comprehensive
+analytical toolkit and an AI-driven methodology recommendation engine in a single
+package. While individual features overlap with specialised tools, no existing package
+provides this integrated, geographically broad workflow from data collection through
 analysis to methodology guidance.
 
 # Acknowledgements

--- a/paper.md
+++ b/paper.md
@@ -10,11 +10,11 @@ tags:
   - FAO-56
   - evapotranspiration
 authors:
-  - name: AquaScope Contributors
-    orcid: 0000-0000-0000-0000
+  - name: Ouedraogo Abdoul Rachid
+    orcid: 0000-0002-4616-4153
     affiliation: 1
 affiliations:
-  - name: Independent Researchers
+  - name: National Central University, Taiwan
     index: 1
 date: 26 June 2026
 bibliography: paper.bib
@@ -244,7 +244,7 @@ analysis to methodology guidance.
 
 AquaScope builds upon the scientific Python ecosystem, particularly pandas
 [@McKinney2010], NumPy [@Harris2020], SciPy [@Virtanen2020], and Pydantic
-[@Pydantic2024]. The authors thank the maintainers of these foundational libraries,
+[@Pydantic2024]. The author thanks the maintainers of these foundational libraries,
 as well as the data providers—USGS, Taiwan MOENV, FAO, UN Environment Programme, and
 the Copernicus Climate Data Store—whose open data policies make integrated water
 resources research possible. The groundwater analysis capabilities draw on the

--- a/paper.md
+++ b/paper.md
@@ -10,7 +10,7 @@ tags:
   - FAO-56
   - evapotranspiration
 authors:
-  - name: Ouedraogo Abdoul Rachid
+  - name: Ouédraogo Abdoul Rachid
     orcid: 0000-0002-4616-4153
     affiliation: 1
 affiliations:


### PR DESCRIPTION
Refs #72.

Brings `paper.md` up to date with the current release and repositions it around the verified competitive landscape from our adoption research.

## Changes
- **Version/counts:** v0.3.0 → v0.6.0; 12 → 19 data sources (full list); 539 → 820+ tests; dashboard 7 → 9 pages.
- **Statement of Need:** now names the real modern competitors (HyRiver/pygeohydro, `dataretrieval`) and foregrounds AquaScope's actual differentiator — coverage well beyond the United States (Taiwan, Japan, Korea, India, EU, global FAO/UN).
- **Features:** added GR4J rainfall-runoff + NSE/KGE/log-NSE auto-calibration and UKIH baseflow.
- **Comparison table:** added HyRiver and `dataretrieval` columns; global-coverage row.
- **Bib:** added `Perrin2003`, `Nash1970`, `Gupta2009`; verified all citations resolve.

## ⚠️ Required before JOSS submission (maintainer input)
The author block is still a placeholder (`name: AquaScope Contributors`, `orcid: 0000-0000-0000-0000`, `affiliation: Independent Researchers`). JOSS requires real author name(s), ORCID, and affiliation. Please fill these in.

## Not done here (tracked separately)
The UQ benchmark evidence (#78) that strengthens the paper's validation section lands with the uncertainty epic (#71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)