### PR TITLE
release: 0.8.0 — groundwater drought

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.8.0] - 2026-07-10
+
+Groundwater drought: daily Taiwan groundwater data, SGI and SPI drought
+indices, and an end-to-end drought-propagation case study.
+
+### Added
 - **Worked example** (`examples/13_groundwater_drought_sgi.py`): an end-to-end
   case study, data to result, characterising Taiwan's 2020-2021 groundwater
   drought. AquaScope collects daily groundwater (`TaiwanWRAGroundwaterDailyCollector`)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Abdoul Rachid
     orcid: "https://orcid.org/0000-0002-4616-4153"
     affiliation: "National Central University, Taiwan"
-version: 0.7.0
-date-released: "2026-06-26"
+version: 0.8.0
+date-released: "2026-07-10"
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
 url: https://rekin226.github.io/aquascope
@@ -55,8 +55,8 @@ preferred-citation:
     - family-names: Ouédraogo
       given-names: Abdoul Rachid
       orcid: "https://orcid.org/0000-0002-4616-4153"
-  version: 0.7.0
-  date-released: "2026-06-26"
+  version: 0.8.0
+  date-released: "2026-07-10"
   license: MIT
   repository-code: https://github.com/Rekin226/aquascope
   url: https://rekin226.github.io/aquascope

--- a/aquascope/__init__.py
+++ b/aquascope/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.7.0"
+__version__ = "0.8.0"
 __author__ = "AquaScope Contributors"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aquascope"
-version = "0.7.0"
+version = "0.8.0"
 description = "Open-source water data aggregation toolkit with AI-powered research methodology recommendations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Cuts AquaScope 0.8.0.

Groundwater drought: daily Taiwan groundwater data, SGI and SPI drought indices, and an end-to-end drought-propagation case study.

## Changes
- Bump version to 0.8.0 in `pyproject.toml` and `aquascope/__init__.py`
- Roll the CHANGELOG `Unreleased` section into `0.8.0 - 2026-07-10`
- Update `CITATION.cff` version and date-released (both occurrences)

## Highlights (from the CHANGELOG)
- `TaiwanWRAGroundwaterDailyCollector`: daily groundwater levels from the WRA gweb HydroInfo portal, with well coordinates and depth joined from the open-data well-status dataset
- `standardised_groundwater_index()` (SGI) and `standardized_precipitation_index()` (SPI), plus `drought_events()`
- Worked example `examples/13_groundwater_drought_sgi.py`: Taiwan 2020-2021 groundwater drought, SGI vs SPI propagation timescales
- `CachedHTTPClient.post_json()` now shares retry/rate-limit/cache behaviour with `get_json()`
- Fix: gweb missing-data sentinel dropped and window-overlap duplicates de-duplicated

After merge: create the GitHub Release `v0.8.0`, which triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)