### PR TITLE
feat: well coordinates for TaiwanWRAGroundwaterDailyCollector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ All notable changes to AquaScope are documented here.
   (the input to a Standardised Groundwater Index) or `"daily"`. Rate-limits
   and caches every request. This unlocks monthly SGI and SPI/SPEI
   drought-propagation analysis on AquaScope-collected data.
+- **Well coordinates for daily groundwater**: `TaiwanWRAGroundwaterDailyCollector`
+  gains `with_metadata=True` (default), joining the open-data 井況 well-status
+  dataset to populate each reading's `location` (TWD97 → WGS84) and
+  `well_depth_m`. The gweb station id matches the suffix of the open-data
+  `wellidentifier` after `GW` (with a well-name fallback), making the daily
+  series spatially complete.
 
 ### Changed
 - `CachedHTTPClient.post_json()` now sends a JSON body and shares the retry,

--- a/aquascope/collectors/taiwan_wra.py
+++ b/aquascope/collectors/taiwan_wra.py
@@ -415,6 +415,33 @@ def _parse_date(value: str | date | None) -> date | None:
     return datetime.strptime(str(value)[:10], "%Y-%m-%d").date()
 
 
+def _build_gweb_well_metadata(rows: list[dict]) -> dict[str, dict]:
+    """Index the open-data 井況 metadata for joining to gweb daily wells.
+
+    The gweb station id (e.g. ``07010211``) is the suffix of the open-data
+    ``wellidentifier`` after ``GW`` (e.g. ``3132014GW07010211``). We index each
+    well's coordinates and depth by that suffix code AND by well name, so the
+    daily collector can attach location even when one key is ambiguous.
+    """
+    meta: dict[str, dict] = {}
+    for r in rows:
+        wid = str(r.get("wellidentifier") or "")
+        code = wid.split("GW")[-1] if "GW" in wid else wid
+        depth = _parse_gw_value(r.get("welldepth"))
+        if depth is None:
+            depth = _parse_gw_value(r.get("finishdepth"))
+        info = {
+            "location": _twd97_to_location(r.get("locationbytwd97")),
+            "well_depth_m": depth,
+        }
+        if code:
+            meta.setdefault(f"code::{code}", info)
+        name = (r.get("wellname") or "").strip()
+        if name:
+            meta.setdefault(f"name::{name}", info)
+    return meta
+
+
 class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
     """Collect DAILY groundwater-level series from the WRA gweb HydroInfo portal.
 
@@ -447,6 +474,12 @@ class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
         reading per well per day (far larger).
     window_years : int
         Chunk size (years) for the windowed chart pulls. Default 5.
+    with_metadata : bool
+        When ``True`` (default), join the open-data 井況 well-status dataset to
+        populate each reading's ``location`` (TWD97 coordinates converted to
+        WGS84) and ``well_depth_m``. The gweb station id is matched to the
+        suffix of the open-data ``wellidentifier`` after ``GW`` (falling back to
+        the well name). Set ``False`` to skip the extra open-data request.
 
     Notes
     -----
@@ -465,6 +498,7 @@ class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
         end: str | date | None = None,
         aggregate: str = "monthly",
         window_years: int = 5,
+        with_metadata: bool = True,
         client: CachedHTTPClient | None = None,
     ):
         if aggregate not in ("monthly", "daily"):
@@ -482,9 +516,35 @@ class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
         self.stations = list(stations) if stations else None
         self.aggregate = aggregate
         self.window_years = max(1, int(window_years))
+        self.with_metadata = with_metadata
         self.start = _parse_date(start)
         self.end = _parse_date(end)
         self._session_ready = False
+        self._well_meta: dict[str, dict] = {}
+
+    def _load_well_metadata(self) -> None:
+        """Fetch the open-data 井況 dataset and index it for coordinate joins."""
+        if self._well_meta:
+            return
+        meta_client = CachedHTTPClient(
+            base_url=WRA_BASE,
+            rate_limiter=RateLimiter(max_calls=15, period_seconds=60),
+            cache_ttl_seconds=86400,
+            verify=False,
+        )
+        rows = meta_client.get_json(GROUNDWATER_WELL_METADATA_DATASET)
+        if isinstance(rows, dict):
+            rows = rows.get("responseData", rows.get("records", []))
+        self._well_meta = _build_gweb_well_metadata(rows)
+
+    def _meta_for(self, station_no: str, station_name: str | None) -> dict:
+        if not self._well_meta:
+            return {}
+        return (
+            self._well_meta.get(f"code::{station_no}")
+            or (self._well_meta.get(f"name::{station_name.strip()}") if station_name else None)
+            or {}
+        )
 
     # ── portal helpers ───────────────────────────────────────────────
     def _ensure_session(self) -> None:
@@ -554,6 +614,8 @@ class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
 
     # ── BaseCollector contract ───────────────────────────────────────
     def fetch_raw(self, **kwargs) -> list[dict]:
+        if self.with_metadata:
+            self._load_well_metadata()
         # Build the (station, zone) work list.
         work: list[tuple[str, str, str]] = []  # (station_no, station_name, zone_name)
         if self.stations:
@@ -602,16 +664,19 @@ class TaiwanWRAGroundwaterDailyCollector(BaseCollector):
                     (datetime(y, m, 15), sum(vs) / len(vs))
                     for (y, m), vs in sorted(buckets.items())
                 ]
+            meta = self._meta_for(rec["station_no"], rec.get("station_name"))
             for dt, value in points:
                 readings.append(
                     GroundwaterLevel(
                         source=DataSource.TAIWAN_WRA,
                         station_id=rec["station_no"],
                         station_name=rec.get("station_name"),
+                        location=meta.get("location"),
                         measurement_datetime=dt,
                         water_level_m=value,
                         unit="m",
                         aquifer_name=rec.get("zone"),
+                        well_depth_m=meta.get("well_depth_m"),
                     )
                 )
         return readings

--- a/tests/test_collectors/test_taiwan_wra_groundwater_daily.py
+++ b/tests/test_collectors/test_taiwan_wra_groundwater_daily.py
@@ -17,6 +17,7 @@ from aquascope.collectors.taiwan_wra import (
     _GWEB_HISTORY,
     _GWEB_STATION_LIST,
     TaiwanWRAGroundwaterDailyCollector,
+    _build_gweb_well_metadata,
 )
 from aquascope.schemas.water_data import DataSource
 
@@ -55,7 +56,8 @@ class _FakeClient:
 
 
 def test_monthly_aggregation_one_well():
-    c = TaiwanWRAGroundwaterDailyCollector(zones=["zhuoshui fan"], client=_FakeClient())
+    c = TaiwanWRAGroundwaterDailyCollector(zones=["zhuoshui fan"], with_metadata=False,
+                                           client=_FakeClient())
     recs = c.collect()
     # 24 months across 2020-2021.
     assert len(recs) == 24
@@ -71,7 +73,7 @@ def test_monthly_aggregation_one_well():
 
 def test_daily_aggregation_drops_nulls():
     c = TaiwanWRAGroundwaterDailyCollector(zones=["zhuoshui fan"], aggregate="daily",
-                                           client=_FakeClient())
+                                           with_metadata=False, client=_FakeClient())
     recs = c.collect()
     total_days = (_FakeClient.SPAN_HI - _FakeClient.SPAN_LO).days + 1
     assert len(recs) == total_days - 1  # one null day dropped
@@ -80,7 +82,7 @@ def test_daily_aggregation_drops_nulls():
 
 def test_zone_alias_and_session_bootstrap():
     fake = _FakeClient()
-    c = TaiwanWRAGroundwaterDailyCollector(zones=["050"], client=fake)
+    c = TaiwanWRAGroundwaterDailyCollector(zones=["050"], with_metadata=False, client=fake)
     c.collect()
     # Session GET happens once before any POST.
     assert fake.calls[0].startswith("GET ")
@@ -89,7 +91,8 @@ def test_zone_alias_and_session_bootstrap():
 
 def test_start_end_clip():
     c = TaiwanWRAGroundwaterDailyCollector(
-        zones=["zhuoshui fan"], start="2021-01-01", end="2021-12-31", client=_FakeClient()
+        zones=["zhuoshui fan"], start="2021-01-01", end="2021-12-31",
+        with_metadata=False, client=_FakeClient()
     )
     recs = c.collect()
     assert {r.measurement_datetime.year for r in recs} == {2021}
@@ -98,7 +101,8 @@ def test_start_end_clip():
 
 def test_explicit_stations_skip_zone_discovery():
     fake = _FakeClient()
-    c = TaiwanWRAGroundwaterDailyCollector(stations=["07010211"], client=fake)
+    c = TaiwanWRAGroundwaterDailyCollector(stations=["07010211"], with_metadata=False,
+                                           client=fake)
     c.collect()
     assert f"POST {_GWEB_AREA_LIST}" not in fake.calls
     assert f"POST {_GWEB_STATION_LIST}" not in fake.calls
@@ -107,3 +111,36 @@ def test_explicit_stations_skip_zone_discovery():
 def test_bad_aggregate_raises():
     with pytest.raises(ValueError, match="aggregate"):
         TaiwanWRAGroundwaterDailyCollector(aggregate="weekly")
+
+
+def test_well_metadata_builder_keys_by_gw_suffix_and_name():
+    rows = [{
+        "wellidentifier": "3132014GW07010211", "wellname": "東芳(1)",
+        "locationbytwd97": "200779.08 2662059.14", "welldepth": "48.0",
+    }]
+    meta = _build_gweb_well_metadata(rows)
+    assert "code::07010211" in meta  # gweb id == suffix after GW
+    assert "name::東芳(1)" in meta
+    assert meta["code::07010211"]["well_depth_m"] == pytest.approx(48.0)
+    # TWD97 -> WGS84 lands inside Taiwan (pyproj optional; skip if absent).
+    loc = meta["code::07010211"]["location"]
+    if loc is not None:
+        assert 21.5 <= loc.latitude <= 26.5 and 118.0 <= loc.longitude <= 122.5
+
+
+def test_metadata_join_populates_location_and_depth():
+    from aquascope.schemas.water_data import GeoLocation
+
+    c = TaiwanWRAGroundwaterDailyCollector(zones=["zhuoshui fan"], with_metadata=False,
+                                           client=_FakeClient())
+    # Inject a pre-built metadata index (skips the open-data fetch).
+    c._well_meta = {
+        "code::07010211": {
+            "location": GeoLocation(latitude=23.5, longitude=120.3),
+            "well_depth_m": 48.0,
+        }
+    }
+    recs = c.collect()
+    assert recs[0].location is not None
+    assert recs[0].location.latitude == pytest.approx(23.5)
+    assert recs[0].well_depth_m == pytest.approx(48.0)


### PR DESCRIPTION
## Summary
Adds `with_metadata=True` (default) to `TaiwanWRAGroundwaterDailyCollector`, joining the open-data 井況 well-status dataset to populate each daily-groundwater reading's `location` (TWD97 → WGS84) and `well_depth_m`.

The gweb station id is the suffix of the open-data `wellidentifier` after `GW` (e.g. `3132014GW07010211` → `07010211`), with a well-name fallback for the rare mismatch. This makes the daily series **spatially complete**, which a national groundwater dataset / data descriptor needs.

## Why
The gweb portal serves daily levels but no coordinates. The open-data 井況 dataset has TWD97 coordinates and depth but uses a different id format. This PR bridges them, so the collector now yields fully-located, depth-tagged daily records from one call.

## Validation
Live: well `07010211` (Zhuoshui fan) → `location=(24.06, 120.52)`, `well_depth_m=131`. Coordinates populate for every reading.

## Tests
2 new tests (metadata-builder keying by GW-suffix + name; join populating location/depth). 8 tests pass, ruff clean. Existing mocked tests opt out with `with_metadata=False`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)