### PR TITLE
Add France (Hub'Eau) hydrometrie collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ env/
 data/cache/
 data/raw/
 data/processed/
+aquascope/collectors/data/
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ Run `aquascope --help` for the full command list.
 15 unified data sources spanning four regions:
 
 - 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies)
-- 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5
+- 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5, France Hub'Eau
 - 🌏 **Asia-Pacific** — Taiwan MOENV / WRA / Civil IoT / DataGov, Japan MLIT, Korea WAMIS
 - 🌐 **Global** — GEMStat (170 countries), UN SDG 6, OpenMeteo, FAO AQUASTAT, FAO WaPOR
 

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -70,6 +70,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         CopernicusCollector,
         EUWFDCollector,
         GEMStatCollector,
+        HubeauHydrometrieCollector,
         JapanMLITCollector,
         KoreaWAMISCollector,
         OpenMeteoCollector,
@@ -108,6 +109,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         "japan_mlit": lambda: JapanMLITCollector(),
         "korea_wamis": lambda: KoreaWAMISCollector(),
         "india_wris": lambda: IndiaWRISCollector(),
+        "hubeau_hydrometrie": lambda: HubeauHydrometrieCollector(),
     }
 
     if source not in collector_map:
@@ -366,6 +368,7 @@ def cmd_list_sources(args: argparse.Namespace) -> None:
         "openmeteo": ("Open-Meteo", "Global", "ERA5 reanalysis, weather forecasts, GloFAS discharge", "https://open-meteo.com"),
         "copernicus": ("Copernicus CDS", "Global", "GloFAS river discharge forecasts", "https://cds.climate.copernicus.eu"),
         "wapor": ("FAO WaPOR", "Global", "Satellite ET, biomass, and water productivity", "https://www.fao.org/in-action/remote-sensing-for-water-productivity"),
+        "hubeau_hydrometrie": ("Hub'Eau", "France", "Hydrometrie", "https://hubeau.eaufrance.fr/api/v2/hydrometrie"),
     }
 
     for src in DataSource:
@@ -912,7 +915,7 @@ def main() -> None:
             "taiwan_moenv", "taiwan_wra_level", "taiwan_wra_reservoir",
             "taiwan_wra_fhy", "taiwan_wra_iot", "taiwan_datagov",
             "usgs", "sdg6", "gemstat", "aquastat", "taiwan_civil_iot", "wqp",
-            "openmeteo", "copernicus", "wapor", "eu_wfd",
+            "openmeteo", "copernicus", "wapor", "eu_wfd", "hubeau_hydrometrie"
         ],
         help="Data source to collect from",
     )

--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -4,6 +4,7 @@ from aquascope.collectors.aquastat import AquastatCollector
 from aquascope.collectors.base import BaseCollector
 from aquascope.collectors.copernicus import CopernicusCollector
 from aquascope.collectors.eu_wfd import EUWFDCollector
+from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
 from aquascope.collectors.gemstat import GEMStatCollector
 from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.japan_mlit import JapanMLITCollector
@@ -48,4 +49,5 @@ __all__ = [
     "WaPORCollector",
     "WQPCollector",
     "IndiaWRISCollector",
+    "HubeauHydrometrieCollector",
 ]

--- a/aquascope/collectors/france_hubeau.py
+++ b/aquascope/collectors/france_hubeau.py
@@ -1,0 +1,175 @@
+"""
+Collector for Hub'Eau (France) — Hydrometrie API.
+
+Real-time river water level and discharge from the French hydrometric
+network (DREAL / SCHAPI, Vigicrues), via Hub'Eau:
+    https://hubeau.eaufrance.fr/page/api-hydrometrie
+
+Endpoint used: ``observations_tr`` — real-time observations (water level,
+discharge), which conveniently also carries each reading's coordinates
+inline, so no separate station-metadata lookup is needed. Station *names*
+are not included on this endpoint, so ``station_name`` is left unset.
+
+No API key required (open data, unauthenticated).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.schemas.water_data import (
+    DataSource,
+    GeoLocation,
+    WaterQualitySample,
+)
+from aquascope.utils.http_client import CachedHTTPClient, RateLimiter
+
+logger = logging.getLogger(__name__)
+
+HUBEAU_BASE = "https://hubeau.eaufrance.fr/api/v2/hydrometrie"
+
+# Hub'Eau's two hydrometric "grandeurs" (quantities)
+GRANDEUR_LABELS: dict[str, str] = {
+    "H": "Water level",
+    "Q": "Discharge",
+}
+GRANDEUR_UNITS: dict[str, str] = {
+    "H": "mm",
+    "Q": "L/s",
+}
+
+
+class HubeauHydrometrieCollector(BaseCollector):
+    """
+    Collect real-time river level/discharge data from Hub'Eau (France).
+
+    Parameters
+    ----------
+    api_key : str, optional
+        Unused — Hub'Eau is open data with no authentication. Kept for
+        interface parity with other collectors.
+    """
+
+    name = "hubeau_hydrometrie"
+
+    def __init__(
+        self,
+        api_key: str = "",
+        client: CachedHTTPClient | None = None,
+    ):
+        super().__init__(
+            client
+            or CachedHTTPClient(
+                base_url=HUBEAU_BASE,
+                rate_limiter=RateLimiter(max_calls=10, period_seconds=60),
+                cache_ttl_seconds=1800,  # upstream refreshes every ~2 minutes
+            )
+        )
+        self.api_key = api_key
+
+    def fetch_raw(
+        self,
+        code_station: str | None = None,
+        grandeur_hydro: str | None = None,
+        date_debut_obs: str | None = None,
+        date_fin_obs: str | None = None,
+        days: int | None = None,
+        size: int = 1000,
+        max_items: int | None = 5_000,
+        **kwargs,
+    ) -> list[dict]:
+        """
+        Fetch real-time observations from Hub'Eau's ``observations_tr``.
+
+        Parameters
+        ----------
+        code_station : str, optional
+            Hydrometric station code (e.g. "K002000101"). Without this
+            (or a date/grandeur filter), Hub'Eau returns observations
+            across thousands of stations nationwide.
+        grandeur_hydro : str, optional
+            "H" (water level) or "Q" (discharge). Omit to fetch both.
+        date_debut_obs / date_fin_obs : str, optional
+            ISO 8601 bounds, e.g. "2026-06-01T00:00:00Z". Built from
+            ``days`` if omitted.
+        days : int, optional
+            Last N days from now (UTC). Ignored if ``date_debut_obs`` is
+            given. Hub'Eau's own default lookback applies if neither is set.
+        size : int
+            Page size (Hub'Eau's hard max is 20000).
+        max_items : int, optional
+            Hard cap on total records fetched across all pages. ``None``
+            means no cap.
+        """
+        if date_debut_obs is None and days is not None:
+            start = datetime.now(timezone.utc) - timedelta(days=days)
+            date_debut_obs = start.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+        all_data: list[dict] = []
+        params: dict[str, Any] = {"format": "json", "size": min(size, 20_000)}
+        if code_station:
+            params["code_station"] = code_station
+        if grandeur_hydro:
+            params["grandeur_hydro"] = grandeur_hydro
+        if date_debut_obs:
+            params["date_debut_obs"] = date_debut_obs
+        if date_fin_obs:
+            params["date_fin_obs"] = date_fin_obs
+        params.update(kwargs)
+
+        url = "/observations_tr"
+        while True:
+            resp = self.client.get_json(url, params=params)
+            rows = resp.get("data", [])
+            all_data.extend(rows)
+
+            if max_items is not None and len(all_data) >= max_items:
+                all_data = all_data[:max_items]
+                logger.debug("Hub'Eau max_items=%d reached — stopping pagination.", max_items)
+                break
+
+            next_link = resp.get("next")
+            if not next_link or len(rows) == 0:
+                break
+            # next_link is absolute and already carries the cursor; switch to direct fetch
+            url = next_link
+            params = {}
+
+        return all_data
+
+    def normalise(self, raw: list[dict]) -> Sequence[WaterQualitySample]:
+        samples: list[WaterQualitySample] = []
+        for row in raw:
+            try:
+                grandeur = row.get("grandeur_hydro", "")
+                label = GRANDEUR_LABELS.get(grandeur, grandeur)
+                unit = GRANDEUR_UNITS.get(grandeur, "")
+
+                val = row.get("resultat_obs")
+                if val is None:
+                    continue
+
+                # observations_tr includes coordinates directly on each row -
+                # no separate referentiel/stations lookup needed.
+                lat, lon = row.get("latitude"), row.get("longitude")
+                loc = GeoLocation(latitude=lat, longitude=lon) if lat is not None and lon is not None else None
+
+                samples.append(
+                    WaterQualitySample(
+                        source=DataSource.HUBEAU,
+                        station_id=row["code_station"],
+                        station_name=row.get("libelle_station"),  # not present on this endpoint; stays None
+                        location=loc,
+                        sample_datetime=datetime.fromisoformat(row["date_obs"]),
+                        parameter=label,
+                        value=float(val),
+                        unit=unit,
+                    )
+                )
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.debug("Skipping Hub'Eau row: %s", exc)
+        return samples

--- a/aquascope/collectors/france_hubeau.py
+++ b/aquascope/collectors/france_hubeau.py
@@ -143,6 +143,7 @@ class HubeauHydrometrieCollector(BaseCollector):
 
     def normalise(self, raw: list[dict]) -> Sequence[WaterQualitySample]:
         samples: list[WaterQualitySample] = []
+        skipped = 0
         for row in raw:
             try:
                 grandeur = row.get("grandeur_hydro", "")
@@ -151,6 +152,7 @@ class HubeauHydrometrieCollector(BaseCollector):
 
                 val = row.get("resultat_obs")
                 if val is None:
+                    skipped += 1
                     continue
 
                 # observations_tr includes coordinates directly on each row -
@@ -158,18 +160,29 @@ class HubeauHydrometrieCollector(BaseCollector):
                 lat, lon = row.get("latitude"), row.get("longitude")
                 loc = GeoLocation(latitude=lat, longitude=lon) if lat is not None and lon is not None else None
 
+                # Hub'Eau returns date_obs with a trailing "Z". datetime.fromisoformat() only
+                # accepts a bare "Z" on Python 3.11+; normalise it explicitly so this works on 3.10 too. 
+                # Stored tz-naive to match the convention used by other collectors in this codebase.
                 samples.append(
                     WaterQualitySample(
                         source=DataSource.HUBEAU,
                         station_id=row["code_station"],
                         station_name=row.get("libelle_station"),  # not present on this endpoint; stays None
                         location=loc,
-                        sample_datetime=datetime.fromisoformat(row["date_obs"]),
+                        sample_datetime=datetime.fromisoformat(row["date_obs"].replace("Z", "+00:00")).replace(tzinfo=None),
                         parameter=label,
                         value=float(val),
                         unit=unit,
                     )
                 )
             except (ValueError, KeyError, TypeError) as exc:
+                skipped += 1
                 logger.debug("Skipping Hub'Eau row: %s", exc)
+
+        if skipped:
+            logger.warning(
+                "Hub'Eau normalise(): skipped %d/%d row(s) (missing/invalid fields)",
+                skipped,
+                len(raw),
+            )
         return samples

--- a/aquascope/collectors/france_hubeau.py
+++ b/aquascope/collectors/france_hubeau.py
@@ -161,7 +161,7 @@ class HubeauHydrometrieCollector(BaseCollector):
                 loc = GeoLocation(latitude=lat, longitude=lon) if lat is not None and lon is not None else None
 
                 # Hub'Eau returns date_obs with a trailing "Z". datetime.fromisoformat() only
-                # accepts a bare "Z" on Python 3.11+; normalise it explicitly so this works on 3.10 too. 
+                # accepts a bare "Z" on Python 3.11+; normalise it explicitly so this works on 3.10 too.
                 # Stored tz-naive to match the convention used by other collectors in this codebase.
                 samples.append(
                     WaterQualitySample(

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -36,7 +36,7 @@ class DataSource(str, Enum):
     TAIWAN_WRA_IOT = "taiwan_wra_iot"
     TAIWAN_DATAGOV = "taiwan_datagov"
     INDIA_WRIS = "india_wris"
-
+    HUBEAU = "france_hubeau"
 
 class GeoLocation(BaseModel):
     """Geographic coordinates for a monitoring station or sample point."""

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -28,6 +28,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | [FAO AQUASTAT](https://www.fao.org/aquastat) | Global | Country-level water withdrawal, irrigation | FAOSTAT API | ✅ |
 | [FAO WaPOR](https://www.fao.org/in-action/remote-sensing-for-water-productivity) | Global | Satellite ET, biomass, water productivity | REST | ✅ |
 | [EU WFD](https://www.eea.europa.eu) | Europe | Water Framework Directive status | REST | ✅ |
+| [Hub'Eau](https://hubeau.eaufrance.fr/api/v2/hydrometrie) | France | River water level, discharge | REST | ✅ |
 | [Japan MLIT](https://www.mlit.go.jp) | Japan | Hydrometeorology, river observations | REST | ✅ |
 | [Korea WAMIS](https://www.wamis.go.kr) | Korea | Hydrology, dam operations | REST | ✅ |
 | [India WRIS](https://indiawris.gov.in) | India | River water level | REST | ✅ |
@@ -48,6 +49,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | Copernicus CDS | **Yes** | [Register](https://cds.climate.copernicus.eu/user/register) — free |
 | FAO AQUASTAT / WaPOR | No | Open access |
 | EU WFD | No | Open access |
+| Hub'Eau | No | Open access |
 | Japan MLIT / Korea WAMIS | No | Open access |
 
 ---

--- a/tests/test_collectors/test_france_hubeau.py
+++ b/tests/test_collectors/test_france_hubeau.py
@@ -1,0 +1,152 @@
+"""Tests for the Hub'Eau (France) hydrometrie collector's normalise().
+
+These test normalise() directly with hand-built fixture rows shaped like
+Hub'Eau's real observations_tr response - no network calls."""
+
+from __future__ import annotations
+
+from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
+from aquascope.schemas.water_data import DataSource, WaterQualitySample
+
+
+class TestFranceHubeauNormaliseGrandeur:
+    def test_water_level_row(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "H",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 1250.0,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert isinstance(samples[0], WaterQualitySample)
+        assert samples[0].source == DataSource.HUBEAU
+        assert samples[0].station_id == "K002000101"
+        assert samples[0].parameter == "Water level"
+        assert samples[0].value == 1250.0
+        assert samples[0].unit == "mm"
+
+    def test_discharge_row(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 84.3,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert samples[0].parameter == "Discharge"
+        assert samples[0].value == 84.3
+        assert samples[0].unit == "L/s"
+
+    def test_unknown_grandeur_falls_back_to_raw_code(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "X",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 1.0,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert samples[0].parameter == "X"
+        assert samples[0].unit == ""
+
+
+class TestFranceHubeauNormaliseLocation:
+    def test_populates_location_when_coords_present(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "A402061001",
+                "grandeur_hydro": "H",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": -212.0,
+                "latitude": 47.866921289,
+                "longitude": 6.796285291,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert samples[0].location is not None
+        assert samples[0].location.latitude == 47.866921289
+        assert samples[0].location.longitude == 6.796285291
+
+    def test_location_none_when_coords_absent(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 84.3,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert samples[0].location is None
+
+
+class TestFranceHubeauNormaliseEdgeCases:
+    def test_skips_row_with_null_value(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:05:00Z",
+                "resultat_obs": None,
+            }
+        ]
+        assert collector.normalise(raw) == []
+
+    def test_skips_row_missing_station_id(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:05:00Z",
+                "resultat_obs": 10.0,
+            }
+        ]
+        assert collector.normalise(raw) == []
+
+    def test_skips_row_with_unparseable_datetime(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "not-a-date",
+                "resultat_obs": 10.0,
+            }
+        ]
+        assert collector.normalise(raw) == []
+
+    def test_mixed_batch_skips_only_invalid_rows(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "H",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 1250.0,
+            },
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:05:00Z",
+                "resultat_obs": None,
+            },
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert samples[0].parameter == "Water level"

--- a/tests/test_collectors/test_france_hubeau.py
+++ b/tests/test_collectors/test_france_hubeau.py
@@ -5,8 +5,83 @@ Hub'Eau's real observations_tr response - no network calls."""
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
 from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
 from aquascope.schemas.water_data import DataSource, WaterQualitySample
+
+
+class TestFranceHubeauFetchRawPagination:
+    def test_follows_next_link_across_pages(self):
+        collector = HubeauHydrometrieCollector()
+
+        page1 = {
+            "data": [
+                {
+                    "code_station": "A1",
+                    "grandeur_hydro": "Q",
+                    "date_obs": "2026-07-08T10:00:00Z",
+                    "resultat_obs": 1.0,
+                }
+            ],
+            "next": "https://hubeau.eaufrance.fr/api/v2/hydrometrie/observations_tr?cursor=abc&size=1",
+        }
+        page2 = {
+            "data": [
+                {
+                    "code_station": "A1",
+                    "grandeur_hydro": "Q",
+                    "date_obs": "2026-07-08T10:05:00Z",
+                    "resultat_obs": 2.0,
+                }
+            ],
+            # no "next" key - this is the last page
+        }
+
+        mock_get_json = Mock(side_effect=[page1, page2])
+        collector.client.get_json = mock_get_json
+
+        raw = collector.fetch_raw(code_station="A1", size=1, max_items=None)
+
+        assert len(raw) == 2
+        assert raw[0]["resultat_obs"] == 1.0
+        assert raw[1]["resultat_obs"] == 2.0
+        assert mock_get_json.call_count == 2
+
+        first_args, first_kwargs = mock_get_json.call_args_list[0]
+        assert first_args[0] == "/observations_tr"
+        assert first_kwargs["params"]["code_station"] == "A1"
+
+        second_args, second_kwargs = mock_get_json.call_args_list[1]
+        assert second_args[0] == page1["next"]
+        assert second_kwargs["params"] == {}
+
+    def test_stops_when_max_items_reached_mid_page(self):
+        collector = HubeauHydrometrieCollector()
+        page1 = {
+            "data": [
+                {
+                    "code_station": "A1",
+                    "grandeur_hydro": "Q",
+                    "date_obs": "2026-07-08T10:00:00Z",
+                    "resultat_obs": 1.0,
+                },
+                {
+                    "code_station": "A1",
+                    "grandeur_hydro": "Q",
+                    "date_obs": "2026-07-08T10:01:00Z",
+                    "resultat_obs": 2.0,
+                },
+            ],
+            "next": "https://hubeau.eaufrance.fr/api/v2/hydrometrie/observations_tr?cursor=abc",
+        }
+        mock_get_json = Mock(return_value=page1)
+        collector.client.get_json = mock_get_json
+
+        raw = collector.fetch_raw(code_station="A1", size=2, max_items=1)
+
+        assert len(raw) == 1  # truncated to max_items even mid-page
+        assert mock_get_json.call_count == 1  # never followed next_link
 
 
 class TestFranceHubeauNormaliseGrandeur:
@@ -93,6 +168,61 @@ class TestFranceHubeauNormaliseLocation:
         samples = collector.normalise(raw)
         assert len(samples) == 1
         assert samples[0].location is None
+
+
+class TestFranceHubeauNormaliseDatetime:
+    def test_z_suffix_parses_to_tz_naive(self):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 84.3,
+            }
+        ]
+        samples = collector.normalise(raw)
+        assert len(samples) == 1
+        dt = samples[0].sample_datetime
+        assert dt.tzinfo is None
+        assert dt.isoformat() == "2026-07-08T10:00:00"
+
+
+class TestFranceHubeauNormaliseLogging:
+    def test_warns_with_skip_count_when_rows_skipped(self, caplog):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "H",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 1250.0,
+            },
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "Q",
+                "date_obs": "2026-07-08T10:05:00Z",
+                "resultat_obs": None,
+            },
+        ]
+        with caplog.at_level("WARNING"):
+            samples = collector.normalise(raw)
+        assert len(samples) == 1
+        assert any("skipped 1/2" in r.message for r in caplog.records)
+
+    def test_no_warning_when_nothing_skipped(self, caplog):
+        collector = HubeauHydrometrieCollector()
+        raw = [
+            {
+                "code_station": "K002000101",
+                "grandeur_hydro": "H",
+                "date_obs": "2026-07-08T10:00:00Z",
+                "resultat_obs": 1250.0,
+            }
+        ]
+        with caplog.at_level("WARNING"):
+            collector.normalise(raw)
+        assert not any("skipped" in r.message for r in caplog.records)
 
 
 class TestFranceHubeauNormaliseEdgeCases:


### PR DESCRIPTION
## France (Hub'Eau) collector

Adds a collector for France using Hub'Eau's Hydrométrie API; real-time river water level and discharge. Related to #11.

**Design note:** guidance suggested `WaterLevelReading` for this data, but I went with `WaterQualitySample` instead, matching the pattern already established in `usgs.py`. Flagging this in case you'd rather keep it schema-literal. As you suggested, I just used the hydrometrie API for now, as a start. Let me know what you think; I'm happy to take on .../v2/qualite_rivieres/analyse_pc as well, either as a second commit to this branch, or a new one.

**Testing:** full suite passes (1001 tests). `ruff` clean. `mypy` hits a pre-existing python_version/numpy stub mismatch unrelated to this PR — no errors attributable to `france_hubeau.py` itself.

Another note: the walkthrough says to "Add your source to the table in README.md"
I couldn't find a table in README.md. The table seems to have moved to docs/data_sources.md
If so, the walkthrough should be updated, accordingly.

**Also:** added `aquascope/collectors/data/` to `.gitignore` (a local cache dir generated by `CachedHTTPClient` when testing from within `collectors/`).