### PR TITLE
feat(io): xarray + GeoPandas interop for collector records

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Feature-group extras:
 pip install "aquascope[ml]"           # sklearn, xgboost, statsmodels
 pip install "aquascope[viz]"          # matplotlib, seaborn, folium
 pip install "aquascope[scientific]"   # xarray, netcdf4, h5py
+pip install "aquascope[interop]"      # xarray + geopandas (collect as_xarray / as_geodataframe)
 pip install "aquascope[spatial]"      # rasterio, geopandas, shapely
 pip install "aquascope[dashboard]"    # streamlit
 pip install "aquascope[forecast]"     # prophet, torch (for LSTM)

--- a/aquascope/collectors/base.py
+++ b/aquascope/collectors/base.py
@@ -36,10 +36,33 @@ class BaseCollector(ABC):
     def normalise(self, raw: Any) -> Sequence[BaseModel]:
         """Convert raw API response into unified Pydantic records."""
 
-    def collect(self, **kwargs) -> Sequence[BaseModel]:
-        """Fetch + normalise in one call."""
+    def collect(
+        self,
+        *,
+        as_xarray: bool = False,
+        as_geodataframe: bool = False,
+        **kwargs,
+    ) -> Any:
+        """Fetch + normalise in one call.
+
+        By default returns the list of unified Pydantic records. Set
+        ``as_xarray=True`` to get an ``xarray.Dataset`` (time-series) or
+        ``as_geodataframe=True`` to get a ``geopandas.GeoDataFrame`` (point
+        geometry) instead — both require the ``interop`` extra. The two flags
+        are mutually exclusive.
+        """
+        if as_xarray and as_geodataframe:
+            raise ValueError("as_xarray and as_geodataframe are mutually exclusive.")
         logger.info("[%s] Starting collection …", self.name)
         raw = self.fetch_raw(**kwargs)
         records = self.normalise(raw)
         logger.info("[%s] Collected %d records.", self.name, len(records))
+        if as_xarray:
+            from aquascope.io.interop import records_to_xarray
+
+            return records_to_xarray(records)
+        if as_geodataframe:
+            from aquascope.io.interop import records_to_geodataframe
+
+            return records_to_geodataframe(records)
         return records

--- a/aquascope/io/__init__.py
+++ b/aquascope/io/__init__.py
@@ -14,6 +14,7 @@ from aquascope.io.hec import (
     write_hec_dss_csv,
     write_hec_ras_flow,
 )
+from aquascope.io.interop import records_to_geodataframe, records_to_xarray
 from aquascope.io.swmm import write_swmm_rainfall, write_swmm_timeseries
 from aquascope.io.waterml import (
     WaterMLTimeSeries,
@@ -28,6 +29,8 @@ __all__ = [
     "WaterMLTimeSeries",
     "dataframe_to_hec_format",
     "dataframe_to_waterml",
+    "records_to_geodataframe",
+    "records_to_xarray",
     "read_waterml",
     "waterml_to_dataframe",
     "write_hec_dss_csv",

--- a/aquascope/io/interop.py
+++ b/aquascope/io/interop.py
@@ -1,0 +1,171 @@
+"""Convert AquaScope records to scientific-Python geo objects.
+
+Bridges the unified Pydantic schema to ``xarray.Dataset`` (gridded/time-series)
+and ``geopandas.GeoDataFrame`` (point/station), so AquaScope data can feed the
+wider Pangeo / NeuralHydrology ecosystem instead of being a closed schema.
+
+Both helpers lazily import their backends and are available via the optional
+``interop`` extra: ``pip install 'aquascope[interop]'``.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
+
+from aquascope.utils.imports import require
+
+if TYPE_CHECKING:  # pragma: no cover
+    import geopandas
+    import xarray
+
+logger = logging.getLogger(__name__)
+
+
+def _source_label(records: list[Any]) -> str:
+    src = getattr(records[0], "source", None)
+    return getattr(src, "value", str(src)) if src is not None else "unknown"
+
+
+def _attach_station_coords(ds: xarray.Dataset, loc_map: dict[str, Any]) -> xarray.Dataset:
+    """Attach lat/lon coords along the ``station_id`` dimension.
+
+    Stations without a location get NaN coordinates rather than being dropped.
+    """
+    sids = [str(s) for s in ds["station_id"].values]
+    lat = [getattr(loc_map.get(s), "latitude", float("nan")) for s in sids]
+    lon = [getattr(loc_map.get(s), "longitude", float("nan")) for s in sids]
+    return ds.assign_coords(
+        lat=("station_id", lat),
+        lon=("station_id", lon),
+    )
+
+
+def records_to_xarray(records: Sequence[Any]) -> xarray.Dataset:
+    """Convert time-series records to an ``xarray.Dataset``.
+
+    Supports ``WaterQualitySample`` (one data variable per parameter) and
+    ``WaterLevelReading`` (a single ``water_level`` variable). The result has
+    dimensions ``(time, station_id)`` with ``lat``/``lon`` station coordinates
+    and per-variable ``units`` attributes.
+
+    An empty input yields an empty ``Dataset``.
+    """
+    xr = require("xarray", feature="xarray export", group="interop")
+    import pandas as pd
+
+    records = list(records)
+    if not records:
+        return xr.Dataset()
+
+    first = records[0]
+
+    # Discriminate on the timestamp field, which is unique per record type
+    # (ReservoirStatus also has water_level, so we cannot key on that).
+    if hasattr(first, "sample_datetime"):
+        units: dict[str, str] = {}
+        loc_map: dict[str, Any] = {}
+        rows = []
+        for r in records:
+            rows.append(
+                {
+                    "time": r.sample_datetime,
+                    "station_id": r.station_id,
+                    "parameter": r.parameter,
+                    "value": r.value,
+                }
+            )
+            if r.parameter not in units and r.unit:
+                units[r.parameter] = r.unit
+            loc_map.setdefault(r.station_id, r.location)
+        wide = pd.DataFrame(rows).pivot_table(
+            index=["time", "station_id"],
+            columns="parameter",
+            values="value",
+            aggfunc="mean",
+        )
+        ds = wide.to_xarray()
+        for param in ds.data_vars:
+            if units.get(str(param)):
+                ds[param].attrs["units"] = units[str(param)]
+
+    elif hasattr(first, "reading_datetime"):
+        loc_map = {}
+        unit: str | None = None
+        rows = []
+        for r in records:
+            rows.append(
+                {
+                    "time": r.reading_datetime,
+                    "station_id": r.station_id,
+                    "water_level": r.water_level,
+                }
+            )
+            loc_map.setdefault(r.station_id, r.location)
+            unit = unit or r.unit
+        wide = (
+            pd.DataFrame(rows)
+            .groupby(["time", "station_id"])["water_level"]
+            .mean()
+            .to_frame()
+        )
+        ds = wide.to_xarray()
+        if unit:
+            ds["water_level"].attrs["units"] = unit
+
+    else:
+        raise TypeError(
+            "records_to_xarray supports WaterQualitySample and WaterLevelReading "
+            f"records; got {type(first).__name__}."
+        )
+
+    ds = _attach_station_coords(ds, loc_map)
+    ds.attrs["source"] = _source_label(records)
+    return ds
+
+
+def records_to_geodataframe(records: Sequence[Any]) -> geopandas.GeoDataFrame:
+    """Convert point/station records to a ``geopandas.GeoDataFrame``.
+
+    One row per record, with ``Point`` geometry in EPSG:4326. Records without
+    a location keep a null geometry (the count is logged) rather than being
+    dropped. The nested ``location`` field is flattened to ``latitude`` /
+    ``longitude`` columns.
+    """
+    gpd = require("geopandas", feature="GeoDataFrame export", group="interop")
+    require("shapely", feature="GeoDataFrame export", group="interop")
+    from shapely.geometry import Point
+
+    records = list(records)
+    if not records:
+        return gpd.GeoDataFrame(geometry=[], crs="EPSG:4326")
+
+    rows = []
+    geoms = []
+    n_missing = 0
+    for r in records:
+        data = r.model_dump()
+        loc = data.pop("location", None)
+        src = data.get("source")
+        if src is not None:
+            data["source"] = getattr(src, "value", src)
+        if loc:
+            data["latitude"] = loc["latitude"]
+            data["longitude"] = loc["longitude"]
+            geoms.append(Point(loc["longitude"], loc["latitude"]))
+        else:
+            data["latitude"] = None
+            data["longitude"] = None
+            geoms.append(None)
+            n_missing += 1
+        rows.append(data)
+
+    if n_missing:
+        logger.info(
+            "%d of %d records have no location; null geometry assigned.",
+            n_missing,
+            len(records),
+        )
+
+    return gpd.GeoDataFrame(rows, geometry=geoms, crs="EPSG:4326")

--- a/aquascope/utils/imports.py
+++ b/aquascope/utils/imports.py
@@ -23,14 +23,23 @@ _INSTALL_MAP = {
 }
 
 
-def require(module_name: str, *, feature: str = "") -> object:
-    """Import a module, raising a helpful error if it's missing."""
+def require(module_name: str, *, feature: str = "", group: str | None = None) -> object:
+    """Import a module, raising a helpful error if it's missing.
+
+    Args:
+        module_name: Importable module name (e.g. ``"xarray"``).
+        feature: Human-readable feature name shown in the error.
+        group: Override the suggested extras group. Defaults to the
+            module's entry in ``_INSTALL_MAP``. Use this when a module is
+            reachable from more than one extra (e.g. ``xarray`` ships in
+            both ``scientific`` and ``interop``).
+    """
     import importlib
 
     try:
         return importlib.import_module(module_name)
     except ImportError:
-        group = _INSTALL_MAP.get(module_name, module_name)
+        group = group or _INSTALL_MAP.get(module_name, module_name)
         feat = f" ({feature})" if feature else ""
         msg = (
             f"Missing optional dependency '{module_name}'{feat}. "

--- a/docs/integration_guides/xarray_integration.md
+++ b/docs/integration_guides/xarray_integration.md
@@ -1,99 +1,95 @@
-# xarray Integration Guide
+# xarray and GeoPandas Integration Guide
 
-Export AquaScope water-quality and hydrology data to
-[xarray](https://docs.xarray.dev/) Datasets for climate and
-spatiotemporal analysis.
+Export AquaScope records to [xarray](https://docs.xarray.dev/) Datasets and
+[GeoPandas](https://geopandas.org/) GeoDataFrames so they compose with the wider
+scientific-Python ecosystem (the Pangeo stack, NeuralHydrology, GIS).
 
 ## Prerequisites
 
 ```bash
-pip install "aquascope[scientific]"   # installs xarray, netcdf4, h5py
+pip install "aquascope[interop]"   # installs xarray, geopandas, shapely
 ```
 
-## Quick Export
+## Quick export to xarray
+
+`records_to_xarray()` builds a Dataset with dimensions `(time, station_id)`, one
+data variable per parameter, `lat`/`lon` station coordinates, and a `units`
+attribute on each variable:
 
 ```python
-import pandas as pd
-import xarray as xr
 from aquascope.collectors import TaiwanMOENVCollector
+from aquascope.io.interop import records_to_xarray
 
-# 1. Collect data
-collector = TaiwanMOENVCollector(api_key="YOUR_KEY")
-records = collector.collect()
-df = pd.DataFrame([r.model_dump() for r in records])
-
-# 2. Convert to xarray Dataset
-ds = xr.Dataset.from_dataframe(
-    df.set_index(["station_id", "timestamp"])
-)
+records = TaiwanMOENVCollector(api_key="YOUR_KEY").collect()
+ds = records_to_xarray(records)
 print(ds)
+# Dimensions:  (time, station_id); data variables: DO, pH, ...; coords lat/lon
 ```
 
-## Adding Coordinates and Attributes
+Or get the Dataset straight from the collector:
 
 ```python
-# Attach CF-compliant metadata for interoperability
+ds = TaiwanMOENVCollector(api_key="YOUR_KEY").collect(as_xarray=True)
+```
+
+`WaterQualitySample` records yield one variable per parameter; `WaterLevelReading`
+records yield a single `water_level` variable. Stations without a known location
+get `NaN` coordinates rather than being dropped.
+
+## Quick export to GeoPandas
+
+```python
+from aquascope.io.interop import records_to_geodataframe
+
+gdf = records_to_geodataframe(records)        # Point geometry, EPSG:4326
+gdf.to_file("stations.gpkg")                  # straight into any GIS workflow
+
+# or directly:
+gdf = TaiwanMOENVCollector().collect(as_geodataframe=True)
+```
+
+Records without a location keep a null geometry (the count is logged), so nothing
+is silently lost.
+
+## Adding CF metadata
+
+```python
 ds.attrs["title"] = "AquaScope Taiwan River Water Quality"
 ds.attrs["Conventions"] = "CF-1.8"
-ds.attrs["source"] = "Taiwan MOENV via AquaScope"
-
-# Rename columns to CF standard names where applicable
-ds = ds.rename({"water_temperature": "sea_water_temperature"})
-ds["sea_water_temperature"].attrs["units"] = "degree_Celsius"
+ds["DO"].attrs["standard_name"] = "mass_concentration_of_oxygen_in_sea_water"
 ```
 
-## Saving to NetCDF
+## Saving to NetCDF / Zarr
 
 ```python
 ds.to_netcdf("taiwan_wq.nc", engine="netcdf4")
-
-# Reload and verify
-ds2 = xr.open_dataset("taiwan_wq.nc")
-print(ds2)
+ds.to_zarr("taiwan_wq.zarr")                  # cloud-native, Dask-friendly
 ```
 
-## Time-Series Resampling
+## Time-series resampling
 
 ```python
-# Monthly mean per station
-monthly = ds.resample(timestamp="ME").mean()
+monthly = ds.resample(time="ME").mean()       # the time dim is named "time"
 monthly["DO"].plot(col="station_id", col_wrap=4)
 ```
 
-## Merging Multiple Sources
+## Merging multiple sources
 
 ```python
 from aquascope.collectors import USGSCollector
 
-usgs = USGSCollector()
-usgs_records = usgs.collect(site="09380000", days=365)
-df_usgs = pd.DataFrame([r.model_dump() for r in usgs_records])
-ds_usgs = xr.Dataset.from_dataframe(
-    df_usgs.set_index(["station_id", "timestamp"])
-)
+ds_tw = TaiwanMOENVCollector().collect(as_xarray=True)
+ds_us = USGSCollector().collect(as_xarray=True)
 
-# Merge along a new "source" dimension
 combined = xr.concat(
-    [ds.expand_dims("source"), ds_usgs.expand_dims("source")],
+    [ds_tw.expand_dims("source"), ds_us.expand_dims("source")],
     dim="source",
 )
 combined["source"] = ["taiwan_moenv", "usgs"]
 ```
 
-## Climate Analysis Example
-
-```python
-# Compute seasonal anomalies
-climatology = ds.groupby("timestamp.season").mean("timestamp")
-anomaly = ds.groupby("timestamp.season") - climatology
-anomaly["DO"].plot(col="season")
-```
-
 ## Tips
 
-- Use `engine="h5netcdf"` for HDF5-backed files when working with
-  large datasets.
-- Set `chunks={"timestamp": 100}` when opening to enable Dask-backed
-  lazy loading for out-of-core computation.
-- AquaScope's `scientific` extra includes everything you need for
-  NetCDF and HDF5 round-trips.
+- Use `engine="h5netcdf"` for HDF5-backed files with large datasets.
+- Open with `chunks={"time": 100}` to enable Dask-backed lazy loading.
+- A runnable end-to-end demo lives in `examples/11_interop_xarray.py`.

--- a/examples/11_interop_xarray.py
+++ b/examples/11_interop_xarray.py
@@ -1,0 +1,73 @@
+"""Interoperability: AquaScope records -> xarray / GeoPandas.
+
+AquaScope normalises every source into unified Pydantic records. This example
+shows how to hand those records to the scientific-Python geo stack so they can
+feed downstream tools (NeuralHydrology, the Pangeo stack, GIS).
+
+Requires the interop extra:  pip install 'aquascope[interop]'
+
+Run:  python examples/11_interop_xarray.py
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from aquascope.io.interop import records_to_geodataframe, records_to_xarray
+from aquascope.schemas.water_data import (
+    DataSource,
+    GeoLocation,
+    WaterQualitySample,
+)
+
+
+def demo_records() -> list[WaterQualitySample]:
+    """A few synthetic samples (in practice these come from a collector)."""
+    tamsui = GeoLocation(latitude=25.17, longitude=121.41)
+    gaoping = GeoLocation(latitude=22.55, longitude=120.43)
+    rows = [
+        ("TAMSUI", datetime(2026, 1, 1), "DO", 8.5, tamsui),
+        ("TAMSUI", datetime(2026, 1, 2), "DO", 8.1, tamsui),
+        ("TAMSUI", datetime(2026, 1, 1), "pH", 7.3, tamsui),
+        ("GAOPING", datetime(2026, 1, 1), "DO", 7.9, gaoping),
+        ("GAOPING", datetime(2026, 1, 2), "DO", 7.6, gaoping),
+    ]
+    return [
+        WaterQualitySample(
+            source=DataSource.TAIWAN_MOENV,
+            station_id=sid,
+            sample_datetime=dt,
+            parameter=param,
+            value=val,
+            unit="mg/l" if param == "DO" else "",
+            location=loc,
+        )
+        for sid, dt, param, val, loc in rows
+    ]
+
+
+def main() -> None:
+    records = demo_records()
+
+    # 1. To xarray.Dataset: dims (time, station_id), one var per parameter,
+    #    lat/lon station coords. Ready for the Pangeo / NeuralHydrology world.
+    ds = records_to_xarray(records)
+    print("=== xarray.Dataset ===")
+    print(ds)
+    print("\nDO at TAMSUI on 2026-01-01:",
+          ds["DO"].sel(time=datetime(2026, 1, 1), station_id="TAMSUI").item())
+
+    # 2. To geopandas.GeoDataFrame: one row per record, Point geometry (EPSG:4326).
+    gdf = records_to_geodataframe(records)
+    print("\n=== geopandas.GeoDataFrame ===")
+    print(gdf[["station_id", "parameter", "value", "geometry"]])
+
+    # 3. In real use, collectors emit these objects directly:
+    #
+    #     from aquascope.collectors import TaiwanMOENVCollector
+    #     ds = TaiwanMOENVCollector().collect(as_xarray=True)
+    #     gdf = TaiwanMOENVCollector().collect(as_geodataframe=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,8 +85,13 @@ spatial = [
     "geopandas>=0.14",
     "shapely>=2.0",
 ]
+interop = [
+    "xarray>=2023.1",
+    "geopandas>=0.14",
+    "shapely>=2.0",
+]
 all = [
-    "aquascope[ml,forecast,copernicus,viz,llm,scientific,dashboard,spatial]",
+    "aquascope[ml,forecast,copernicus,viz,llm,scientific,dashboard,spatial,interop]",
 ]
 dev = [
     "pytest>=7.0",

--- a/tests/test_io/test_interop.py
+++ b/tests/test_io/test_interop.py
@@ -1,0 +1,160 @@
+"""Tests for the xarray / GeoPandas interop bridge (aquascope.io.interop).
+
+Guarded by importorskip so a bare core install skips cleanly; CI installs the
+interop/spatial/scientific extras and runs them."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+pytest.importorskip("xarray", reason="xarray not installed (aquascope[interop])")
+pytest.importorskip("geopandas", reason="geopandas not installed (aquascope[interop])")
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.io.interop import records_to_geodataframe, records_to_xarray
+from aquascope.schemas.water_data import (
+    DataSource,
+    GeoLocation,
+    WaterLevelReading,
+    WaterQualitySample,
+)
+
+
+def _wq(station, dt, param, value, unit="mg/l", loc=None):
+    return WaterQualitySample(
+        source=DataSource.WQP,
+        station_id=station,
+        sample_datetime=dt,
+        parameter=param,
+        value=value,
+        unit=unit,
+        location=loc,
+    )
+
+
+def _wl(station, dt, level, loc=None):
+    return WaterLevelReading(
+        source=DataSource.TAIWAN_WRA,
+        station_id=station,
+        reading_datetime=dt,
+        water_level=level,
+        location=loc,
+    )
+
+
+class TestRecordsToXarray:
+    def test_water_quality_dims_and_vars(self):
+        loc = GeoLocation(latitude=24.1, longitude=120.7)
+        recs = [
+            _wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=loc),
+            _wq("S1", datetime(2026, 1, 2), "DO", 8.1, loc=loc),
+            _wq("S1", datetime(2026, 1, 1), "pH", 7.2, unit="", loc=loc),
+        ]
+        ds = records_to_xarray(recs)
+        assert set(ds.dims) == {"time", "station_id"}
+        assert "DO" in ds.data_vars and "pH" in ds.data_vars
+        assert ds["DO"].attrs.get("units") == "mg/l"
+        assert ds["DO"].sel(time=datetime(2026, 1, 1), station_id="S1").item() == 8.5
+        assert ds.attrs["source"] == "wqp"
+
+    def test_station_coords_present(self):
+        loc = GeoLocation(latitude=24.1, longitude=120.7)
+        ds = records_to_xarray([_wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=loc)])
+        assert float(ds["lat"].sel(station_id="S1")) == 24.1
+        assert float(ds["lon"].sel(station_id="S1")) == 120.7
+
+    def test_missing_location_gives_nan_coords(self):
+        ds = records_to_xarray([_wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=None)])
+        import math
+
+        assert math.isnan(float(ds["lat"].sel(station_id="S1")))
+
+    def test_water_level_records(self):
+        ds = records_to_xarray(
+            [
+                _wl("G1", datetime(2026, 1, 1), 12.3),
+                _wl("G1", datetime(2026, 1, 2), 12.9),
+            ]
+        )
+        assert "water_level" in ds.data_vars
+        assert ds["water_level"].attrs.get("units") == "m"
+        assert set(ds.dims) == {"time", "station_id"}
+
+    def test_empty_input(self):
+        ds = records_to_xarray([])
+        assert len(ds.data_vars) == 0
+
+    def test_unsupported_type_raises(self):
+        from aquascope.schemas.water_data import ReservoirStatus
+
+        rec = ReservoirStatus(
+            source=DataSource.TAIWAN_WRA, reservoir_name="R1", date=datetime(2026, 1, 1)
+        )
+        with pytest.raises(TypeError):
+            records_to_xarray([rec])
+
+
+class TestRecordsToGeoDataFrame:
+    def test_geometry_and_crs(self):
+        loc = GeoLocation(latitude=24.1, longitude=120.7)
+        gdf = records_to_geodataframe([_wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=loc)])
+        assert gdf.crs.to_epsg() == 4326
+        assert gdf.geometry.iloc[0].x == 120.7
+        assert gdf.geometry.iloc[0].y == 24.1
+        assert gdf["latitude"].iloc[0] == 24.1
+        assert gdf["source"].iloc[0] == "wqp"
+
+    def test_missing_location_null_geometry_not_dropped(self):
+        gdf = records_to_geodataframe(
+            [
+                _wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=None),
+                _wq("S2", datetime(2026, 1, 1), "DO", 8.0,
+                    loc=GeoLocation(latitude=1.0, longitude=2.0)),
+            ]
+        )
+        assert len(gdf) == 2
+        assert gdf.geometry.iloc[0] is None
+        assert gdf.geometry.iloc[1] is not None
+
+    def test_empty_input(self):
+        gdf = records_to_geodataframe([])
+        assert len(gdf) == 0
+        assert gdf.crs.to_epsg() == 4326
+
+
+class _FakeCollector(BaseCollector):
+    name = "fake"
+
+    def fetch_raw(self, **kwargs):
+        return [1]
+
+    def normalise(self, raw):
+        loc = GeoLocation(latitude=24.1, longitude=120.7)
+        return [_wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=loc)]
+
+
+class TestCollectConvenience:
+    def test_collect_as_xarray(self):
+        import xarray as xr
+
+        out = _FakeCollector().collect(as_xarray=True)
+        assert isinstance(out, xr.Dataset)
+        assert "DO" in out.data_vars
+
+    def test_collect_as_geodataframe(self):
+        import geopandas as gpd
+
+        out = _FakeCollector().collect(as_geodataframe=True)
+        assert isinstance(out, gpd.GeoDataFrame)
+        assert len(out) == 1
+
+    def test_collect_default_returns_records(self):
+        out = _FakeCollector().collect()
+        assert isinstance(out, list)
+        assert out[0].parameter == "DO"
+
+    def test_mutually_exclusive(self):
+        with pytest.raises(ValueError):
+            _FakeCollector().collect(as_xarray=True, as_geodataframe=True)


### PR DESCRIPTION
Closes #73, closes #74, closes #75. First slice of epic #70.

Bridges AquaScope's unified Pydantic records to `xarray.Dataset` and `geopandas.GeoDataFrame` — the table-stakes interoperability gap our adoption research flagged (US peers like HyRiver already emit these; we were a closed schema).

## What's in it
- **`records_to_xarray()`** — time-series records → `Dataset`, dims `(time, station_id)`, one var per parameter (`WaterQualitySample`) or `water_level` (`WaterLevelReading`), `lat`/`lon` coords, `units` attrs. Missing location → `NaN` coords, not dropped. Empty → empty `Dataset`.
- **`records_to_geodataframe()`** — point records → `GeoDataFrame`, `Point` geometry (EPSG:4326), flattened `lat`/`lon` columns, null geometry for missing location (count logged), nothing dropped.
- **`collect(as_xarray=, as_geodataframe=)`** — one-call convenience on every collector; mutually exclusive; default still returns the record list.
- New **`[interop]`** extra (xarray + geopandas + shapely); `require()` gains a `group=` override so the missing-dep error points at `[interop]`.
- Tests (importorskip-guarded so a bare install skips, CI runs them), a runnable `examples/11_interop_xarray.py`, and the xarray integration guide rewritten around the real API (the old one referenced a non-existent `timestamp` field).

## Verification
- 160 passed + 1 skipped locally (interop tests run with xarray/geopandas installed); ruff clean; example runs and produces the expected `(time, station_id)` Dataset and Point GeoDataFrame.

## Not in this PR
Cloud-native reads (STAC/Zarr) are a separate future concern; this is the in-memory object bridge that unblocks composition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)