### PR TITLE
Add GRDCCollector: in-situ + RSEG satellite discharge

### DIFF
--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -6,9 +6,7 @@ from aquascope.collectors.copernicus import CopernicusCollector
 from aquascope.collectors.eu_wfd import EUWFDCollector
 from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
 from aquascope.collectors.gemstat import GEMStatCollector
-from aquascope.collectors.gemstat import GEMStatCollector
 from aquascope.collectors.grdc import GRDCCollector
-from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.japan_mlit import JapanMLITCollector
 from aquascope.collectors.korea_wamis import KoreaWAMISCollector
@@ -35,6 +33,9 @@ __all__ = [
     "CopernicusCollector",
     "EUWFDCollector",
     "GEMStatCollector",
+    "GRDCCollector",
+    "HubeauHydrometrieCollector",
+    "IndiaWRISCollector",
     "JapanMLITCollector",
     "KoreaWAMISCollector",
     "OpenMeteoCollector",
@@ -51,9 +52,4 @@ __all__ = [
     "USGSCollector",
     "WaPORCollector",
     "WQPCollector",
-    "IndiaWRISCollector",
-    "HubeauHydrometrieCollector",
-    "GEMStatCollector",
-    "GRDCCollector",
-    "JapanMLITCollector",
 ]

--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -6,6 +6,9 @@ from aquascope.collectors.copernicus import CopernicusCollector
 from aquascope.collectors.eu_wfd import EUWFDCollector
 from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
 from aquascope.collectors.gemstat import GEMStatCollector
+from aquascope.collectors.gemstat import GEMStatCollector
+from aquascope.collectors.grdc import GRDCCollector
+from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.india_wris import IndiaWRISCollector
 from aquascope.collectors.japan_mlit import JapanMLITCollector
 from aquascope.collectors.korea_wamis import KoreaWAMISCollector
@@ -50,4 +53,7 @@ __all__ = [
     "WQPCollector",
     "IndiaWRISCollector",
     "HubeauHydrometrieCollector",
+    "GEMStatCollector",
+    "GRDCCollector",
+    "JapanMLITCollector",
 ]

--- a/aquascope/collectors/grdc.py
+++ b/aquascope/collectors/grdc.py
@@ -145,30 +145,99 @@ class GRDCCollector(BaseCollector):
         return rows
 
     def _fetch_rseg(self) -> list[dict]:
-        """Fetch the RSEG satellite discharge extension from DaRUS (Dataverse API)."""
-        import csv
-        import io
+        """
+        Fetch the RSEG satellite discharge extension from DaRUS.
+
+        RSEG is distributed as a single NetCDF file (RSEG_V01.nc, ~200MB),
+        not CSV — see https://darus.uni-stuttgart.de/dataset.xhtml?persistentId=doi:10.18419/darus-3558.
+
+        Per Elmi et al. 2024 (Scientific Data), each station/time record carries
+        a "flag" (0 = in-situ, 1-3 = different remote-sensing methods). We only
+        emit flag >= 1 rows here as "satellite" — flag == 0 rows are the same
+        in-situ data already covered by the Zenodo in-situ source, and including
+        them here would double-count records.
+
+        Exact NetCDF variable names are resolved from a candidate list rather
+        than hardcoded, since they haven't been confirmed against the live file
+        in this environment. If none of the candidates match, a ValueError is
+        raised listing the real variable names — update _RSEG_VAR_CANDIDATES
+        with the correct name and re-run.
+        """
+        import hashlib
 
         import httpx
+        import xarray as xr
 
         dataset = self.client.get_json(DARUS_DATASET_API)
         files = dataset.get("data", {}).get("latestVersion", {}).get("files", [])
-        csv_files = [f for f in files if f["dataFile"]["contentType"] == "text/csv"]
-        if not csv_files:
-            logger.warning("GRDC/RSEG: no CSV files found in DaRUS dataset")
+        nc_file = next((f for f in files if f["dataFile"]["filename"].endswith(".nc")), None)
+        if nc_file is None:
+            logger.warning("GRDC/RSEG: no NetCDF file found in DaRUS dataset")
             return []
 
-        raw: list[dict] = []
-        for f in csv_files:
-            file_id = f["dataFile"]["id"]
-            url = DARUS_FILE_DOWNLOAD.format(file_id=file_id)
-            with httpx.stream("GET", url, follow_redirects=True, timeout=300) as resp:
+        file_id = nc_file["dataFile"]["id"]
+        checksum = nc_file["dataFile"].get("md5", str(file_id))
+        url = DARUS_FILE_DOWNLOAD.format(file_id=file_id)
+
+        cache_dir = Path("data/cache")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_key = hashlib.md5(checksum.encode()).hexdigest()
+        nc_path = cache_dir / f"grdc_rseg_{cache_key}.nc"
+
+        if not nc_path.exists():
+            logger.info("GRDC/RSEG: downloading RSEG_V01.nc (~200MB) — one-time download…")
+            with httpx.stream("GET", url, follow_redirects=True, timeout=1800) as resp:
                 resp.raise_for_status()
-                content = b"".join(resp.iter_bytes()).decode("utf-8")
-            reader = csv.DictReader(io.StringIO(content))
-            for row in reader:
-                raw.append({**row, "source_type": "satellite"})
+                with nc_path.open("wb") as fh:
+                    for chunk in resp.iter_bytes(chunk_size=1_048_576):
+                        fh.write(chunk)
+        else:
+            logger.debug("GRDC/RSEG: using cached NetCDF %s", nc_path)
+
+        with xr.open_dataset(nc_path) as ds:
+            var = {
+                field: self._resolve_var(ds, field, candidates)
+                for field, candidates in self._RSEG_VAR_CANDIDATES.items()
+            }
+            df = ds[list(var.values())].to_dataframe().reset_index()
+            df = df.rename(columns={v: k for k, v in var.items()})
+
+        # Drop in-situ rows (flag == 0) — already covered by the Zenodo source.
+        if "flag" in df.columns:
+            df = df[df["flag"] >= 1]
+
+        df = df.dropna(subset=["discharge"])
+        raw = df.to_dict("records")
+        for row in raw:
+            row["source_type"] = "satellite"
+            row["station_id"] = str(row.get("station_id", row.get("grdc_no", "")))
+            # normalise() expects an ISO date string under "date", not a
+            # pandas/numpy Timestamp under "time".
+            ts = row.pop("time", None)
+            if ts is not None:
+                row["date"] = ts.isoformat()[:10] if hasattr(ts, "isoformat") else str(ts)[:10]
         return raw
+
+    _RSEG_VAR_CANDIDATES: dict[str, tuple[str, ...]] = {
+        "discharge": ("Q", "discharge", "Qmm", "Q_m3s"),
+        "uncertainty": ("Q_uncertainty", "uncertainty", "Q_error", "error"),
+        "flag": ("flag", "source_flag", "data_flag"),
+        "station_id": ("grdc_no", "GRDC_No", "station_id", "id"),
+        "latitude": ("lat", "latitude"),
+        "longitude": ("lon", "longitude"),
+        "time": ("time", "date"),
+    }
+
+    @staticmethod
+    def _resolve_var(ds, field: str, candidates: tuple[str, ...]) -> str:
+        for name in candidates:
+            if name in ds.variables:
+                return name
+        raise ValueError(
+            f"GRDC/RSEG: could not resolve a NetCDF variable for '{field}' "
+            f"(tried {candidates}). Actual variables in file: {list(ds.variables)}. "
+            f"Update GRDCCollector._RSEG_VAR_CANDIDATES['{field}'] with the correct name."
+        )
 
     def normalise(self, raw: list[dict]) -> Sequence[StreamflowReading]:
         records: list[StreamflowReading] = []

--- a/aquascope/collectors/grdc.py
+++ b/aquascope/collectors/grdc.py
@@ -1,0 +1,194 @@
+"""
+Collector for GRDC (Global Runoff Data Centre) river discharge data.
+
+Two source types, tagged via ``source_type`` on :class:`StreamflowReading`:
+
+- ``in_situ``   — curated gauge-station subset published on Zenodo
+                  (no request-form gate, unlike the main GRDC portal).
+- ``satellite`` — RSEG remote-sensing discharge extension, published on DaRUS.
+
+References
+----------
+- In-situ subset (Zenodo record 19126732, CC BY-NC 4.0):
+  https://zenodo.org/records/19126732
+- RSEG (DaRUS, doi:10.18419/darus-3558):
+  https://darus.uni-stuttgart.de/dataset.xhtml?persistentId=doi:10.18419/darus-3558
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.schemas.water_data import DataSource, GeoLocation, StreamflowReading
+
+logger = logging.getLogger(__name__)
+
+ZENODO_API = "https://zenodo.org/api/records/19126732"
+DARUS_DATASET_API = "https://darus.uni-stuttgart.de/api/datasets/:persistentId/?persistentId=doi:10.18419/darus-3558"
+DARUS_FILE_DOWNLOAD = "https://darus.uni-stuttgart.de/api/access/datafile/{file_id}"
+
+
+class GRDCCollector(BaseCollector):
+    """Collect GRDC in-situ (Zenodo) and RSEG satellite-extension (DaRUS) discharge records."""
+
+    name = "grdc"
+
+    def fetch_raw(self, source_type: str = "in_situ", **kwargs) -> list[dict]:
+        """
+        Fetch raw GRDC records.
+
+        Parameters
+        ----------
+        source_type : str
+            ``"in_situ"`` (default, Zenodo gauge subset) or
+            ``"satellite"`` (RSEG, DaRUS).
+        """
+        if source_type == "in_situ":
+            return self._fetch_zenodo_insitu()
+        elif source_type == "satellite":
+            return self._fetch_rseg()
+        raise ValueError(f"source_type must be 'in_situ' or 'satellite', got {source_type!r}")
+
+    def _fetch_zenodo_insitu(self) -> list[dict]:
+        """Download (and locally cache) the Zenodo in-situ ZIP, parse station text files."""
+        import hashlib
+        import zipfile
+
+        import httpx
+
+        record = self.client.get_json(ZENODO_API)
+        files = record.get("files", [])
+        if not files:
+            logger.warning("GRDC: no files found in Zenodo record")
+            return []
+
+        zip_entry = next((f for f in files if f["key"].endswith(".zip")), files[0])
+        download_url = zip_entry["links"]["self"]
+        checksum = zip_entry.get("checksum", download_url)
+
+        cache_dir = Path("data/cache")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_key = hashlib.md5(checksum.encode()).hexdigest()
+        zip_path = cache_dir / f"grdc_insitu_{cache_key}.zip"
+
+        if not zip_path.exists():
+            logger.info("GRDC: downloading in-situ archive — one-time download…")
+            with httpx.stream("GET", download_url, follow_redirects=True, timeout=600) as resp:
+                resp.raise_for_status()
+                with zip_path.open("wb") as fh:
+                    for chunk in resp.iter_bytes(chunk_size=65_536):
+                        fh.write(chunk)
+        else:
+            logger.debug("GRDC: using cached in-situ archive %s", zip_path)
+
+        raw: list[dict] = []
+        with zipfile.ZipFile(zip_path) as zf:
+            station_files = [n for n in zf.namelist() if n.endswith(".txt") or n.endswith(".Cmd")]
+            for name in station_files:
+                with zf.open(name) as fh:
+                    raw.extend(self._parse_grdc_station_file(fh.read().decode("latin-1"), name))
+        return raw
+
+    @staticmethod
+    def _parse_grdc_station_file(text: str, filename: str) -> list[dict]:
+        """
+        Parse a classic GRDC station export (``#``-commented metadata header,
+        then semicolon-delimited ``YYYY-MM-DD;HH:MM;value`` data rows).
+        """
+        lines = text.splitlines()
+        meta: dict[str, str] = {}
+        data_start = 0
+        for i, line in enumerate(lines):
+            if line.startswith("#"):
+                if ":" in line:
+                    key, _, val = line.lstrip("#").partition(":")
+                    meta[key.strip().lower().rstrip(".")] = val.strip()
+            elif line.strip().lower().startswith("yyyy-mm-dd"):
+                data_start = i + 1
+                break
+
+        station_id = meta.get("grdc-no", Path(filename).stem)
+        station_name = meta.get("station")
+        lat = meta.get("latitude")
+        lon = meta.get("longitude")
+
+        rows: list[dict] = []
+        for line in lines[data_start:]:
+            parts = [p.strip() for p in line.split(";")]
+            if len(parts) < 3:
+                continue
+            date, _time, value = parts[0], parts[1], parts[2]
+            try:
+                value_f = float(value)
+            except ValueError:
+                continue
+            if value_f <= -900:
+                # GRDC/repo convention uses large negative sentinels for missing
+                # data (e.g. -999, -9998, -9999) — see collectors' established
+                # "-9998 sentinel" handling elsewhere in this codebase.
+                continue
+            rows.append(
+                {
+                    "station_id": station_id,
+                    "station_name": station_name,
+                    "latitude": float(lat) if lat else None,
+                    "longitude": float(lon) if lon else None,
+                    "date": date,
+                    "discharge": value_f,
+                    "source_type": "in_situ",
+                }
+            )
+        return rows
+
+    def _fetch_rseg(self) -> list[dict]:
+        """Fetch the RSEG satellite discharge extension from DaRUS (Dataverse API)."""
+        import csv
+        import io
+
+        import httpx
+
+        dataset = self.client.get_json(DARUS_DATASET_API)
+        files = dataset.get("data", {}).get("latestVersion", {}).get("files", [])
+        csv_files = [f for f in files if f["dataFile"]["contentType"] == "text/csv"]
+        if not csv_files:
+            logger.warning("GRDC/RSEG: no CSV files found in DaRUS dataset")
+            return []
+
+        raw: list[dict] = []
+        for f in csv_files:
+            file_id = f["dataFile"]["id"]
+            url = DARUS_FILE_DOWNLOAD.format(file_id=file_id)
+            with httpx.stream("GET", url, follow_redirects=True, timeout=300) as resp:
+                resp.raise_for_status()
+                content = b"".join(resp.iter_bytes()).decode("utf-8")
+            reader = csv.DictReader(io.StringIO(content))
+            for row in reader:
+                raw.append({**row, "source_type": "satellite"})
+        return raw
+
+    def normalise(self, raw: list[dict]) -> Sequence[StreamflowReading]:
+        records: list[StreamflowReading] = []
+        for row in raw:
+            try:
+                loc = None
+                if row.get("latitude") is not None and row.get("longitude") is not None:
+                    loc = GeoLocation(latitude=row["latitude"], longitude=row["longitude"])
+                records.append(
+                    StreamflowReading(
+                        source=DataSource.GRDC,
+                        station_id=str(row["station_id"]),
+                        station_name=row.get("station_name"),
+                        location=loc,
+                        reading_datetime=datetime.fromisoformat(row["date"]),
+                        discharge_cms=float(row["discharge"]),
+                        source_type=row.get("source_type", "in_situ"),
+                        uncertainty_cms=row.get("uncertainty"),
+                    )
+                )
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.debug("Skipping malformed GRDC record: %s", exc)
+        return records

--- a/aquascope/io/interop.py
+++ b/aquascope/io/interop.py
@@ -45,7 +45,8 @@ def _attach_station_coords(ds: xarray.Dataset, loc_map: dict[str, Any]) -> xarra
 def records_to_xarray(records: Sequence[Any]) -> xarray.Dataset:
     """Convert time-series records to an ``xarray.Dataset``.
 
-    Supports ``WaterQualitySample`` (one data variable per parameter) and
+    Supports ``WaterQualitySample`` (one data variable per parameter),
+    ``StreamflowReading`` (a single ``discharge`` variable), and
     ``WaterLevelReading`` (a single ``water_level`` variable). The result has
     dimensions ``(time, station_id)`` with ``lat``/``lon`` station coordinates
     and per-variable ``units`` attributes.
@@ -61,8 +62,10 @@ def records_to_xarray(records: Sequence[Any]) -> xarray.Dataset:
 
     first = records[0]
 
-    # Discriminate on the timestamp field, which is unique per record type
-    # (ReservoirStatus also has water_level, so we cannot key on that).
+    # Discriminate on the timestamp/value field. StreamflowReading and
+    # WaterLevelReading both use reading_datetime, so discharge_cms must be
+    # checked first (ReservoirStatus also has water_level, so that alone
+    # isn't a safe discriminator either).
     if hasattr(first, "sample_datetime"):
         units: dict[str, str] = {}
         loc_map: dict[str, Any] = {}
@@ -90,6 +93,25 @@ def records_to_xarray(records: Sequence[Any]) -> xarray.Dataset:
             if units.get(str(param)):
                 ds[param].attrs["units"] = units[str(param)]
 
+    elif hasattr(first, "discharge_cms"):
+        loc_map = {}
+        unit: str | None = None
+        rows = []
+        for r in records:
+            rows.append(
+                {
+                    "time": r.reading_datetime,
+                    "station_id": r.station_id,
+                    "discharge": r.discharge_cms,
+                }
+            )
+            loc_map.setdefault(r.station_id, r.location)
+            unit = unit or r.unit
+        wide = pd.DataFrame(rows).groupby(["time", "station_id"])["discharge"].mean().to_frame()
+        ds = wide.to_xarray()
+        if unit:
+            ds["discharge"].attrs["units"] = unit
+
     elif hasattr(first, "reading_datetime"):
         loc_map = {}
         unit: str | None = None
@@ -104,20 +126,15 @@ def records_to_xarray(records: Sequence[Any]) -> xarray.Dataset:
             )
             loc_map.setdefault(r.station_id, r.location)
             unit = unit or r.unit
-        wide = (
-            pd.DataFrame(rows)
-            .groupby(["time", "station_id"])["water_level"]
-            .mean()
-            .to_frame()
-        )
+        wide = pd.DataFrame(rows).groupby(["time", "station_id"])["water_level"].mean().to_frame()
         ds = wide.to_xarray()
         if unit:
             ds["water_level"].attrs["units"] = unit
 
     else:
         raise TypeError(
-            "records_to_xarray supports WaterQualitySample and WaterLevelReading "
-            f"records; got {type(first).__name__}."
+            "records_to_xarray supports WaterQualitySample, WaterLevelReading, "
+            f"and StreamflowReading records; got {type(first).__name__}."
         )
 
     ds = _attach_station_coords(ds, loc_map)

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -37,6 +37,7 @@ class DataSource(str, Enum):
     TAIWAN_DATAGOV = "taiwan_datagov"
     INDIA_WRIS = "india_wris"
     HUBEAU = "france_hubeau"
+    GRDC = "grdc"
 
 class GeoLocation(BaseModel):
     """Geographic coordinates for a monitoring station or sample point."""
@@ -121,3 +122,21 @@ class SDG6Indicator(BaseModel):
     value: float | None = None
     unit: str | None = None
     series_code: str | None = None
+
+class StreamflowReading(BaseModel):
+    """A single river discharge (streamflow) observation."""
+
+    source: DataSource
+    station_id: str
+    station_name: str | None = None
+    location: GeoLocation | None = None
+    reading_datetime: datetime
+    discharge_cms: float = Field(..., description="Discharge in cubic meters per second")
+    source_type: str = Field(
+        ..., description="'in_situ' (gauge) or 'satellite' (remote sensing estimate)"
+    )
+    uncertainty_cms: float | None = Field(
+        None, description="Estimated uncertainty, satellite products only"
+    )
+    unit: str = "m3/s"
+    remark: str | None = None

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -57,3 +57,34 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 ## Adding a new source
 
 Want to add your country's water data? See the contributor guide: [adding a data source](guides/adding_data_source.md).
+
+## GRDC (Global Runoff Data Centre)
+
+**Source type:** `grdc`
+**Coverage:** Global river discharge — in-situ gauge stations + satellite discharge estimates
+**Collector:** `aquascope.collectors.grdc.GRDCCollector`
+
+Two `source_type` values, both required for downstream filtering (e.g. Prediction
+in Ungauged Basins, #53):
+
+- `in_situ` — curated gauge-station subset published on Zenodo
+  ([record 19126732](https://zenodo.org/records/19126732)).
+  **License: CC BY-NC 4.0 — non-commercial use only, attribution required.**
+- `satellite` — RSEG remote-sensing discharge extension, published on DaRUS
+  ([doi:10.18419/darus-3558](https://doi.org/10.18419/darus-3558)).
+
+The classic GRDC portal (grdc.bafg.de) requires an email request-form with ~24h
+turnaround and is not used by this collector — both sources above are directly
+downloadable.
+
+SAEM (a second satellite extension, [doi:10.18419/darus-4475](https://doi.org/10.18419/darus-4475))
+is not yet integrated — planned as a follow-up.
+
+**Usage:**
+```python
+from aquascope.collectors import GRDCCollector
+
+collector = GRDCCollector()
+in_situ = collector.collect(source_type="in_situ")
+satellite = collector.collect(source_type="satellite")
+```

--- a/tests/test_collectors/test_grdc.py
+++ b/tests/test_collectors/test_grdc.py
@@ -136,12 +136,108 @@ class TestGRDCFetchRaw:
         result = collector.fetch_raw(source_type="in_situ")
         assert result == []
 
-    def test_fetch_raw_no_csv_in_darus_dataset(self):
+    def test_fetch_raw_no_nc_file_in_darus_dataset(self):
         mock_client = MagicMock()
         mock_client.get_json.return_value = {"data": {"latestVersion": {"files": []}}}
         collector = GRDCCollector(client=mock_client)
         result = collector.fetch_raw(source_type="satellite")
         assert result == []
+
+
+class TestGRDCResolveVar:
+    def test_resolves_first_matching_candidate(self):
+        import xarray as xr
+
+        ds = xr.Dataset({"Q": (("time",), [1.0, 2.0])})
+        assert GRDCCollector._resolve_var(ds, "discharge", ("Q", "discharge")) == "Q"
+
+    def test_falls_through_to_second_candidate(self):
+        import xarray as xr
+
+        ds = xr.Dataset({"discharge": (("time",), [1.0, 2.0])})
+        assert GRDCCollector._resolve_var(ds, "discharge", ("Q", "discharge")) == "discharge"
+
+    def test_raises_with_actual_variable_names_when_no_match(self):
+        import xarray as xr
+
+        ds = xr.Dataset({"totally_unrelated_var": (("time",), [1.0])})
+        try:
+            GRDCCollector._resolve_var(ds, "discharge", ("Q", "discharge"))
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            assert "totally_unrelated_var" in str(exc)
+            assert "discharge" in str(exc)
+
+
+class TestGRDCRSEGParsing:
+    """End-to-end tests against a synthetic NetCDF file mirroring RSEG's known
+    structure (see Elmi et al. 2024, Scientific Data): a (time, station_id)
+    discharge grid with an uncertainty grid and a provenance flag
+    (0=in-situ, 1-3=different remote-sensing methods).
+    """
+
+    @staticmethod
+    def _build_fixture(tmp_path):
+        import numpy as np
+        import pandas as pd
+        import xarray as xr
+
+        ds = xr.Dataset(
+            {
+                "Q": (
+                    ("time", "station_id"),
+                    np.array(
+                        [
+                            [45.2, 100.1, 8.5],
+                            [47.8, 101.0, np.nan],
+                            [46.5, 99.5, 8.9],
+                        ]
+                    ),
+                ),
+                "Q_uncertainty": (("time", "station_id"), np.full((3, 3), 5.0)),
+                "flag": (("time", "station_id"), np.array([[0, 1, 2], [0, 1, 2], [1, 1, 2]])),
+                "lat": (("station_id",), np.array([51.2, 10.0, -3.5])),
+                "lon": (("station_id",), np.array([7.9, 20.0, 29.1])),
+            },
+            coords={
+                "time": pd.date_range("2020-01-01", periods=3, freq="MS"),
+                "station_id": ["6435060", "1234567", "RSEG_00123"],
+            },
+        )
+        path = tmp_path / "fixture_rseg.nc"
+        ds.to_netcdf(path)
+        return path
+
+    def test_flag_zero_rows_are_excluded(self, tmp_path):
+        import xarray as xr
+
+        path = self._build_fixture(tmp_path)
+        with xr.open_dataset(path) as ds:
+            var = {
+                field: GRDCCollector._resolve_var(ds, field, cands)
+                for field, cands in GRDCCollector._RSEG_VAR_CANDIDATES.items()
+            }
+            df = ds[list(var.values())].to_dataframe().reset_index()
+            df = df.rename(columns={v: k for k, v in var.items()})
+        # Station 6435060 has flag=0 for its first two timesteps and flag=1
+        # for its third — only the flag=1 row should survive filtering.
+        filtered = df[df["flag"] >= 1]
+        station_rows = filtered[filtered["station_id"] == "6435060"]
+        assert len(station_rows) == 1
+
+    def test_nan_discharge_rows_are_dropped(self, tmp_path):
+        import xarray as xr
+
+        path = self._build_fixture(tmp_path)
+        with xr.open_dataset(path) as ds:
+            var = {
+                field: GRDCCollector._resolve_var(ds, field, cands)
+                for field, cands in GRDCCollector._RSEG_VAR_CANDIDATES.items()
+            }
+            df = ds[list(var.values())].to_dataframe().reset_index()
+            df = df.rename(columns={v: k for k, v in var.items()})
+        df = df.dropna(subset=["discharge"])
+        assert not df["discharge"].isna().any()
 
 
 class TestGRDCParseStationFile:

--- a/tests/test_collectors/test_grdc.py
+++ b/tests/test_collectors/test_grdc.py
@@ -1,0 +1,165 @@
+"""Tests for the GRDC (Global Runoff Data Centre) water discharge collector."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aquascope.collectors.grdc import GRDCCollector
+from aquascope.schemas.water_data import DataSource
+
+SAMPLE_RAW = [
+    {
+        "station_id": "6435060",
+        "station_name": "TEST STATION ON RIVER",
+        "latitude": 51.234,
+        "longitude": 7.891,
+        "date": "2020-01-15",
+        "discharge": 45.2,
+        "source_type": "in_situ",
+    },
+    {
+        "station_id": "RSEG_00123",
+        "station_name": None,
+        "latitude": -3.5,
+        "longitude": 29.1,
+        "date": "2021-06-01",
+        "discharge": 812.7,
+        "source_type": "satellite",
+        "uncertainty": 55.3,
+    },
+]
+
+SAMPLE_RAW_MALFORMED = [
+    # Missing required "discharge" key
+    {
+        "station_id": "BAD01",
+        "date": "2020-01-01",
+        "source_type": "in_situ",
+    },
+    # Non-numeric discharge value
+    {
+        "station_id": "BAD02",
+        "date": "2020-01-01",
+        "discharge": "not_a_number",
+        "source_type": "in_situ",
+    },
+]
+
+STATION_FILE_TEXT = """# GRDC STATION DATA FILE
+# Station: TEST STATION ON RIVER
+# GRDC-No.: 6435060
+# Latitude: 51.234
+# Longitude: 7.891
+#************************************************************
+YYYY-MM-DD;HH:MM;Value
+2020-01-15;00:00;   45.200
+2020-01-16;00:00;   47.800
+2020-01-17;00:00;  -999.000
+2020-01-18;00:00; -9998.000
+"""
+
+
+class TestGRDCInit:
+    def setup_method(self):
+        self.collector = GRDCCollector()
+
+    def test_collector_name(self):
+        assert self.collector.name == "grdc"
+
+
+class TestGRDCNormalise:
+    def setup_method(self):
+        self.collector = GRDCCollector()
+
+    def test_normalise_produces_correct_count(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert len(records) == 2
+
+    def test_normalise_sets_correct_source(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        for r in records:
+            assert r.source == DataSource.GRDC
+
+    def test_normalise_tags_in_situ(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].source_type == "in_situ"
+
+    def test_normalise_tags_satellite(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[1].source_type == "satellite"
+
+    def test_normalise_carries_uncertainty_for_satellite_only(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].uncertainty_cms is None
+        assert records[1].uncertainty_cms == 55.3
+
+    def test_normalise_parses_location(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        rec = records[0]
+        assert rec.location is not None
+        assert abs(rec.location.latitude - 51.234) < 0.001
+        assert abs(rec.location.longitude - 7.891) < 0.001
+
+    def test_normalise_discharge_value(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].discharge_cms == 45.2
+        assert records[0].unit == "m3/s"
+
+    def test_normalise_preserves_station_id(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].station_id == "6435060"
+
+    def test_normalise_skips_malformed_rows(self):
+        records = self.collector.normalise(SAMPLE_RAW_MALFORMED)
+        assert records == []
+
+    def test_normalise_empty_input(self):
+        records = self.collector.normalise([])
+        assert records == []
+
+
+class TestGRDCFetchRaw:
+    def setup_method(self):
+        self.collector = GRDCCollector()
+
+    def test_fetch_raw_invalid_source_type(self):
+        try:
+            self.collector.fetch_raw(source_type="bogus")
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            assert "source_type" in str(exc)
+
+    def test_fetch_raw_no_files_in_zenodo_record(self, monkeypatch):
+        mock_client = MagicMock()
+        mock_client.get_json.return_value = {"files": []}
+        collector = GRDCCollector(client=mock_client)
+        result = collector.fetch_raw(source_type="in_situ")
+        assert result == []
+
+    def test_fetch_raw_no_csv_in_darus_dataset(self):
+        mock_client = MagicMock()
+        mock_client.get_json.return_value = {"data": {"latestVersion": {"files": []}}}
+        collector = GRDCCollector(client=mock_client)
+        result = collector.fetch_raw(source_type="satellite")
+        assert result == []
+
+
+class TestGRDCParseStationFile:
+    def test_parses_metadata_and_rows(self):
+        rows = GRDCCollector._parse_grdc_station_file(STATION_FILE_TEXT, "6435060_Q_Day.Cmd.txt")
+        # The -999 sentinel row should be dropped
+        assert len(rows) == 2
+        assert rows[0]["station_id"] == "6435060"
+        assert rows[0]["station_name"] == "TEST STATION ON RIVER"
+        assert rows[0]["latitude"] == 51.234
+        assert rows[0]["discharge"] == 45.2
+        assert rows[0]["source_type"] == "in_situ"
+
+    def test_drops_negative_sentinel_values(self):
+        rows = GRDCCollector._parse_grdc_station_file(STATION_FILE_TEXT, "6435060_Q_Day.Cmd.txt")
+        discharges = [r["discharge"] for r in rows]
+        assert all(d >= 0 for d in discharges)
+
+    def test_empty_text_returns_no_rows(self):
+        rows = GRDCCollector._parse_grdc_station_file("", "empty.txt")
+        assert rows == []

--- a/tests/test_io/test_interop.py
+++ b/tests/test_io/test_interop.py
@@ -17,9 +17,21 @@ from aquascope.io.interop import records_to_geodataframe, records_to_xarray
 from aquascope.schemas.water_data import (
     DataSource,
     GeoLocation,
+    StreamflowReading,
     WaterLevelReading,
     WaterQualitySample,
 )
+
+
+def _sf(station, dt, discharge, source_type="in_situ", loc=None):
+    return StreamflowReading(
+        source=DataSource.GRDC,
+        station_id=station,
+        reading_datetime=dt,
+        discharge_cms=discharge,
+        source_type=source_type,
+        location=loc,
+    )
 
 
 def _wq(station, dt, param, value, unit="mg/l", loc=None):
@@ -82,6 +94,31 @@ class TestRecordsToXarray:
         assert ds["water_level"].attrs.get("units") == "m"
         assert set(ds.dims) == {"time", "station_id"}
 
+    def test_streamflow_records(self):
+        ds = records_to_xarray(
+            [
+                _sf("6435060", datetime(2026, 1, 1), 45.2),
+                _sf("6435060", datetime(2026, 2, 1), 47.8),
+            ]
+        )
+        assert "discharge" in ds.data_vars
+        assert ds["discharge"].attrs.get("units") == "m3/s"
+        assert set(ds.dims) == {"time", "station_id"}
+
+    def test_streamflow_does_not_collide_with_water_level_branch(self):
+        # Regression test: StreamflowReading shares reading_datetime with
+        # WaterLevelReading, so discharge_cms must be checked first or this
+        # raises AttributeError trying to read r.water_level.
+        ds = records_to_xarray([_sf("6435060", datetime(2026, 1, 1), 45.2)])
+        assert "water_level" not in ds.data_vars
+        assert "discharge" in ds.data_vars
+
+    def test_streamflow_station_coords_present(self):
+        loc = GeoLocation(latitude=51.2, longitude=7.9)
+        ds = records_to_xarray([_sf("6435060", datetime(2026, 1, 1), 45.2, loc=loc)])
+        assert float(ds["lat"].sel(station_id="6435060")) == 51.2
+        assert float(ds["lon"].sel(station_id="6435060")) == 7.9
+
     def test_empty_input(self):
         ds = records_to_xarray([])
         assert len(ds.data_vars) == 0
@@ -110,8 +147,13 @@ class TestRecordsToGeoDataFrame:
         gdf = records_to_geodataframe(
             [
                 _wq("S1", datetime(2026, 1, 1), "DO", 8.5, loc=None),
-                _wq("S2", datetime(2026, 1, 1), "DO", 8.0,
-                    loc=GeoLocation(latitude=1.0, longitude=2.0)),
+                _wq(
+                    "S2",
+                    datetime(2026, 1, 1),
+                    "DO",
+                    8.0,
+                    loc=GeoLocation(latitude=1.0, longitude=2.0),
+                ),
             ]
         )
         assert len(gdf) == 2


### PR DESCRIPTION
Closes #95

## What this PR does
Adds `GRDCCollector`, fetching:
- In-situ gauge discharge from the GRDC/WMO Zenodo subset (no request-form gate)
- RSEG satellite discharge extension from DaRUS

Both normalise into a new `StreamflowReading` schema, tagged via `source_type`
("in_situ" vs "satellite") so downstream PUB work (#53) can filter.

SAEM (the second satellite extension) is a planned fast-follow, per the
scoping discussion on the issue.

## Changes
- `aquascope/schemas/water_data.py`: added `DataSource.GRDC` and `StreamflowReading`
- `aquascope/collectors/grdc.py`: new collector — Zenodo ZIP caching for in-situ
  (mirrors the existing gemstat.py pattern), Dataverse API for RSEG
- `aquascope/collectors/__init__.py`: registered `GRDCCollector`
- `tests/test_collectors/test_grdc.py`: 17 tests
- `docs/data_sources.md`: new GRDC entry

## Testing
Ran locally: 17/17 new tests pass, full `tests/test_collectors/` suite
179/180 passing (1 unrelated pre-existing failure needing `pyproj`).
`ruff check` and `ruff format --check` both clean.