### PR TITLE
feat(gr4j): quantile prediction intervals (UQ)

### DIFF
--- a/aquascope/models/rainfall_runoff.py
+++ b/aquascope/models/rainfall_runoff.py
@@ -21,6 +21,7 @@ Perrin, C., Michel, C., & Andreassian, V. (2003). Improvement of a
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from dataclasses import dataclass
 
 import numpy as np
@@ -376,4 +377,171 @@ def calibrate(
         objective_name=objective,
         n_iterations=int(opt_result.nit),
         simulated=best_sim.streamflow,
+    )
+
+
+# ── Uncertainty quantification ────────────────────────────────────────────
+
+
+@dataclass
+class GR4JProbabilisticResult:
+    """Probabilistic GR4J prediction.
+
+    Attributes
+    ----------
+    median : pd.Series
+        Central (q=0.5) streamflow estimate (mm/day).
+    quantiles : dict[float, pd.Series]
+        Predictive quantile bands keyed by quantile level (e.g. 0.05,
+        0.95), each a streamflow series aligned with the input index.
+        Bands are non-negative and monotonic in the quantile level.
+    params : dict
+        Calibrated GR4J parameters (X1-X4) underlying the prediction.
+    method : str
+        How the bands were produced: ``"residual"`` or ``"ensemble"``.
+    """
+
+    median: pd.Series
+    quantiles: dict[float, pd.Series]
+    params: dict[str, float]
+    method: str
+
+
+def residual_quantile_bands(
+    simulated: pd.Series,
+    observed: pd.Series,
+    quantiles: Sequence[float] = (0.05, 0.25, 0.5, 0.75, 0.95),
+    *,
+    warmup_days: int = 0,
+    heteroscedastic: bool = False,
+    eps: float = 1e-6,
+) -> dict[float, pd.Series]:
+    """Predictive quantile bands from the empirical residual distribution.
+
+    Fits residuals ``obs - sim`` over the post-warmup period, then offsets the
+    simulated series by their quantiles. With ``heteroscedastic=True`` the
+    residuals are taken relative to flow magnitude — ``(obs - sim) / (sim +
+    eps)`` — so bands widen at high flows, which better matches streamflow
+    error structure. Bands are clipped to be non-negative and sorted so that
+    lower quantiles never exceed higher ones at any time step.
+    """
+    sim = simulated.astype(float)
+    obs = observed.astype(float)
+    sim_eval = sim.values[warmup_days:]
+    obs_eval = obs.values[warmup_days:]
+    mask = np.isfinite(sim_eval) & np.isfinite(obs_eval)
+    se, oe = sim_eval[mask], obs_eval[mask]
+    if len(se) == 0:
+        raise ValueError("No finite paired (simulated, observed) values for residuals.")
+
+    qs = sorted(quantiles)
+    sim_all = sim.values
+    if heteroscedastic:
+        rel = (oe - se) / (se + eps)
+        offsets = [np.quantile(rel, q) * (sim_all + eps) for q in qs]
+    else:
+        resid = oe - se
+        offsets = [np.full_like(sim_all, np.quantile(resid, q)) for q in qs]
+
+    stacked = np.clip(np.vstack([sim_all + off for off in offsets]), 0.0, None)
+    # Enforce monotonicity across quantile levels per time step (clipping at 0
+    # can otherwise tie or invert the lowest bands).
+    stacked = np.sort(stacked, axis=0)
+    return {
+        q: pd.Series(stacked[i], index=sim.index, name=f"q{q:g}")
+        for i, q in enumerate(qs)
+    }
+
+
+def _parameter_ensemble_bands(
+    best_params: dict[str, float],
+    precip: pd.Series,
+    pet: pd.Series,
+    quantiles: Sequence[float],
+    n_members: int,
+    perturb: float,
+    seed: int | None,
+    warmup_days: int,
+) -> dict[float, pd.Series]:
+    """Quantile bands from an ensemble of parameter-perturbed simulations.
+
+    Each member adds Gaussian noise (sigma = ``perturb`` x the parameter's
+    bound width) to the calibrated X1-X4, clipped to the GR4J bounds, then
+    simulates. Bands are the empirical quantiles across members per time step.
+    """
+    rng = np.random.default_rng(seed)
+    order = ["X1", "X2", "X3", "X4"]
+    sims = []
+    for _ in range(n_members):
+        p = {}
+        for k in order:
+            lo, hi = GR4J_PARAM_BOUNDS[k]
+            val = best_params[k] + rng.normal(0.0, perturb * (hi - lo))
+            p[k] = float(np.clip(val, lo, hi))
+        model = GR4J(x1=p["X1"], x2=p["X2"], x3=p["X3"], x4=p["X4"])
+        sims.append(model.simulate(precip, pet, warmup_days=warmup_days).streamflow.values)
+    ens = np.vstack(sims)
+    idx = precip.index
+    return {
+        q: pd.Series(np.clip(np.quantile(ens, q, axis=0), 0.0, None), index=idx, name=f"q{q:g}")
+        for q in sorted(quantiles)
+    }
+
+
+def predict_quantiles(
+    precip: pd.Series,
+    pet: pd.Series,
+    observed: pd.Series,
+    quantiles: Sequence[float] = (0.05, 0.25, 0.5, 0.75, 0.95),
+    *,
+    method: str = "residual",
+    objective: str = "kge",
+    warmup_days: int = 365,
+    heteroscedastic: bool = True,
+    n_members: int = 50,
+    perturb: float = 0.05,
+    seed: int | None = 42,
+    maxiter: int = 100,
+) -> GR4JProbabilisticResult:
+    """Calibrate GR4J and produce calibrated predictive quantile bands.
+
+    Two methods:
+
+    - ``"residual"`` (default): the deterministic simulation offset by
+      empirical residual quantiles (see :func:`residual_quantile_bands`).
+      Fast, and the natural citable path for adding UQ to GR4J.
+    - ``"ensemble"``: an ensemble of parameter-perturbed simulations
+      (see :func:`_parameter_ensemble_bands`). Captures parameter
+      uncertainty but is ``n_members`` times more expensive.
+
+    The deterministic :meth:`GR4J.simulate` path is unchanged; UQ is opt-in.
+    """
+    if method not in ("residual", "ensemble"):
+        raise ValueError(f"method must be 'residual' or 'ensemble'; got {method!r}.")
+
+    cal = calibrate(
+        precip,
+        pet,
+        observed,
+        objective=objective,
+        warmup_days=warmup_days,
+        seed=seed,
+        maxiter=maxiter,
+    )
+    best = GR4J(**{k.lower(): v for k, v in cal.params.items()})
+    sim = best.simulate(precip, pet, warmup_days=warmup_days).streamflow
+
+    qs = sorted(quantiles)
+    if method == "residual":
+        bands = residual_quantile_bands(
+            sim, observed, qs, warmup_days=warmup_days, heteroscedastic=heteroscedastic
+        )
+    else:
+        bands = _parameter_ensemble_bands(
+            cal.params, precip, pet, qs, n_members, perturb, seed, warmup_days
+        )
+
+    median = bands.get(0.5, sim)
+    return GR4JProbabilisticResult(
+        median=median, quantiles=bands, params=cal.params, method=method
     )

--- a/tests/test_models/test_gr4j_uq.py
+++ b/tests/test_models/test_gr4j_uq.py
@@ -1,0 +1,109 @@
+"""Tests for GR4J quantile prediction intervals (#77, epic #71).
+
+Validates the residual and ensemble UQ paths and their coverage using the
+probabilistic metrics from #76."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aquascope.analysis.metrics import picp
+from aquascope.models.rainfall_runoff import (
+    GR4J,
+    GR4JProbabilisticResult,
+    predict_quantiles,
+    residual_quantile_bands,
+)
+
+QUANTILES = (0.05, 0.25, 0.5, 0.75, 0.95)
+
+
+def _synthetic_inputs(n: int = 500, seed: int = 0):
+    rng = np.random.default_rng(seed)
+    idx = pd.date_range("2018-01-01", periods=n, freq="D")
+    precip = pd.Series(rng.gamma(0.6, 6.0, n), index=idx)
+    doy = idx.dayofyear.to_numpy()
+    pet = pd.Series(2.5 + 1.5 * np.sin(2 * np.pi * doy / 365.0), index=idx)
+    # "Observed" = a known GR4J run plus a little multiplicative noise.
+    truth = GR4J(x1=320.0, x2=-1.0, x3=70.0, x4=1.6).simulate(precip, pet, warmup_days=0)
+    obs = truth.streamflow * (1.0 + rng.normal(0.0, 0.1, n))
+    obs = obs.clip(lower=0.0)
+    return precip, pet, obs
+
+
+class TestResidualQuantileBands:
+    def test_additive_offsets_match_residual_quantiles(self):
+        idx = pd.date_range("2020-01-01", periods=200)
+        sim = pd.Series(np.full(200, 5.0), index=idx)
+        rng = np.random.default_rng(1)
+        resid = rng.normal(0.0, 1.0, 200)
+        obs = pd.Series(5.0 + resid, index=idx)
+        bands = residual_quantile_bands(sim, obs, [0.05, 0.5, 0.95])
+        assert bands[0.5].iloc[0] == pytest.approx(5.0 + np.quantile(resid, 0.5), abs=1e-9)
+        assert bands[0.95].iloc[0] == pytest.approx(5.0 + np.quantile(resid, 0.95), abs=1e-9)
+
+    def test_monotonic_and_non_negative(self):
+        idx = pd.date_range("2020-01-01", periods=100)
+        sim = pd.Series(np.linspace(0.0, 3.0, 100), index=idx)
+        rng = np.random.default_rng(2)
+        obs = pd.Series(np.clip(sim.values + rng.normal(0, 2, 100), 0, None), index=idx)
+        bands = residual_quantile_bands(sim, obs, QUANTILES)
+        lo, hi = bands[0.05].values, bands[0.95].values
+        assert np.all(lo <= bands[0.5].values + 1e-9)
+        assert np.all(bands[0.5].values <= hi + 1e-9)
+        assert np.all(lo >= 0.0)
+
+    def test_heteroscedastic_widens_at_high_flow(self):
+        idx = pd.date_range("2020-01-01", periods=300)
+        sim = pd.Series(np.linspace(1.0, 50.0, 300), index=idx)
+        rng = np.random.default_rng(3)
+        obs = pd.Series(sim.values * (1.0 + rng.normal(0, 0.2, 300)), index=idx).clip(lower=0)
+        bands = residual_quantile_bands(sim, obs, QUANTILES, heteroscedastic=True)
+        width = bands[0.95].values - bands[0.05].values
+        assert width[-1] > width[0]  # wider band at high flow
+
+    def test_raises_without_finite_pairs(self):
+        idx = pd.date_range("2020-01-01", periods=5)
+        sim = pd.Series([np.nan] * 5, index=idx)
+        obs = pd.Series([1.0] * 5, index=idx)
+        with pytest.raises(ValueError):
+            residual_quantile_bands(sim, obs, QUANTILES)
+
+
+class TestPredictQuantiles:
+    def test_residual_structure_and_coverage(self):
+        precip, pet, obs = _synthetic_inputs()
+        res = predict_quantiles(
+            precip, pet, obs, quantiles=QUANTILES,
+            method="residual", warmup_days=120, maxiter=4, seed=0,
+        )
+        assert isinstance(res, GR4JProbabilisticResult)
+        assert res.method == "residual"
+        assert set(res.quantiles) == set(QUANTILES)
+        # median is the 0.5 band
+        assert res.median.equals(res.quantiles[0.5])
+        # bands non-negative and ordered
+        assert np.all(res.quantiles[0.05].values >= 0.0)
+        assert np.all(res.quantiles[0.05].values <= res.quantiles[0.95].values + 1e-9)
+        # in-sample coverage of the central 90% band should be near nominal
+        ev = slice(120, None)
+        cov = picp(
+            obs.values[ev], res.quantiles[0.05].values[ev], res.quantiles[0.95].values[ev]
+        )
+        assert cov >= 0.8
+
+    def test_ensemble_method_runs(self):
+        precip, pet, obs = _synthetic_inputs(n=400)
+        res = predict_quantiles(
+            precip, pet, obs, quantiles=(0.1, 0.5, 0.9),
+            method="ensemble", warmup_days=90, maxiter=3, n_members=8, seed=1,
+        )
+        assert res.method == "ensemble"
+        assert np.all(res.quantiles[0.1].values <= res.quantiles[0.9].values + 1e-9)
+
+    def test_invalid_method_raises(self):
+        precip, pet, obs = _synthetic_inputs(n=200)
+        with pytest.raises(ValueError):
+            predict_quantiles(precip, pet, obs, method="bogus", maxiter=2)


### PR DESCRIPTION
Closes #77. Builds on #76 (merged). Part of epic #71.

GR4J emitted only a deterministic hydrograph; this adds **opt-in calibrated predictive quantile bands**. The deterministic `simulate()` path is unchanged.

## API (`models/rainfall_runoff.py`)
- **`GR4JProbabilisticResult`** — `median` + `quantiles` dict + `params` + `method`.
- **`residual_quantile_bands(simulated, observed, quantiles, heteroscedastic=False)`** — the core, fast, citable path: empirical residual quantiles offset the simulation. Heteroscedastic mode scales residuals by flow magnitude (wider bands at high flow). Non-negative, monotonic across quantile levels.
- **`predict_quantiles(...)`** — calibrates, then produces bands via `method="residual"` (default) or `method="ensemble"` (parameter-perturbation).

## Validation (with #76 metrics)
7 tests: additive offsets match residual quantiles, monotonic + non-negative bands, heteroscedastic widening at high flow, and **in-sample PICP ≥ 0.8** for the central 90% band on a synthetic basin (the coverage check #77 asked for). Existing GR4J + metrics suites still pass (47). ruff clean.

## Next
**#78** runs this across the bundled CAMELS basins and reports per-basin PICP/CRPS + a reliability diagram — the multi-basin demonstration that makes the UQ citable, and the validation evidence for the JOSS paper (#72).

🤖 Generated with [Claude Code](https://claude.com/claude-code)