### PR TITLE
release: 0.8.1 — France Hub'Eau and GRDC discharge, CLI source repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,55 @@ All notable changes to AquaScope are documented here.
 
 ### Fixed
 
+## [0.8.1] - 2026-07-17
+
+Two new river-discharge sources, France (Hub'Eau) and GRDC, and a repair to how
+the CLI advertises and reaches its collectors.
+
+### Added
+- **France (Hub'Eau)** (`collectors/france_hubeau.py`): `HubeauHydrometrieCollector`
+  collects real-time river water level and discharge from Hub'Eau's Hydrométrie
+  API, France's national open hydrometry service. No API key required. Available
+  as `aquascope collect --source hubeau_hydrometrie`. Readings are emitted as
+  `WaterQualitySample`, following the pattern already established in `usgs.py`.
+- **GRDC river discharge** (`collectors/grdc.py`): `GRDCCollector` reaches global
+  river discharge without the classic GRDC portal's email request-form gate. Two
+  modes: `in_situ` (the curated gauge-station subset published on Zenodo) and
+  `satellite` (the RSEG remote-sensing discharge extension published on DaRUS).
+  Each reading is tagged with `source_type`, so downstream work such as
+  Prediction in Ungauged Basins can filter gauge from satellite. Note that the
+  in-situ subset is licensed CC BY-NC 4.0: non-commercial use only, attribution
+  required. Available as `aquascope collect --source grdc`, with `--mode`
+  selecting `in_situ` (default) or `satellite`.
+- **`StreamflowReading` schema** (`schemas/water_data.py`): the canonical record
+  for river discharge, carrying `discharge_cms`, `source_type`, and an optional
+  `uncertainty_cms` for satellite products. `records_to_xarray()` converts it to
+  a `discharge` data variable alongside the existing sample and water-level
+  record types.
+
+### Fixed
+- **`aquascope list-sources` rendered 8 of 22 sources as blank placeholders.**
+  The info table is keyed by `DataSource` value, but the Hub'Eau entry was keyed
+  `hubeau_hydrometrie` while its enum value is `france_hubeau`, so the lookup
+  never matched. GRDC, EU WFD, Japan MLIT, Korea WAMIS, and India WRIS had no
+  entry at all. All now render their region, data types, and endpoint.
+- **`GRDCCollector` was unreachable from the CLI.** It was registered in
+  `collectors/__init__.py` and documented, but had no `collect` entry, leaving it
+  importable from Python only.
+- **`japan_mlit` and `korea_wamis` were unreachable from the CLI.** Both were
+  already in the collector map but missing from the `--source` choices, so
+  argparse rejected them as invalid.
+
+### Notes
+- River discharge is currently emitted under two schemas: GRDC uses the new
+  `StreamflowReading`, while Hub'Eau and USGS use `WaterQualitySample`.
+  Consolidating on `StreamflowReading` is planned and will be a breaking change
+  for those collectors when it lands.
+- `GRACE` and `USGS_GW` are declared in `DataSource` but have no collector yet,
+  and still list without metadata.
+- India WRIS is not exposed through `aquascope collect`: its collector requires
+  arguments the command does not pass. It remains available from Python.
+
 ## [0.8.0] - 2026-07-10
 
 Groundwater drought: daily Taiwan groundwater data, SGI and SPI drought

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Abdoul Rachid
     orcid: "https://orcid.org/0000-0002-4616-4153"
     affiliation: "National Central University, Taiwan"
-version: 0.8.0
-date-released: "2026-07-10"
+version: 0.8.1
+date-released: "2026-07-17"
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
 url: https://rekin226.github.io/aquascope
@@ -55,8 +55,8 @@ preferred-citation:
     - family-names: Ouédraogo
       given-names: Abdoul Rachid
       orcid: "https://orcid.org/0000-0002-4616-4153"
-  version: 0.8.0
-  date-released: "2026-07-10"
+  version: 0.8.1
+  date-released: "2026-07-17"
   license: MIT
   repository-code: https://github.com/Rekin226/aquascope
   url: https://rekin226.github.io/aquascope

--- a/aquascope/__init__.py
+++ b/aquascope/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"
 __author__ = "AquaScope Contributors"
 __license__ = "MIT"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aquascope"
-version = "0.8.0"
+version = "0.8.1"
 description = "Open-source water data aggregation toolkit with AI-powered research methodology recommendations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Cuts 0.8.1. Version bump, changelog, and citation metadata only — no library code changes.

## What's in this release

Two new river-discharge sources landed since 0.8.0, plus the CLI repair from #105 that makes them actually reachable.

- **France (Hub'Eau)** (#96) — real-time river level and discharge from France's national open hydrometry API, no key required.
- **GRDC** (#102) — global river discharge, both in-situ gauges (Zenodo) and RSEG satellite estimates (DaRUS), bypassing the classic GRDC portal's request-form gate. Introduces the `StreamflowReading` schema.
- **CLI source repair** (#105) — `list-sources` was rendering 8 of 22 sources blank, and GRDC / `japan_mlit` / `korea_wamis` were unreachable from `collect`.

## Files touched

| File | Change |
| :--- | :--- |
| `pyproject.toml` | `version = "0.8.1"` |
| `aquascope/__init__.py` | `__version__ = "0.8.1"` |
| `CHANGELOG.md` | Roll `[Unreleased]` → `[0.8.1] - 2026-07-17`, fresh `[Unreleased]` above |
| `CITATION.cff` | `version` + `date-released`, both blocks (top-level and `preferred-citation`) |

`paper.md` is deliberately **not** touched: it is pinned at v0.7.0 for the JOSS submission, and this release is not paper-linked (0.8.0 left it alone for the same reason).

## Called out in the changelog

Rather than papered over, since they affect users:

- **Discharge ships under two schemas.** GRDC uses the new `StreamflowReading`; Hub'Eau and USGS use `WaterQualitySample`. Consolidating is a breaking change and wants its own minor release.
- **GRDC in-situ data is CC BY-NC 4.0** — non-commercial only, attribution required. Worth knowing before it goes in a pipeline.
- **GRACE / USGS_GW** are declared in `DataSource` with no collector and still list without metadata.
- **India WRIS** is Python-only; its collector needs arguments `collect` does not pass.

## Verification

- Version consistent across all four references; `aquascope.__version__` reports `0.8.1`.
- `CITATION.cff` parses; both blocks read 0.8.1 / 2026-07-17.
- Full suite: **1006 passed, 9 skipped**. `ruff check` clean.

## After merge

Publishing is the maintainer's step: creating the GitHub Release (`AquaScope v0.8.1`, tag `v0.8.1`) triggers `publish.yml` → PyPI via trusted publishing. If the `pypi` environment has required reviewers, it will wait on your approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QSdSmz67W8UtBNTSmUQAxM