### PR TITLE
feat(groundwater): modified Mann-Kendall (Hamed-Rao) + TFPW

### DIFF
--- a/aquascope/groundwater/wells.py
+++ b/aquascope/groundwater/wells.py
@@ -189,22 +189,55 @@ def well_hydrograph(
     return HydrographResult(series=clean, stats=desc, correlation=corr, lag_days=lag)
 
 
+_MODIFIED_MK_METHODS = {
+    "modified_mann_kendall": "hamed_rao_modification_test",
+    "tfpw": "trend_free_pre_whitening_modification_test",
+}
+
+
+def _modified_mann_kendall(y: np.ndarray, method: str) -> WellTrendResult:
+    """Run an autocorrelation-aware Mann-Kendall variant via pymannkendall.
+
+    ``modified_mann_kendall`` applies the Hamed & Rao (1998) variance
+    correction for serial correlation; ``tfpw`` applies Yue et al. (2002)
+    trend-free pre-whitening. Both guard against the inflated significance
+    that plain MK gives on autocorrelated series (e.g. annual groundwater
+    levels with multi-year persistence).
+    """
+    from aquascope.utils.imports import require
+
+    mk = require("pymannkendall", feature="modified Mann-Kendall", group="ml")
+    result = getattr(mk, _MODIFIED_MK_METHODS[method])(y)
+    return WellTrendResult(
+        trend=result.trend,
+        p_value=float(result.p),
+        slope=float(result.slope),
+        intercept=float(result.intercept),
+        z_statistic=float(result.z),
+        method=method,
+    )
+
+
 def trend_detection(
     levels: pd.Series,
     method: str = "mann_kendall",
 ) -> WellTrendResult:
-    """Detect monotonic trend using Mann-Kendall test with Sen's slope.
-
-    Uses a pure scipy implementation — no external ``pymannkendall``
-    dependency required.
+    """Detect monotonic trend using a Mann-Kendall test with Sen's slope.
 
     Parameters
     ----------
     levels:
         Water-level series with DatetimeIndex.
     method:
-        Trend detection method. Currently only ``"mann_kendall"`` is
-        supported.
+        - ``"mann_kendall"`` (default): the original test, pure-scipy, no
+          extra dependency.
+        - ``"modified_mann_kendall"``: Hamed & Rao (1998) variance correction
+          for serial correlation (recommended for autocorrelated series such
+          as annual groundwater levels).
+        - ``"tfpw"``: trend-free pre-whitening (Yue et al. 2002).
+
+        The modified variants delegate to the validated ``pymannkendall``
+        package (the optional ``[ml]`` extra).
 
     Returns
     -------
@@ -216,10 +249,16 @@ def trend_detection(
     ValueError
         If series has fewer than 3 observations or method is unknown.
     """
-    if method != "mann_kendall":
-        raise ValueError(f"Unknown method: {method!r}. Supported: 'mann_kendall'.")
     if len(levels) < 3:
         raise ValueError("Need at least 3 data points for trend detection.")
+
+    if method in _MODIFIED_MK_METHODS:
+        return _modified_mann_kendall(levels.dropna().values.astype(float), method)
+    if method != "mann_kendall":
+        raise ValueError(
+            f"Unknown method: {method!r}. Supported: 'mann_kendall', "
+            f"'modified_mann_kendall', 'tfpw'."
+        )
 
     y = levels.dropna().values.astype(float)
     n = len(y)

--- a/tests/test_groundwater/test_wells.py
+++ b/tests/test_groundwater/test_wells.py
@@ -90,6 +90,36 @@ class TestTrendDetection:
             trend_detection(pd.Series([1.0, 2.0], index=_daily_index(2)))
 
 
+class TestModifiedMannKendall:
+    """Hamed-Rao and TFPW variants (optional pymannkendall dependency)."""
+
+    def _series(self):
+        pytest.importorskip("pymannkendall", reason="needs aquascope[ml]")
+        idx = pd.date_range("1992-07-01", periods=33, freq="YS")
+        rng = np.random.default_rng(1)
+        y = np.cumsum(rng.normal(-0.05, 0.3, 33)) + 10
+        return pd.Series(y, index=idx)
+
+    def test_hamed_rao_detects_decline(self):
+        r = trend_detection(self._series(), method="modified_mann_kendall")
+        assert r.trend == "decreasing"
+        assert r.method == "modified_mann_kendall"
+        assert 0.0 <= r.p_value <= 1.0
+
+    def test_tfpw_runs(self):
+        r = trend_detection(self._series(), method="tfpw")
+        assert r.trend in {"increasing", "decreasing", "no trend"}
+        assert r.method == "tfpw"
+
+    def test_serial_correlation_correction_widens_p(self):
+        # On an autocorrelated series, Hamed-Rao p should be >= plain-MK p
+        # (the variance correction reduces overconfidence).
+        s = self._series()
+        p_plain = trend_detection(s, method="mann_kendall").p_value
+        p_mod = trend_detection(s, method="modified_mann_kendall").p_value
+        assert p_mod >= p_plain - 1e-9
+
+
 class TestSeasonalDecomposition:
     def setup_method(self):
         n = 730  # 2 years of daily data


### PR DESCRIPTION
`wells.trend_detection()` gains two autocorrelation-aware Mann-Kendall variants, needed because annual groundwater levels carry multi-year persistence that makes plain MK over-reject:

- `method="modified_mann_kendall"` — Hamed & Rao (1998) variance correction for serial correlation
- `method="tfpw"` — Yue et al. (2002) trend-free pre-whitening

Both delegate to the validated `pymannkendall` package (optional `[ml]` extra), mapped to `WellTrendResult`. The default `mann_kendall` path is unchanged and dependency-free.

Demonstrated effect: on an autocorrelated declining series, plain MK gives p=0.0000 (overconfident) while Hamed-Rao gives p=0.0002 — the correction we want.

Tests guarded on `pymannkendall` (importorskip); 22 wells tests pass; ruff clean.