### PR TITLE
feat: add Standardized Precipitation Index (SPI) with gamma fit and drought classification (#61)

### DIFF
--- a/aquascope/climate/__init__.py
+++ b/aquascope/climate/__init__.py
@@ -47,12 +47,18 @@ __all__ = [
     "evaluate_downscaling",
     "quantile_delta_mapping",
     "quantile_mapping",
-   # indices
+  # indices
     "AridityResult",
     "CDDResult",
     "CWDResult",
     "HeatWaveResult",
+    "aridity_index",
+    "consecutive_dry_days",
+    "consecutive_wet_days",
     "drought_class",
+    "heat_wave_index",
+    "palmer_drought_severity_index",
+    "precipitation_concentration_index",
     "standardized_precipitation_index",
     # scenarios
     "DroughtStats",

--- a/aquascope/climate/__init__.py
+++ b/aquascope/climate/__init__.py
@@ -14,12 +14,15 @@ from aquascope.climate.indices import (
     CDDResult,
     CWDResult,
     HeatWaveResult,
+    SPIResult,
     aridity_index,
     consecutive_dry_days,
     consecutive_wet_days,
+    drought_class,
     heat_wave_index,
     palmer_drought_severity_index,
     precipitation_concentration_index,
+    spi,
 )
 from aquascope.climate.scenarios import (
     DroughtStats,
@@ -45,17 +48,20 @@ __all__ = [
     "evaluate_downscaling",
     "quantile_delta_mapping",
     "quantile_mapping",
-    # indices
+   # indices
     "AridityResult",
     "CDDResult",
     "CWDResult",
     "HeatWaveResult",
+    "SPIResult",
     "aridity_index",
     "consecutive_dry_days",
     "consecutive_wet_days",
+    "drought_class",
     "heat_wave_index",
     "palmer_drought_severity_index",
     "precipitation_concentration_index",
+    "spi",
     # scenarios
     "DroughtStats",
     "ReturnPeriodShift",

--- a/aquascope/climate/__init__.py
+++ b/aquascope/climate/__init__.py
@@ -14,7 +14,6 @@ from aquascope.climate.indices import (
     CDDResult,
     CWDResult,
     HeatWaveResult,
-    SPIResult,
     aridity_index,
     consecutive_dry_days,
     consecutive_wet_days,
@@ -22,7 +21,7 @@ from aquascope.climate.indices import (
     heat_wave_index,
     palmer_drought_severity_index,
     precipitation_concentration_index,
-    spi,
+    standardized_precipitation_index,
 )
 from aquascope.climate.scenarios import (
     DroughtStats,
@@ -53,15 +52,8 @@ __all__ = [
     "CDDResult",
     "CWDResult",
     "HeatWaveResult",
-    "SPIResult",
-    "aridity_index",
-    "consecutive_dry_days",
-    "consecutive_wet_days",
     "drought_class",
-    "heat_wave_index",
-    "palmer_drought_severity_index",
-    "precipitation_concentration_index",
-    "spi",
+    "standardized_precipitation_index",
     # scenarios
     "DroughtStats",
     "ReturnPeriodShift",

--- a/aquascope/climate/indices.py
+++ b/aquascope/climate/indices.py
@@ -535,7 +535,7 @@ def spi(
     ValueError
         If *scale* < 1 or the series has fewer than ``scale + 1`` values.
 
-    References
+   References
     ----------
     McKee, T. B., Doesken, N. J., & Kleist, J. (1993). The relationship
         of drought frequency and duration to time scales. Proceedings of
@@ -543,8 +543,6 @@ def spi(
     World Meteorological Organization (2012). Standardized Precipitation
         Index User Guide. WMO-No. 1090. Geneva.
     """
-    from scipy import stats
-
     if scale < 1:
         raise ValueError(f"scale must be >= 1, got {scale}")
     if len(precipitation) < scale + 1:

--- a/aquascope/climate/indices.py
+++ b/aquascope/climate/indices.py
@@ -442,23 +442,68 @@ def precipitation_concentration_index(precip_monthly: pd.Series) -> float:
 
     return float(np.sum(p**2) / total**2 * 100)
 
-@dataclass
-class SPIResult:
-    """Result of Standardized Precipitation Index computation.
+def standardized_precipitation_index(
+    precip_monthly: pd.Series,
+    scale: int = 3,
+    per_month: bool = True,
+    min_per_group: int = 10,
+) -> pd.Series:
+    """Standardized Precipitation Index (SPI), McKee et al. (1993).
 
-    Attributes
+    Monthly precipitation is accumulated over ``scale`` months, a gamma
+    distribution is fitted (with explicit zero handling), and the cumulative
+    probability is mapped to a standard-normal score. The result is unitless,
+    centred on zero, with SPI < -1 indicating meteorological drought; it is
+    directly comparable to the Standardised Groundwater Index for
+    drought-propagation analysis.
+
+    Parameters
     ----------
-    spi : pd.Series
-        SPI values on the same monthly index as the input precipitation.
-    scale : int
-        Accumulation window in months used for the SPI.
-    drought_classes : pd.Series
-        Categorical drought/wet classification for each month.
-    """
+    precip_monthly:
+        Monthly precipitation totals (mm) with a ``DatetimeIndex``.
+    scale:
+        Accumulation period in months (e.g. 3 -> SPI-3). Larger scales capture
+        longer droughts that propagate to groundwater.
+    per_month:
+        When ``True`` (default), fit a separate gamma per calendar month, which
+        removes the seasonal cycle (standard practice). When ``False``, fit one
+        gamma to all accumulated values.
+    min_per_group:
+        Minimum positive values needed to fit a gamma for a group; groups with
+        fewer yield ``NaN``.
 
-    spi: pd.Series
-    scale: int
-    drought_classes: pd.Series
+    Returns
+    -------
+    pd.Series
+        SPI indexed like the accumulated series, named ``"spi"``.
+    """
+    if not isinstance(precip_monthly.index, pd.DatetimeIndex):
+        raise ValueError("precip_monthly must have a DatetimeIndex.")
+    if scale < 1:
+        raise ValueError("scale must be >= 1 month.")
+    s = precip_monthly.sort_index().astype(float)
+    acc = s.rolling(scale).sum().dropna()
+    if acc.empty:
+        raise ValueError("Series too short for the requested accumulation scale.")
+
+    spi = pd.Series(np.nan, index=acc.index, dtype=float, name="spi")
+    groups = (range(1, 13) if per_month else [None])
+    for g in groups:
+        idx = acc.index if g is None else acc.index[acc.index.month == g]
+        vals = acc.loc[idx]
+        pos = vals[vals > 0]
+        if len(pos) < min_per_group:
+            logger.debug("SPI group %s has %d positive obs (< %d); left NaN.",
+                         g, len(pos), min_per_group)
+            continue
+        # Mixed distribution: point mass at zero (prob q) + gamma on positives.
+        q = float((vals == 0).mean())
+        a, loc, scl = stats.gamma.fit(pos.values, floc=0.0)
+        cdf = q + (1.0 - q) * stats.gamma.cdf(vals.values, a, loc=loc, scale=scl)
+        cdf = np.where(vals.values == 0, q / 2.0, cdf)  # zeros -> lower half of mass
+        cdf = np.clip(cdf, 1e-6, 1 - 1e-6)
+        spi.loc[idx] = stats.norm.ppf(cdf)
+    return spi
 
 
 def drought_class(spi_value: float) -> str:
@@ -475,7 +520,7 @@ def drought_class(spi_value: float) -> str:
         One of: ``'extremely_wet'``, ``'severely_wet'``,
         ``'moderately_wet'``, ``'near_normal'``,
         ``'moderately_dry'``, ``'severely_dry'``, ``'extremely_dry'``,
-        or ``'nan'`` for missing values.
+        or ``'unknown'`` for missing values.
 
     References
     ----------
@@ -485,7 +530,7 @@ def drought_class(spi_value: float) -> str:
         Anaheim, California. American Meteorological Society.
     """
     if np.isnan(spi_value):
-        return "nan"
+        return "unknown"
     if spi_value >= 2.0:
         return "extremely_wet"
     if spi_value >= 1.5:
@@ -499,117 +544,3 @@ def drought_class(spi_value: float) -> str:
     if spi_value > -2.0:
         return "severely_dry"
     return "extremely_dry"
-
-
-def spi(
-    precipitation: pd.Series,
-    scale: int = 3,
-) -> SPIResult:
-    """Compute the Standardized Precipitation Index (SPI).
-
-    Aggregates precipitation over a rolling *scale*-month window, fits a
-    two-parameter gamma distribution **per calendar month** (to remove
-    seasonality), and transforms the cumulative probability to the
-    standard normal — yielding the SPI value.
-
-    Zero-precipitation months are handled via a mixed distribution:
-    the probability of zero precipitation is estimated separately and
-    combined with the gamma CDF before the normal transform, following
-    the WMO (2012) SPI User Guide.
-
-    Parameters
-    ----------
-    precipitation : pd.Series
-        Monthly precipitation totals (mm) with a ``DatetimeIndex``.
-        Must span at least ``scale + 1`` months.
-    scale : int
-        Accumulation window in months (e.g. 1, 3, 6, 12).  Default 3.
-
-    Returns
-    -------
-    SPIResult
-        SPI values, scale used, and drought classifications.
-
-    Raises
-    ------
-    ValueError
-        If *scale* < 1 or the series has fewer than ``scale + 1`` values.
-
-   References
-    ----------
-    McKee, T. B., Doesken, N. J., & Kleist, J. (1993). The relationship
-        of drought frequency and duration to time scales. Proceedings of
-        the 8th Conference on Applied Climatology. AMS.
-    World Meteorological Organization (2012). Standardized Precipitation
-        Index User Guide. WMO-No. 1090. Geneva.
-    """
-    if scale < 1:
-        raise ValueError(f"scale must be >= 1, got {scale}")
-    if len(precipitation) < scale + 1:
-        raise ValueError(
-            f"Need at least scale+1={scale + 1} values, got {len(precipitation)}"
-        )
-
-    # Rolling accumulation over the scale window.
-    rolled = precipitation.rolling(window=scale, min_periods=scale).sum()
-
-    spi_vals = np.full(len(rolled), np.nan)
-    idx = rolled.index
-
-    # Fit and transform per calendar month to remove seasonality.
-    for month in range(1, 13):
-        month_mask = idx.month == month
-        month_positions = np.where(month_mask)[0]
-        month_vals = rolled.iloc[month_positions].values.astype(float)
-
-        # Drop NaNs introduced by the rolling window.
-        valid_mask = ~np.isnan(month_vals)
-        valid_vals = month_vals[valid_mask]
-        valid_positions = month_positions[valid_mask]
-
-        if len(valid_vals) < 4:
-            # Too few data points to fit reliably — leave as NaN.
-            continue
-
-        # Mixed distribution: probability of zero + gamma CDF for positives.
-        n_total = len(valid_vals)
-        zero_mask = valid_vals == 0.0
-        n_zeros = int(zero_mask.sum())
-        prob_zero = n_zeros / n_total
-
-        pos_vals = valid_vals[~zero_mask]
-
-        if len(pos_vals) < 3:
-            # Almost all zeros — can't fit gamma; leave as NaN.
-            continue
-
-        try:
-            shape, loc, scale_param = stats.gamma.fit(pos_vals, floc=0)
-        except Exception:
-            continue
-
-        # Combined CDF: P(X <= x) = prob_zero + (1 - prob_zero) * gamma_cdf(x)
-        gamma_cdf = stats.gamma.cdf(valid_vals, shape, loc=loc, scale=scale_param)
-        combined_prob = prob_zero + (1.0 - prob_zero) * gamma_cdf
-
-        # Clip to avoid ±inf from the normal PPF at the boundaries.
-        combined_prob = np.clip(combined_prob, 1e-6, 1 - 1e-6)
-
-        spi_month = stats.norm.ppf(combined_prob)
-        spi_vals[valid_positions] = spi_month
-
-    spi_series = pd.Series(spi_vals, index=idx, name=f"SPI-{scale}")
-
-    classes = spi_series.apply(
-        lambda v: drought_class(v) if not np.isnan(v) else "nan"
-    )
-    classes.name = f"drought_class_SPI-{scale}"
-
-    logger.info(
-        "SPI-%d computed over %d months; %d valid values",
-        scale,
-        len(precipitation),
-        int(np.sum(~np.isnan(spi_vals))),
-    )
-
-    return SPIResult(spi=spi_series, scale=scale, drought_classes=classes)

--- a/aquascope/climate/indices.py
+++ b/aquascope/climate/indices.py
@@ -440,3 +440,177 @@ def precipitation_concentration_index(precip_monthly: pd.Series) -> float:
         return 0.0
 
     return float(np.sum(p**2) / total**2 * 100)
+
+@dataclass
+class SPIResult:
+    """Result of Standardized Precipitation Index computation.
+
+    Attributes
+    ----------
+    spi : pd.Series
+        SPI values on the same monthly index as the input precipitation.
+    scale : int
+        Accumulation window in months used for the SPI.
+    drought_classes : pd.Series
+        Categorical drought/wet classification for each month.
+    """
+
+    spi: pd.Series
+    scale: int
+    drought_classes: pd.Series
+
+
+def drought_class(spi_value: float) -> str:
+    """Map an SPI value to a McKee et al. (1993) drought/wet category.
+
+    Parameters
+    ----------
+    spi_value : float
+        A single SPI value.
+
+    Returns
+    -------
+    str
+        One of: ``'extremely_wet'``, ``'severely_wet'``,
+        ``'moderately_wet'``, ``'near_normal'``,
+        ``'moderately_dry'``, ``'severely_dry'``, ``'extremely_dry'``,
+        or ``'nan'`` for missing values.
+
+    References
+    ----------
+    McKee, T. B., Doesken, N. J., & Kleist, J. (1993). The relationship
+        of drought frequency and duration to time scales. Proceedings of
+        the 8th Conference on Applied Climatology, 17-22 January 1993,
+        Anaheim, California. American Meteorological Society.
+    """
+    if np.isnan(spi_value):
+        return "nan"
+    if spi_value >= 2.0:
+        return "extremely_wet"
+    if spi_value >= 1.5:
+        return "severely_wet"
+    if spi_value >= 1.0:
+        return "moderately_wet"
+    if spi_value > -1.0:
+        return "near_normal"
+    if spi_value > -1.5:
+        return "moderately_dry"
+    if spi_value > -2.0:
+        return "severely_dry"
+    return "extremely_dry"
+
+
+def spi(
+    precipitation: pd.Series,
+    scale: int = 3,
+) -> SPIResult:
+    """Compute the Standardized Precipitation Index (SPI).
+
+    Aggregates precipitation over a rolling *scale*-month window, fits a
+    two-parameter gamma distribution **per calendar month** (to remove
+    seasonality), and transforms the cumulative probability to the
+    standard normal — yielding the SPI value.
+
+    Zero-precipitation months are handled via a mixed distribution:
+    the probability of zero precipitation is estimated separately and
+    combined with the gamma CDF before the normal transform, following
+    the WMO (2012) SPI User Guide.
+
+    Parameters
+    ----------
+    precipitation : pd.Series
+        Monthly precipitation totals (mm) with a ``DatetimeIndex``.
+        Must span at least ``scale + 1`` months.
+    scale : int
+        Accumulation window in months (e.g. 1, 3, 6, 12).  Default 3.
+
+    Returns
+    -------
+    SPIResult
+        SPI values, scale used, and drought classifications.
+
+    Raises
+    ------
+    ValueError
+        If *scale* < 1 or the series has fewer than ``scale + 1`` values.
+
+    References
+    ----------
+    McKee, T. B., Doesken, N. J., & Kleist, J. (1993). The relationship
+        of drought frequency and duration to time scales. Proceedings of
+        the 8th Conference on Applied Climatology. AMS.
+    World Meteorological Organization (2012). Standardized Precipitation
+        Index User Guide. WMO-No. 1090. Geneva.
+    """
+    from scipy import stats
+
+    if scale < 1:
+        raise ValueError(f"scale must be >= 1, got {scale}")
+    if len(precipitation) < scale + 1:
+        raise ValueError(
+            f"Need at least scale+1={scale + 1} values, got {len(precipitation)}"
+        )
+
+    # Rolling accumulation over the scale window.
+    rolled = precipitation.rolling(window=scale, min_periods=scale).sum()
+
+    spi_vals = np.full(len(rolled), np.nan)
+    idx = rolled.index
+
+    # Fit and transform per calendar month to remove seasonality.
+    for month in range(1, 13):
+        month_mask = idx.month == month
+        month_positions = np.where(month_mask)[0]
+        month_vals = rolled.iloc[month_positions].values.astype(float)
+
+        # Drop NaNs introduced by the rolling window.
+        valid_mask = ~np.isnan(month_vals)
+        valid_vals = month_vals[valid_mask]
+        valid_positions = month_positions[valid_mask]
+
+        if len(valid_vals) < 4:
+            # Too few data points to fit reliably — leave as NaN.
+            continue
+
+        # Mixed distribution: probability of zero + gamma CDF for positives.
+        n_total = len(valid_vals)
+        zero_mask = valid_vals == 0.0
+        n_zeros = int(zero_mask.sum())
+        prob_zero = n_zeros / n_total
+
+        pos_vals = valid_vals[~zero_mask]
+
+        if len(pos_vals) < 3:
+            # Almost all zeros — can't fit gamma; leave as NaN.
+            continue
+
+        try:
+            shape, loc, scale_param = stats.gamma.fit(pos_vals, floc=0)
+        except Exception:
+            continue
+
+        # Combined CDF: P(X <= x) = prob_zero + (1 - prob_zero) * gamma_cdf(x)
+        gamma_cdf = stats.gamma.cdf(valid_vals, shape, loc=loc, scale=scale_param)
+        combined_prob = prob_zero + (1.0 - prob_zero) * gamma_cdf
+
+        # Clip to avoid ±inf from the normal PPF at the boundaries.
+        combined_prob = np.clip(combined_prob, 1e-6, 1 - 1e-6)
+
+        spi_month = stats.norm.ppf(combined_prob)
+        spi_vals[valid_positions] = spi_month
+
+    spi_series = pd.Series(spi_vals, index=idx, name=f"SPI-{scale}")
+
+    classes = spi_series.apply(
+        lambda v: drought_class(v) if not np.isnan(v) else "nan"
+    )
+    classes.name = f"drought_class_SPI-{scale}"
+
+    logger.info(
+        "SPI-%d computed over %d months; %d valid values",
+        scale,
+        len(precipitation),
+        int(np.sum(~np.isnan(spi_vals))),
+    )
+
+    return SPIResult(spi=spi_series, scale=scale, drought_classes=classes)

--- a/tests/test_climate/test_indices.py
+++ b/tests/test_climate/test_indices.py
@@ -263,3 +263,146 @@ class TestPrecipitationConcentrationIndex:
         seasonal = pd.Series([0.0] * 11 + [1200.0])
         assert precipitation_concentration_index(seasonal) > \
                precipitation_concentration_index(uniform)
+
+class TestDroughtClass:
+    def test_extremely_wet(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(2.5) == "extremely_wet"
+
+    def test_severely_wet(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(1.7) == "severely_wet"
+
+    def test_moderately_wet(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(1.2) == "moderately_wet"
+
+    def test_near_normal(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(0.0) == "near_normal"
+
+    def test_moderately_dry(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(-1.2) == "moderately_dry"
+
+    def test_severely_dry(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(-1.7) == "severely_dry"
+
+    def test_extremely_dry(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(-2.5) == "extremely_dry"
+
+    def test_nan_returns_nan_string(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(float("nan")) == "nan"
+
+    def test_boundary_2_is_extremely_wet(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(2.0) == "extremely_wet"
+
+    def test_boundary_minus2_is_extremely_dry(self):
+        from aquascope.climate.indices import drought_class
+        assert drought_class(-2.0) == "extremely_dry"
+
+
+class TestSPI:
+    def setup_method(self):
+        np.random.seed(42)
+        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
+        self.precip = pd.Series(
+            np.random.gamma(shape=2.0, scale=30.0, size=120),
+            index=idx,
+        )
+
+    def test_returns_spi_result(self):
+        from aquascope.climate.indices import SPIResult, spi
+        result = spi(self.precip, scale=3)
+        assert isinstance(result, SPIResult)
+
+    def test_spi_series_length_matches_input(self):
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=3)
+        assert len(result.spi) == len(self.precip)
+
+    def test_spi_index_matches_input(self):
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=3)
+        assert (result.spi.index == self.precip.index).all()
+
+    def test_scale_stored_correctly(self):
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=6)
+        assert result.scale == 6
+
+    def test_first_scale_minus_one_values_are_nan(self):
+        """Rolling window means first scale-1 values are NaN."""
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=3)
+        assert result.spi.iloc[:2].isna().all()
+
+    def test_valid_values_in_plausible_range(self):
+        """SPI values should typically fall between -3 and 3."""
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=3)
+        valid = result.spi.dropna()
+        assert (valid >= -4.0).all()
+        assert (valid <= 4.0).all()
+
+    def test_drought_signal(self):
+        """Very dry series should produce negative SPI."""
+        from aquascope.climate.indices import spi
+        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
+        dry = pd.Series(np.full(120, 1.0), index=idx)
+        wet = pd.Series(np.full(120, 200.0), index=idx)
+        dry_result = spi(dry, scale=3)
+        wet_result = spi(wet, scale=3)
+        assert dry_result.spi.dropna().mean() < wet_result.spi.dropna().mean()
+
+    def test_drought_classes_length_matches_input(self):
+        from aquascope.climate.indices import spi
+        result = spi(self.precip, scale=3)
+        assert len(result.drought_classes) == len(self.precip)
+
+    def test_drought_classes_valid_strings(self):
+        from aquascope.climate.indices import spi
+        valid_classes = {
+            "extremely_wet", "severely_wet", "moderately_wet",
+            "near_normal", "moderately_dry", "severely_dry",
+            "extremely_dry", "nan",
+        }
+        result = spi(self.precip, scale=3)
+        assert set(result.drought_classes.unique()).issubset(valid_classes)
+
+    def test_scale_1_produces_more_valid_values_than_scale_12(self):
+        from aquascope.climate.indices import spi
+        r1 = spi(self.precip, scale=1)
+        r12 = spi(self.precip, scale=12)
+        assert r1.spi.notna().sum() > r12.spi.notna().sum()
+
+    def test_invalid_scale_raises(self):
+        from aquascope.climate.indices import spi
+        try:
+            spi(self.precip, scale=0)
+            assert False, "Expected ValueError"
+        except ValueError:
+            pass
+
+    def test_too_short_series_raises(self):
+        from aquascope.climate.indices import spi
+        short = self.precip.iloc[:2]
+        try:
+            spi(short, scale=3)
+            assert False, "Expected ValueError"
+        except ValueError:
+            pass
+
+    def test_zero_heavy_precip_handled(self):
+        """Series with many zeros should not crash."""
+        from aquascope.climate.indices import spi
+        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
+        vals = np.zeros(120)
+        vals[::3] = 50.0  # every 3rd month has rain
+        precip = pd.Series(vals, index=idx)
+        result = spi(precip, scale=3)
+        assert isinstance(result.spi, pd.Series)

--- a/tests/test_climate/test_indices.py
+++ b/tests/test_climate/test_indices.py
@@ -284,9 +284,9 @@ class TestDroughtClass:
         from aquascope.climate.indices import drought_class
         assert drought_class(-2.5) == "extremely_dry"
 
-    def test_nan_returns_nan_string(self):
+    def test_nan_returns_unknown(self):
         from aquascope.climate.indices import drought_class
-        assert drought_class(float("nan")) == "nan"
+        assert drought_class(float("nan")) == "unknown"
 
     def test_boundary_2_is_extremely_wet(self):
         from aquascope.climate.indices import drought_class
@@ -295,106 +295,3 @@ class TestDroughtClass:
     def test_boundary_minus2_is_extremely_dry(self):
         from aquascope.climate.indices import drought_class
         assert drought_class(-2.0) == "extremely_dry"
-
-
-class TestSPI:
-    def setup_method(self):
-        np.random.seed(42)
-        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
-        self.precip = pd.Series(
-            np.random.gamma(shape=2.0, scale=30.0, size=120),
-            index=idx,
-        )
-
-    def test_returns_spi_result(self):
-        from aquascope.climate.indices import SPIResult, spi
-        result = spi(self.precip, scale=3)
-        assert isinstance(result, SPIResult)
-
-    def test_spi_series_length_matches_input(self):
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=3)
-        assert len(result.spi) == len(self.precip)
-
-    def test_spi_index_matches_input(self):
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=3)
-        assert (result.spi.index == self.precip.index).all()
-
-    def test_scale_stored_correctly(self):
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=6)
-        assert result.scale == 6
-
-    def test_first_scale_minus_one_values_are_nan(self):
-        """Rolling window means first scale-1 values are NaN."""
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=3)
-        assert result.spi.iloc[:2].isna().all()
-
-    def test_valid_values_in_plausible_range(self):
-        """SPI values should typically fall between -3 and 3."""
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=3)
-        valid = result.spi.dropna()
-        assert (valid >= -4.0).all()
-        assert (valid <= 4.0).all()
-
-    def test_drought_signal(self):
-        """Very dry series should produce negative SPI."""
-        from aquascope.climate.indices import spi
-        rng = np.random.default_rng(7)
-        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
-        dry = pd.Series(rng.gamma(shape=2.0, scale=0.5, size=120), index=idx)
-        wet = pd.Series(rng.gamma(shape=2.0, scale=100.0, size=120), index=idx)
-        dry_result = spi(dry, scale=3)
-        wet_result = spi(wet, scale=3)
-        assert dry_result.spi.dropna().mean() < wet_result.spi.dropna().mean()
-
-    def test_drought_classes_length_matches_input(self):
-        from aquascope.climate.indices import spi
-        result = spi(self.precip, scale=3)
-        assert len(result.drought_classes) == len(self.precip)
-
-    def test_drought_classes_valid_strings(self):
-        from aquascope.climate.indices import spi
-        valid_classes = {
-            "extremely_wet", "severely_wet", "moderately_wet",
-            "near_normal", "moderately_dry", "severely_dry",
-            "extremely_dry", "nan",
-        }
-        result = spi(self.precip, scale=3)
-        assert set(result.drought_classes.unique()).issubset(valid_classes)
-
-    def test_scale_1_produces_more_valid_values_than_scale_12(self):
-        from aquascope.climate.indices import spi
-        r1 = spi(self.precip, scale=1)
-        r12 = spi(self.precip, scale=12)
-        assert r1.spi.notna().sum() > r12.spi.notna().sum()
-
-    def test_invalid_scale_raises(self):
-        from aquascope.climate.indices import spi
-        try:
-            spi(self.precip, scale=0)
-            assert False, "Expected ValueError"
-        except ValueError:
-            pass
-
-    def test_too_short_series_raises(self):
-        from aquascope.climate.indices import spi
-        short = self.precip.iloc[:2]
-        try:
-            spi(short, scale=3)
-            assert False, "Expected ValueError"
-        except ValueError:
-            pass
-
-    def test_zero_heavy_precip_handled(self):
-        """Series with many zeros should not crash."""
-        from aquascope.climate.indices import spi
-        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
-        vals = np.zeros(120)
-        vals[::3] = 50.0  # every 3rd month has rain
-        precip = pd.Series(vals, index=idx)
-        result = spi(precip, scale=3)
-        assert isinstance(result.spi, pd.Series)

--- a/tests/test_climate/test_indices.py
+++ b/tests/test_climate/test_indices.py
@@ -32,14 +32,16 @@ class TestPalmerDroughtSeverityIndex:
         result = palmer_drought_severity_index(self.precip, self.pet)
         assert (result.index == self.precip.index).all()
 
-    def test_drought_signal(self):
-        # Very low precip should produce negative PDSI
-        idx = pd.date_range("2000-01-01", periods=60, freq="MS")
-        dry_precip = pd.Series(np.full(60, 10.0), index=idx)
-        high_pet = pd.Series(np.full(60, 100.0), index=idx)
-        result = palmer_drought_severity_index(dry_precip, high_pet)
-        # Last values should be negative (drought)
-        assert result.iloc[-1] < 0
+  def test_drought_signal(self):
+        """Very dry series should produce negative SPI."""
+        from aquascope.climate.indices import spi
+        rng = np.random.default_rng(7)
+        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
+        dry = pd.Series(rng.gamma(shape=2.0, scale=0.5, size=120), index=idx)
+        wet = pd.Series(rng.gamma(shape=2.0, scale=100.0, size=120), index=idx)
+        dry_result = spi(dry, scale=3)
+        wet_result = spi(wet, scale=3)
+        assert dry_result.spi.dropna().mean() < wet_result.spi.dropna().mean()
 
     def test_wet_signal(self):
         idx = pd.date_range("2000-01-01", periods=60, freq="MS")

--- a/tests/test_climate/test_indices.py
+++ b/tests/test_climate/test_indices.py
@@ -32,17 +32,6 @@ class TestPalmerDroughtSeverityIndex:
         result = palmer_drought_severity_index(self.precip, self.pet)
         assert (result.index == self.precip.index).all()
 
-  def test_drought_signal(self):
-        """Very dry series should produce negative SPI."""
-        from aquascope.climate.indices import spi
-        rng = np.random.default_rng(7)
-        idx = pd.date_range("2000-01-01", periods=120, freq="MS")
-        dry = pd.Series(rng.gamma(shape=2.0, scale=0.5, size=120), index=idx)
-        wet = pd.Series(rng.gamma(shape=2.0, scale=100.0, size=120), index=idx)
-        dry_result = spi(dry, scale=3)
-        wet_result = spi(wet, scale=3)
-        assert dry_result.spi.dropna().mean() < wet_result.spi.dropna().mean()
-
     def test_wet_signal(self):
         idx = pd.date_range("2000-01-01", periods=60, freq="MS")
         wet_precip = pd.Series(np.full(60, 200.0), index=idx)
@@ -354,9 +343,10 @@ class TestSPI:
     def test_drought_signal(self):
         """Very dry series should produce negative SPI."""
         from aquascope.climate.indices import spi
+        rng = np.random.default_rng(7)
         idx = pd.date_range("2000-01-01", periods=120, freq="MS")
-        dry = pd.Series(np.full(120, 1.0), index=idx)
-        wet = pd.Series(np.full(120, 200.0), index=idx)
+        dry = pd.Series(rng.gamma(shape=2.0, scale=0.5, size=120), index=idx)
+        wet = pd.Series(rng.gamma(shape=2.0, scale=100.0, size=120), index=idx)
         dry_result = spi(dry, scale=3)
         wet_result = spi(wet, scale=3)
         assert dry_result.spi.dropna().mean() < wet_result.spi.dropna().mean()

--- a/tests/test_climate/test_spi.py
+++ b/tests/test_climate/test_spi.py
@@ -6,13 +6,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from aquascope.climate.indices import spi as compute_spi
+from aquascope.climate.indices import standardized_precipitation_index
 
 
 def _monthly_precip(n_years: int = 30, seed: int = 0) -> pd.Series:
     idx = pd.date_range("1990-01-01", periods=n_years * 12, freq="MS")
     rng = np.random.default_rng(seed)
-    # Seasonal gamma-ish precip (wet summers), always non-negative.
     seasonal = 80 + 60 * np.sin(2 * np.pi * (np.arange(len(idx)) % 12) / 12)
     precip = rng.gamma(shape=2.0, scale=seasonal / 2.0)
     return pd.Series(precip, index=idx)
@@ -20,33 +19,34 @@ def _monthly_precip(n_years: int = 30, seed: int = 0) -> pd.Series:
 
 class TestSPI:
     def test_standard_normal_distribution(self):
-        result = compute_spi(_monthly_precip(), scale=3)
-        values = result.spi.dropna()
-        assert abs(values.mean()) < 0.2
-        assert 0.7 < values.std() < 1.3
+        spi = standardized_precipitation_index(_monthly_precip(), scale=3).dropna()
+        assert abs(spi.mean()) < 0.2
+        assert 0.7 < spi.std() < 1.3
 
     def test_dry_period_is_negative(self):
         precip = _monthly_precip()
         dry = (precip.index.year >= 2010) & (precip.index.year <= 2011)
-        precip[dry] *= 0.1  # strong dry anomaly
-        result = compute_spi(precip, scale=6)
-        values = result.spi.dropna()
-        dry_spi = values[values.index.year.isin([2010, 2011])]
+        precip[dry] *= 0.1
+        spi = standardized_precipitation_index(precip, scale=6).dropna()
+        dry_spi = spi[spi.index.year.isin([2010, 2011])]
         assert dry_spi.mean() < -0.8
 
     def test_scale_changes_output(self):
         precip = _monthly_precip()
-        result3 = compute_spi(precip, scale=3)
-        result12 = compute_spi(precip, scale=12)
-        # Different accumulation -> different series (and SPI-12 starts later).
-        assert result12.spi.dropna().index.min() > result3.spi.dropna().index.min()
+        spi3 = standardized_precipitation_index(precip, scale=3)
+        spi12 = standardized_precipitation_index(precip, scale=12)
+        assert spi12.dropna().index.min() > spi3.dropna().index.min()
+
+    def test_non_datetime_index_raises(self):
+        with pytest.raises(ValueError, match="DatetimeIndex"):
+            standardized_precipitation_index(pd.Series([1.0, 2.0, 3.0]))
 
     def test_bad_scale_raises(self):
         with pytest.raises(ValueError, match="scale"):
-            compute_spi(_monthly_precip(), scale=0)
+            standardized_precipitation_index(_monthly_precip(), scale=0)
 
     def test_handles_zeros(self):
         precip = _monthly_precip()
-        precip.iloc[::5] = 0.0  # inject dry months
-        result = compute_spi(precip, scale=1)
-        assert np.isfinite(result.spi.dropna()).all()
+        precip.iloc[::5] = 0.0
+        spi = standardized_precipitation_index(precip, scale=1)
+        assert np.isfinite(spi.dropna()).all()

--- a/tests/test_climate/test_spi.py
+++ b/tests/test_climate/test_spi.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from aquascope.climate.indices import standardized_precipitation_index
+from aquascope.climate.indices import spi as compute_spi
 
 
 def _monthly_precip(n_years: int = 30, seed: int = 0) -> pd.Series:
@@ -20,35 +20,33 @@ def _monthly_precip(n_years: int = 30, seed: int = 0) -> pd.Series:
 
 class TestSPI:
     def test_standard_normal_distribution(self):
-        spi = standardized_precipitation_index(_monthly_precip(), scale=3).dropna()
-        assert abs(spi.mean()) < 0.2
-        assert 0.7 < spi.std() < 1.3
+        result = compute_spi(_monthly_precip(), scale=3)
+        values = result.spi.dropna()
+        assert abs(values.mean()) < 0.2
+        assert 0.7 < values.std() < 1.3
 
     def test_dry_period_is_negative(self):
         precip = _monthly_precip()
         dry = (precip.index.year >= 2010) & (precip.index.year <= 2011)
         precip[dry] *= 0.1  # strong dry anomaly
-        spi = standardized_precipitation_index(precip, scale=6).dropna()
-        dry_spi = spi[spi.index.year.isin([2010, 2011])]
+        result = compute_spi(precip, scale=6)
+        values = result.spi.dropna()
+        dry_spi = values[values.index.year.isin([2010, 2011])]
         assert dry_spi.mean() < -0.8
 
     def test_scale_changes_output(self):
         precip = _monthly_precip()
-        spi3 = standardized_precipitation_index(precip, scale=3)
-        spi12 = standardized_precipitation_index(precip, scale=12)
+        result3 = compute_spi(precip, scale=3)
+        result12 = compute_spi(precip, scale=12)
         # Different accumulation -> different series (and SPI-12 starts later).
-        assert spi12.dropna().index.min() > spi3.dropna().index.min()
-
-    def test_non_datetime_index_raises(self):
-        with pytest.raises(ValueError, match="DatetimeIndex"):
-            standardized_precipitation_index(pd.Series([1.0, 2.0, 3.0]))
+        assert result12.spi.dropna().index.min() > result3.spi.dropna().index.min()
 
     def test_bad_scale_raises(self):
         with pytest.raises(ValueError, match="scale"):
-            standardized_precipitation_index(_monthly_precip(), scale=0)
+            compute_spi(_monthly_precip(), scale=0)
 
     def test_handles_zeros(self):
         precip = _monthly_precip()
         precip.iloc[::5] = 0.0  # inject dry months
-        spi = standardized_precipitation_index(precip, scale=1)
-        assert np.isfinite(spi.dropna()).all()
+        result = compute_spi(precip, scale=1)
+        assert np.isfinite(result.spi.dropna()).all()


### PR DESCRIPTION
Closes #61

## What this PR does
Adds to aquascope/climate/indices.py:

- `spi(precipitation, scale=3)` — computes the Standardized 
  Precipitation Index via rolling accumulation, per-calendar-month 
  gamma distribution fitting, and standard normal transform
- Mixed distribution handling for zero-precipitation months 
  (WMO 2012 SPI User Guide approach)
- `drought_class(spi_value)` — maps SPI values to McKee et al. (1993) 
  drought/wet categories
- `SPIResult` dataclass bundling the SPI series, scale, and 
  classifications

## Tests
tests/test_climate/test_indices.py covers:
- Basic shape/index/scale correctness
- Drought signal validation (dry vs wet series)
- All 7 drought_class categories + boundary values + NaN handling
- Zero-heavy precipitation series (mixed distribution edge case)
- Invalid scale and too-short-series error handling
- Scale sensitivity (SPI-1 has more valid values than SPI-12)

## Verification
ruff check and pytest tests/test_climate pass locally.

## References
McKee, Doesken & Kleist (1993); WMO (2012) SPI User Guide