### PR TITLE
chore: pin ruff to 0.15.20 for reproducible lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ all = [
 dev = [
     "pytest>=7.0",
     "pytest-cov>=4.0",
-    "ruff>=0.3",
+    "ruff==0.15.20",
     "mypy>=1.8",
     "pre-commit>=3.0",
     "nbformat>=5.0",


### PR DESCRIPTION
## Why
CI installs ruff via the unpinned `ruff>=0.3` constraint, so it always grabs the **latest** release (`0.15.20` today). Each new ruff version can tighten lint rules, so behavior drifts over time and, more importantly, **contributors with an older local ruff see lint pass locally but fail in CI.**

This bit #69 directly: the `I001` blank-line rule enforced by ruff 0.15.20 wasn't flagged by the contributor's older local ruff, leading to three round-trip commits chasing a green check.

## What
Pin the dev dependency to the exact version CI was already resolving:

```diff
-    "ruff>=0.3",
+    "ruff==0.15.20",
```

Now `pip install -e ".[dev]"` gives every contributor and CI the same ruff, so "passes locally" means "passes CI."

## Not included (deliberate)
- **`ruff format --check` CI step** — would require a one-time `ruff format` pass over the whole codebase first; left as a separate follow-up to keep this PR a zero-risk one-liner.
- Bumping ruff later is now an explicit, reviewable change rather than silent drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)