### PR TITLE
fix(cli): register GRDC and repair the list-sources info table

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,12 +261,12 @@ Run `aquascope --help` for the full command list.
 
 ## 🌍 Data sources at a glance
 
-15 unified data sources spanning four regions:
+17 unified data sources spanning four regions:
 
 - 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies)
 - 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5, France Hub'Eau
 - 🌏 **Asia-Pacific** — Taiwan MOENV / WRA / Civil IoT / DataGov, Japan MLIT, Korea WAMIS
-- 🌐 **Global** — GEMStat (170 countries), UN SDG 6, OpenMeteo, FAO AQUASTAT, FAO WaPOR
+- 🌐 **Global** — GEMStat (170 countries), UN SDG 6, OpenMeteo, FAO AQUASTAT, FAO WaPOR, GRDC (river discharge)
 
 Full details, endpoints, and API-key requirements: [docs/data_sources.md](docs/data_sources.md). Want to add your country's water service? See [adding a data source](docs/guides/adding_data_source.md).
 

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -70,6 +70,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         CopernicusCollector,
         EUWFDCollector,
         GEMStatCollector,
+        GRDCCollector,
         HubeauHydrometrieCollector,
         JapanMLITCollector,
         KoreaWAMISCollector,
@@ -110,6 +111,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         "korea_wamis": lambda: KoreaWAMISCollector(),
         "india_wris": lambda: IndiaWRISCollector(),
         "hubeau_hydrometrie": lambda: HubeauHydrometrieCollector(),
+        "grdc": lambda: GRDCCollector(),
     }
 
     if source not in collector_map:
@@ -165,6 +167,11 @@ def cmd_collect(args: argparse.Namespace) -> None:
             kwargs["year"] = args.year
         if args.water_body_type:
             kwargs["water_body_type"] = args.water_body_type
+    if source == "grdc" and args.mode:
+        if args.mode not in ("in_situ", "satellite"):
+            logger.error("GRDC --mode must be 'in_situ' or 'satellite'; got '%s'.", args.mode)
+            sys.exit(1)
+        kwargs["source_type"] = args.mode
 
     records = collector.collect(**kwargs)
     if not records:
@@ -368,7 +375,12 @@ def cmd_list_sources(args: argparse.Namespace) -> None:
         "openmeteo": ("Open-Meteo", "Global", "ERA5 reanalysis, weather forecasts, GloFAS discharge", "https://open-meteo.com"),
         "copernicus": ("Copernicus CDS", "Global", "GloFAS river discharge forecasts", "https://cds.climate.copernicus.eu"),
         "wapor": ("FAO WaPOR", "Global", "Satellite ET, biomass, and water productivity", "https://www.fao.org/in-action/remote-sensing-for-water-productivity"),
-        "hubeau_hydrometrie": ("Hub'Eau", "France", "Hydrometrie", "https://hubeau.eaufrance.fr/api/v2/hydrometrie"),
+        "eu_wfd": ("EU WFD", "Europe", "Water Framework Directive status", "https://www.eea.europa.eu"),
+        "france_hubeau": ("Hub'Eau", "France", "River water level and discharge (hydrométrie)", "https://hubeau.eaufrance.fr/api/v2/hydrometrie"),
+        "grdc": ("GRDC", "Global", "River discharge: in-situ gauges + RSEG satellite estimates", "https://zenodo.org/records/19126732"),
+        "japan_mlit": ("Japan MLIT", "Japan", "Hydrometeorology, river observations", "https://www.mlit.go.jp"),
+        "korea_wamis": ("Korea WAMIS", "Korea", "Hydrology, dam operations", "https://www.wamis.go.kr"),
+        "india_wris": ("India WRIS", "India", "River water level", "https://indiawris.gov.in"),
     }
 
     for src in DataSource:
@@ -915,7 +927,8 @@ def main() -> None:
             "taiwan_moenv", "taiwan_wra_level", "taiwan_wra_reservoir",
             "taiwan_wra_fhy", "taiwan_wra_iot", "taiwan_datagov",
             "usgs", "sdg6", "gemstat", "aquastat", "taiwan_civil_iot", "wqp",
-            "openmeteo", "copernicus", "wapor", "eu_wfd", "hubeau_hydrometrie"
+            "openmeteo", "copernicus", "wapor", "eu_wfd", "hubeau_hydrometrie",
+            "japan_mlit", "korea_wamis", "grdc",
         ],
         help="Data source to collect from",
     )
@@ -925,7 +938,7 @@ def main() -> None:
     p_collect.add_argument("--countries", default=None, help="ISO3 country codes, comma-separated (SDG6)")
     p_collect.add_argument("--state", default=None, help="US state code e.g. US:06 (WQP)")
     p_collect.add_argument("--variables", default=None, help="Comma-separated variable IDs (AQUASTAT)")
-    p_collect.add_argument("--mode", default=None, help="Collector mode (openmeteo: weather/forecast/flood)")
+    p_collect.add_argument("--mode", default=None, help="Collector mode (openmeteo: weather/forecast/flood; grdc: in_situ/satellite)")
     p_collect.add_argument("--bbox", default=None, help="Bounding box west,south,east,north (WaPOR)")
     p_collect.add_argument("--variable", default=None, help="Variable code for the selected collector (WaPOR)")
     p_collect.add_argument("--lat", type=float, default=None, help="Latitude (openmeteo/copernicus)")

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -39,6 +39,7 @@ class DataSource(str, Enum):
     HUBEAU = "france_hubeau"
     GRDC = "grdc"
 
+
 class GeoLocation(BaseModel):
     """Geographic coordinates for a monitoring station or sample point."""
 
@@ -123,6 +124,7 @@ class SDG6Indicator(BaseModel):
     unit: str | None = None
     series_code: str | None = None
 
+
 class StreamflowReading(BaseModel):
     """A single river discharge (streamflow) observation."""
 
@@ -132,11 +134,7 @@ class StreamflowReading(BaseModel):
     location: GeoLocation | None = None
     reading_datetime: datetime
     discharge_cms: float = Field(..., description="Discharge in cubic meters per second")
-    source_type: str = Field(
-        ..., description="'in_situ' (gauge) or 'satellite' (remote sensing estimate)"
-    )
-    uncertainty_cms: float | None = Field(
-        None, description="Estimated uncertainty, satellite products only"
-    )
+    source_type: str = Field(..., description="'in_situ' (gauge) or 'satellite' (remote sensing estimate)")
+    uncertainty_cms: float | None = Field(None, description="Estimated uncertainty, satellite products only")
     unit: str = "m3/s"
     remark: str | None = None

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,6 +1,6 @@
 # Data Sources
 
-AquaScope ships **20 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
+AquaScope ships **21 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
 
 Most sources emit point observations and share the unified `water_data` schema (`WaterQualitySample`, `WaterLevelReading`, `ReservoirStatus`). Three aggregate/gridded sources use purpose-built record types that match their data shape: **FAO AQUASTAT** returns country-level `AquastatRecord`, **UN SDG 6** returns `SDG6Indicator`, and **FAO WaPOR** returns gridded `WaPORObservation`.
 
@@ -32,6 +32,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | [Japan MLIT](https://www.mlit.go.jp) | Japan | Hydrometeorology, river observations | REST | ✅ |
 | [Korea WAMIS](https://www.wamis.go.kr) | Korea | Hydrology, dam operations | REST | ✅ |
 | [India WRIS](https://indiawris.gov.in) | India | River water level | REST | ✅ |
+| [GRDC](https://zenodo.org/records/19126732) | Global | River discharge (in-situ gauges + RSEG satellite) | Zenodo / Dataverse | ✅ |
 
 ---
 
@@ -87,4 +88,10 @@ from aquascope.collectors import GRDCCollector
 collector = GRDCCollector()
 in_situ = collector.collect(source_type="in_situ")
 satellite = collector.collect(source_type="satellite")
+```
+
+From the CLI:
+```bash
+aquascope collect --source grdc                    # in-situ gauges (default)
+aquascope collect --source grdc --mode satellite   # RSEG satellite estimates
 ```

--- a/tests/test_cli/test_source_registry.py
+++ b/tests/test_cli/test_source_registry.py
@@ -1,0 +1,59 @@
+"""Tests that the CLI's source registries stay in sync.
+
+The ``--source`` choices, the collector map, and the ``list-sources`` info table
+are three hand-maintained lists that have drifted apart before: a collector
+could be registered in ``collectors/__init__.py`` yet be unreachable from the
+CLI, and an info entry keyed by anything other than its ``DataSource`` value
+silently rendered as a placeholder.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+import pytest
+
+from aquascope.cli import cmd_list_sources, main
+from aquascope.schemas.water_data import DataSource
+
+# Sources with a working collector reachable from `aquascope collect`.
+# GRACE and USGS_GW are declared in DataSource but have no collector yet, and
+# India WRIS needs required arguments the collect command does not pass.
+CLI_SOURCES = (
+    "grdc",
+    "hubeau_hydrometrie",
+    "japan_mlit",
+    "korea_wamis",
+)
+
+
+@pytest.mark.parametrize("source", CLI_SOURCES)
+def test_source_is_a_valid_collect_choice(source, capsys, monkeypatch):
+    """Every registered collector is reachable from `aquascope collect`."""
+    monkeypatch.setattr(sys, "argv", ["aquascope", "collect", "--source", "__nonexistent__"])
+    with pytest.raises(SystemExit):
+        main()
+    err = capsys.readouterr().err
+    assert source in err, f"'{source}' is not an `aquascope collect --source` choice"
+
+
+def test_list_sources_renders_metadata_for_grdc_and_hubeau(capsys):
+    """The two sources added in 0.8.x render real metadata, not placeholders."""
+    cmd_list_sources(argparse.Namespace())
+    out = capsys.readouterr().out
+
+    assert "GRDC" in out
+    assert "Hub'Eau" in out
+    # The info table is keyed by DataSource.value; a mismatched key falls back
+    # to printing the raw enum value alongside em-dash placeholders.
+    assert DataSource.HUBEAU.value not in out
+    assert DataSource.GRDC.value not in out
+
+
+def test_grdc_rejects_an_unknown_mode(monkeypatch):
+    """GRDC's --mode maps to source_type and only accepts its two values."""
+    monkeypatch.setattr(sys, "argv", ["aquascope", "collect", "--source", "grdc", "--mode", "bogus"])
+    with pytest.raises(SystemExit) as exc:
+        main()
+    assert exc.value.code == 1


### PR DESCRIPTION
Pre-release cleanup found while cutting 0.8.1. The two collectors that landed since 0.8.0 (France Hub'Eau #96, GRDC #102) are both partly invisible from the CLI.

## The problem

`--source` choices, the `collect` collector map, and the `list-sources` info table are three hand-maintained lists that have drifted apart. On current `main`, **8 of 22 sources render as placeholders**:

```
  france_hubeau              grdc
    Region : —                 Region : —
    Data   : —                 Data   : —
    URL    : —                 URL    : —
```

Root causes, all distinct:

1. **Hub'Eau's info entry never matched.** It was keyed `"hubeau_hydrometrie"`, but `list-sources` looks up by `DataSource.value`, which is `"france_hubeau"`. The entry was dead on arrival.
2. **GRDC was never wired into the CLI.** #102 registered it in `collectors/__init__.py` and documented it, but added no `collect` entry, so it was Python-import-only.
3. **`japan_mlit` / `korea_wamis` were unreachable.** Both sat in the collector map but were missing from the argparse `choices`, so `--source japan_mlit` was rejected as an invalid choice.

## Changes

- Key the info table by `DataSource.value`; add entries for GRDC, EU WFD, Japan MLIT, Korea WAMIS, India WRIS.
- Wire `GRDCCollector` into `collect`. `--mode` selects `in_situ` (default) or `satellite`, matching how openmeteo already uses `--mode`.
- Add `japan_mlit`, `korea_wamis`, `grdc` to `--source` choices.
- README: add GRDC, and correct the source count (it said 15 but has listed 16 since France landed; now 17).
- docs: add GRDC to the source table (it was documented in prose only) and show CLI usage.
- Reformat `water_data.py`.

## Not fixed here

- **GRACE / USGS_GW still render blank.** Both are declared in `DataSource` with no collector and zero references anywhere in the codebase. Advertising them in `list-sources` looks wrong, but whether to implement, mark as planned, or drop them is a roadmap call, not a release fix.
- **India WRIS stays out of `--source`.** Its `fetch_raw` requires five positional args (`state_name`, `district_name`, `agency_name`, `startdate`, `enddate`) that `collect` does not pass, so exposing it needs new flags. Its info entry is fixed, so it no longer renders blank.

## Why CI did not catch this

`ci.yml` runs `ruff check` but never `ruff format --check`, which is how #102's `water_data.py` drift slipped through. (`cli.py` was already drifted at v0.8.0 and is reformatted here.) There were also **no tests for `cli.py` at all**.

## Testing

Adds `tests/test_cli/`. Verified the tests fail against the unfixed `cli.py` (5 of 6 fail) and pass with the fix. Full suite: **1006 passed, 9 skipped**. `ruff check` and `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSdSmz67W8UtBNTSmUQAxM