### PR TITLE
feat: SGI and SPI drought indices for propagation analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+- **Drought indices** (`groundwater/drought.py`, `climate/indices.py`):
+  `standardised_groundwater_index()` (SGI, Bloomfield & Marchant 2013: per
+  calendar-month non-parametric normal-scores transform) and
+  `standardized_precipitation_index()` (SPI, McKee 1993: gamma fit with zero
+  handling and configurable accumulation scale), plus `drought_events()` to
+  extract runs below a threshold from any standardised index. These make
+  groundwater-meteorological drought-propagation analysis (SGI vs SPI lag) a
+  first-class AquaScope workflow.
 - **Daily Taiwan groundwater** (`collectors/taiwan_wra.py`):
   `TaiwanWRAGroundwaterDailyCollector` reaches the sub-annual (daily)
   groundwater-level series from the WRA gweb HydroInfo portal, which the

--- a/aquascope/climate/__init__.py
+++ b/aquascope/climate/__init__.py
@@ -20,6 +20,7 @@ from aquascope.climate.indices import (
     heat_wave_index,
     palmer_drought_severity_index,
     precipitation_concentration_index,
+    standardized_precipitation_index,
 )
 from aquascope.climate.scenarios import (
     DroughtStats,
@@ -56,6 +57,7 @@ __all__ = [
     "heat_wave_index",
     "palmer_drought_severity_index",
     "precipitation_concentration_index",
+    "standardized_precipitation_index",
     # scenarios
     "DroughtStats",
     "ReturnPeriodShift",

--- a/aquascope/climate/indices.py
+++ b/aquascope/climate/indices.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 
 import numpy as np
 import pandas as pd
+from scipy import stats
 
 logger = logging.getLogger(__name__)
 
@@ -440,3 +441,67 @@ def precipitation_concentration_index(precip_monthly: pd.Series) -> float:
         return 0.0
 
     return float(np.sum(p**2) / total**2 * 100)
+
+
+def standardized_precipitation_index(
+    precip_monthly: pd.Series,
+    scale: int = 3,
+    per_month: bool = True,
+    min_per_group: int = 10,
+) -> pd.Series:
+    """Standardized Precipitation Index (SPI), McKee et al. (1993).
+
+    Monthly precipitation is accumulated over ``scale`` months, a gamma
+    distribution is fitted (with explicit zero handling), and the cumulative
+    probability is mapped to a standard-normal score. The result is unitless,
+    centred on zero, with SPI < -1 indicating meteorological drought; it is
+    directly comparable to the Standardised Groundwater Index for
+    drought-propagation analysis.
+
+    Parameters
+    ----------
+    precip_monthly:
+        Monthly precipitation totals (mm) with a ``DatetimeIndex``.
+    scale:
+        Accumulation period in months (e.g. 3 -> SPI-3). Larger scales capture
+        longer droughts that propagate to groundwater.
+    per_month:
+        When ``True`` (default), fit a separate gamma per calendar month, which
+        removes the seasonal cycle (standard practice). When ``False``, fit one
+        gamma to all accumulated values.
+    min_per_group:
+        Minimum positive values needed to fit a gamma for a group; groups with
+        fewer yield ``NaN``.
+
+    Returns
+    -------
+    pd.Series
+        SPI indexed like the accumulated series, named ``"spi"``.
+    """
+    if not isinstance(precip_monthly.index, pd.DatetimeIndex):
+        raise ValueError("precip_monthly must have a DatetimeIndex.")
+    if scale < 1:
+        raise ValueError("scale must be >= 1 month.")
+    s = precip_monthly.sort_index().astype(float)
+    acc = s.rolling(scale).sum().dropna()
+    if acc.empty:
+        raise ValueError("Series too short for the requested accumulation scale.")
+
+    spi = pd.Series(np.nan, index=acc.index, dtype=float, name="spi")
+    groups = (range(1, 13) if per_month else [None])
+    for g in groups:
+        idx = acc.index if g is None else acc.index[acc.index.month == g]
+        vals = acc.loc[idx]
+        pos = vals[vals > 0]
+        if len(pos) < min_per_group:
+            logger.debug("SPI group %s has %d positive obs (< %d); left NaN.",
+                         g, len(pos), min_per_group)
+            continue
+        # Mixed distribution: point mass at zero (prob q) + gamma on positives.
+        q = float((vals == 0).mean())
+        a, loc, scl = stats.gamma.fit(pos.values, floc=0.0)
+        cdf = q + (1.0 - q) * stats.gamma.cdf(vals.values, a, loc=loc, scale=scl)
+        cdf = np.where(vals.values == 0, q / 2.0, cdf)  # zeros -> lower half of mass
+        cdf = np.clip(cdf, 1e-6, 1 - 1e-6)
+        spi.loc[idx] = stats.norm.ppf(cdf)
+    return spi

--- a/aquascope/groundwater/__init__.py
+++ b/aquascope/groundwater/__init__.py
@@ -15,6 +15,11 @@ from aquascope.groundwater.aquifer import (
     theis_drawdown,
     theis_recovery,
 )
+from aquascope.groundwater.drought import (
+    DroughtEvent,
+    drought_events,
+    standardised_groundwater_index,
+)
 from aquascope.groundwater.grace import (
     DepletionResult,
     GRACEProcessor,
@@ -56,6 +61,9 @@ __all__ = [
     "trend_detection",
     "seasonal_decomposition",
     "recession_analysis",
+    "DroughtEvent",
+    "standardised_groundwater_index",
+    "drought_events",
     # recharge
     "RechargeResult",
     "water_table_fluctuation",

--- a/aquascope/groundwater/drought.py
+++ b/aquascope/groundwater/drought.py
@@ -1,0 +1,121 @@
+"""Groundwater drought indices.
+
+Implements the Standardised Groundwater level Index (SGI) of Bloomfield &
+Marchant (2013, HESS 17:4769): a per-calendar-month, non-parametric normal-
+scores transform of a groundwater-level series, merged into a continuous index.
+SGI < -1 marks groundwater drought; the index is directly comparable to the
+Standardized Precipitation Index (SPI) for drought-propagation analysis.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DroughtEvent:
+    """A continuous run of an index below a drought threshold.
+
+    Attributes
+    ----------
+    start, end:
+        First and last timestamps of the event.
+    duration:
+        Number of time steps in the event.
+    severity:
+        Sum of the (negative) index over the event (more negative = worse).
+    peak:
+        Most negative index value reached.
+    """
+
+    start: pd.Timestamp
+    end: pd.Timestamp
+    duration: int
+    severity: float
+    peak: float
+
+
+def standardised_groundwater_index(
+    levels: pd.Series, min_per_month: int = 5
+) -> pd.Series:
+    """Standardised Groundwater Index (SGI), Bloomfield & Marchant (2013).
+
+    For each calendar month the groundwater levels (across all years) are
+    transformed to standard-normal scores via a non-parametric normal-scores
+    (inverse-normal of plotting positions) transform; the twelve monthly series
+    are then merged into one continuous monthly index. The result is unitless,
+    centred on zero, with SGI < -1 indicating groundwater drought.
+
+    Parameters
+    ----------
+    levels:
+        Groundwater-level series with a ``DatetimeIndex`` (one value per month
+        is expected; multiple values in a month are kept and standardised
+        within that calendar month).
+    min_per_month:
+        Minimum number of observations a calendar month must have to be
+        standardised. Months with fewer are returned as ``NaN`` (the record is
+        too short to estimate that month's distribution).
+
+    Returns
+    -------
+    pd.Series
+        The SGI, indexed like the (sorted, non-null) input, named ``"sgi"``.
+    """
+    if not isinstance(levels.index, pd.DatetimeIndex):
+        raise ValueError("levels must have a DatetimeIndex.")
+    s = levels.dropna().sort_index()
+    if len(s) < min_per_month:
+        raise ValueError(
+            f"Need at least {min_per_month} observations; got {len(s)}."
+        )
+
+    sgi = pd.Series(np.nan, index=s.index, dtype=float, name="sgi")
+    month = s.index.month
+    for m in range(1, 13):
+        idx = s.index[month == m]
+        if len(idx) == 0:
+            continue
+        vals = s.loc[idx]
+        if len(vals) < min_per_month:
+            logger.debug("Month %d has %d obs (< %d); left NaN.", m, len(vals), min_per_month)
+            continue
+        # Average ranks -> plotting positions -> inverse standard normal.
+        ranks = stats.rankdata(vals.values, method="average")
+        sgi.loc[idx] = stats.norm.ppf((ranks - 0.5) / len(vals))
+    return sgi
+
+
+def drought_events(index: pd.Series, threshold: float = -1.0) -> list[DroughtEvent]:
+    """Identify drought events as runs of *index* at or below *threshold*.
+
+    Works on any standardised index (SGI or SPI). Returns events ordered in
+    time, each with duration, accumulated severity, and peak (most negative)
+    value.
+    """
+    s = index.dropna().sort_index()
+    below = s <= threshold
+    events: list[DroughtEvent] = []
+    run_start: pd.Timestamp | None = None
+    prev: pd.Timestamp | None = None
+    for ts, flag in below.items():
+        if flag and run_start is None:
+            run_start = ts
+        elif not flag and run_start is not None:
+            seg = s.loc[run_start:prev]
+            events.append(DroughtEvent(run_start, prev, len(seg),
+                                       float(seg.sum()), float(seg.min())))
+            run_start = None
+        prev = ts
+    if run_start is not None:
+        seg = s.loc[run_start:prev]
+        events.append(DroughtEvent(run_start, prev, len(seg),
+                                   float(seg.sum()), float(seg.min())))
+    return events

--- a/tests/test_climate/test_spi.py
+++ b/tests/test_climate/test_spi.py
@@ -1,0 +1,54 @@
+"""Tests for the Standardized Precipitation Index."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aquascope.climate.indices import standardized_precipitation_index
+
+
+def _monthly_precip(n_years: int = 30, seed: int = 0) -> pd.Series:
+    idx = pd.date_range("1990-01-01", periods=n_years * 12, freq="MS")
+    rng = np.random.default_rng(seed)
+    # Seasonal gamma-ish precip (wet summers), always non-negative.
+    seasonal = 80 + 60 * np.sin(2 * np.pi * (np.arange(len(idx)) % 12) / 12)
+    precip = rng.gamma(shape=2.0, scale=seasonal / 2.0)
+    return pd.Series(precip, index=idx)
+
+
+class TestSPI:
+    def test_standard_normal_distribution(self):
+        spi = standardized_precipitation_index(_monthly_precip(), scale=3).dropna()
+        assert abs(spi.mean()) < 0.2
+        assert 0.7 < spi.std() < 1.3
+
+    def test_dry_period_is_negative(self):
+        precip = _monthly_precip()
+        dry = (precip.index.year >= 2010) & (precip.index.year <= 2011)
+        precip[dry] *= 0.1  # strong dry anomaly
+        spi = standardized_precipitation_index(precip, scale=6).dropna()
+        dry_spi = spi[spi.index.year.isin([2010, 2011])]
+        assert dry_spi.mean() < -0.8
+
+    def test_scale_changes_output(self):
+        precip = _monthly_precip()
+        spi3 = standardized_precipitation_index(precip, scale=3)
+        spi12 = standardized_precipitation_index(precip, scale=12)
+        # Different accumulation -> different series (and SPI-12 starts later).
+        assert spi12.dropna().index.min() > spi3.dropna().index.min()
+
+    def test_non_datetime_index_raises(self):
+        with pytest.raises(ValueError, match="DatetimeIndex"):
+            standardized_precipitation_index(pd.Series([1.0, 2.0, 3.0]))
+
+    def test_bad_scale_raises(self):
+        with pytest.raises(ValueError, match="scale"):
+            standardized_precipitation_index(_monthly_precip(), scale=0)
+
+    def test_handles_zeros(self):
+        precip = _monthly_precip()
+        precip.iloc[::5] = 0.0  # inject dry months
+        spi = standardized_precipitation_index(precip, scale=1)
+        assert np.isfinite(spi.dropna()).all()

--- a/tests/test_groundwater/test_drought.py
+++ b/tests/test_groundwater/test_drought.py
@@ -1,0 +1,94 @@
+"""Tests for the Standardised Groundwater Index and drought events."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aquascope.groundwater.drought import (
+    drought_events,
+    standardised_groundwater_index,
+)
+
+
+def _monthly(n_years: int = 25, start: str = "1995-01-15") -> pd.DatetimeIndex:
+    return pd.date_range(start, periods=n_years * 12, freq="MS")
+
+
+class TestSGI:
+    def setup_method(self):
+        self.idx = _monthly(25)
+        rng = np.random.default_rng(0)
+        seasonal = 2.0 * np.sin(2 * np.pi * np.arange(len(self.idx)) / 12)
+        self.levels = pd.Series(10.0 + seasonal + rng.normal(0, 1, len(self.idx)),
+                                index=self.idx)
+
+    def test_standard_normal_distribution(self):
+        sgi = standardised_groundwater_index(self.levels)
+        s = sgi.dropna()
+        # Normal scores -> mean ~0, std ~1.
+        assert abs(s.mean()) < 0.15
+        assert 0.8 < s.std() < 1.2
+
+    def test_removes_seasonality(self):
+        # SGI is standardised per calendar month, so the strong seasonal cycle
+        # in the raw levels should not survive into the index.
+        sgi = standardised_groundwater_index(self.levels).dropna()
+        by_month = sgi.groupby(sgi.index.month).mean()
+        assert by_month.abs().max() < 0.5  # raw seasonal swing was +/-2 m
+
+    def test_rank_preserving_within_month(self):
+        # Within one calendar month, the lowest level gets the lowest SGI.
+        sgi = standardised_groundwater_index(self.levels)
+        jan = self.levels[self.levels.index.month == 1]
+        jan_sgi = sgi[sgi.index.month == 1]
+        assert jan_sgi.loc[jan.idxmin()] == jan_sgi.min()
+        assert jan_sgi.loc[jan.idxmax()] == jan_sgi.max()
+
+    def test_drought_year_is_negative(self):
+        # Depress two years of levels; their SGI should be strongly negative.
+        levels = self.levels.copy()
+        drought = (levels.index.year >= 2015) & (levels.index.year <= 2016)
+        levels[drought] -= 5.0
+        sgi = standardised_groundwater_index(levels)
+        assert sgi[drought].mean() < -1.0
+
+    def test_non_datetime_index_raises(self):
+        with pytest.raises(ValueError, match="DatetimeIndex"):
+            standardised_groundwater_index(pd.Series([1.0, 2.0, 3.0]))
+
+    def test_too_short_raises(self):
+        s = pd.Series([1.0, 2.0], index=_monthly(1)[:2])
+        with pytest.raises(ValueError, match="at least"):
+            standardised_groundwater_index(s, min_per_month=5)
+
+    def test_short_month_left_nan(self):
+        # 4 years -> each calendar month has 4 obs; with min_per_month=5 all NaN.
+        s = pd.Series(np.arange(48.0), index=_monthly(4))
+        sgi = standardised_groundwater_index(s, min_per_month=5)
+        assert sgi.isna().all()
+
+
+class TestDroughtEvents:
+    def test_detects_below_threshold_run(self):
+        idx = _monthly(3)
+        vals = np.zeros(36)
+        vals[10:16] = -1.5  # a 6-month drought
+        events = drought_events(pd.Series(vals, index=idx), threshold=-1.0)
+        assert len(events) == 1
+        assert events[0].duration == 6
+        assert events[0].peak == pytest.approx(-1.5)
+        assert events[0].severity == pytest.approx(-9.0)
+
+    def test_no_event_when_above_threshold(self):
+        idx = _monthly(2)
+        assert drought_events(pd.Series(np.zeros(24), index=idx)) == []
+
+    def test_trailing_event_closed(self):
+        idx = _monthly(1)
+        vals = np.zeros(12)
+        vals[9:] = -2.0  # runs to the end of the series
+        events = drought_events(pd.Series(vals, index=idx), threshold=-1.0)
+        assert len(events) == 1
+        assert events[0].duration == 3


### PR DESCRIPTION
## Summary
Adds the two standardised drought indices AquaScope was missing, which together enable groundwater drought-propagation analysis (the standard SGI-vs-SPI lag method):

- **`standardised_groundwater_index()`** (`groundwater/drought.py`) — SGI, Bloomfield & Marchant (2013): a per-calendar-month non-parametric normal-scores transform of a groundwater-level series, merged into a continuous monthly index. SGI < −1 marks groundwater drought; it removes the seasonal cycle and is directly comparable to SPI.
- **`standardized_precipitation_index()`** (`climate/indices.py`) — SPI, McKee et al. (1993): gamma fit with explicit zero handling, fitted per calendar month, configurable accumulation `scale` (SPI-3, SPI-12, …).
- **`drought_events()`** — extract below-threshold runs (duration, accumulated severity, peak) from any standardised index.

## Why
AquaScope had PDSI and rainfall indices but no SGI or SPI, the core methods for relating meteorological to groundwater drought. These make that a first-class workflow, and power the Taiwan groundwater case study.

## Validation
On real WRA data (Zhuoshui fan well 07010211, 1997-2025), SGI is standard-normal (mean 0, std 0.97) and the 2021 drought registers as **SGI ≈ −2 (severe/extreme) from March to May 2021**, recovering by August, the textbook signature.

## Tests
16 tests: SGI standard-normal output, seasonality removal, rank preservation, drought-year negativity, short-record handling; SPI standard-normal output, dry-period negativity, scale behaviour, zero handling. All pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)