### PR TITLE
docs: reconcile source counts to 22 + CI drift guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ---
 
-AquaScope unifies **20 global water-data sources** behind one Python schema, then layers a full scientific computing stack on top — from **Bulletin 17C flood frequency** to **FAO-56 crop water requirements** — wrapped in an AI engine that scores **26 research methodologies** against your dataset and auto-executes **7 analysis pipelines**. Validated against the CAMELS benchmark with 820+ tests.
+AquaScope unifies **22 global water-data sources** behind one Python schema, then layers a full scientific computing stack on top — from **Bulletin 17C flood frequency** to **FAO-56 crop water requirements** — wrapped in an AI engine that scores **26 research methodologies** against your dataset and auto-executes **7 analysis pipelines**. Validated against the CAMELS benchmark with 820+ tests.
 
 ---
 
@@ -55,7 +55,7 @@ For the full capability list see [docs/features.md](docs/features.md).
 | Non-stationary GEV | ✅ | — | partial | — |
 | Baseflow separation (Lyne-Hollick, Eckhardt) | ✅ | — | — | — |
 | FAO-56 Penman-Monteith ET₀ + crop water | ✅ | — | — | — |
-| 15 unified data collectors | ✅ | — | — | per-source |
+| 22 unified data collectors | ✅ | — | — | per-source |
 | AI methodology recommender (OpenAI / Groq / HF / Ollama) | ✅ | — | — | — |
 | Interactive Streamlit dashboard | ✅ | — | — | — |
 | Free, MIT, Python-native | ✅ | partial | ✅ | varies |
@@ -123,7 +123,7 @@ print(sig["flashiness"])       # Richards-Baker flashiness index
 
 22 signatures across magnitude, variability, timing, recession, and flashiness — see [docs/features.md](docs/features.md#hydrological-analysis).
 
-### 3. Collect data from any of the 20 sources
+### 3. Collect data from any of the 22 sources
 
 ```python
 from aquascope.collectors import USGSCollector, AquastatCollector, WaporCollector
@@ -264,7 +264,7 @@ Run `aquascope --help` for the full command list.
 
 ## 🌍 Data sources at a glance
 
-18 unified data sources spanning four regions:
+22 data collectors spanning four regions (highlights below, full list in the [docs](docs/data_sources.md)):
 
 - 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies), CAMELS-CL (Chile streamflow)
 - 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5, France Hub'Eau
@@ -289,7 +289,7 @@ Full details, endpoints, and API-key requirements: [docs/data_sources.md](docs/d
 | Resource | What it covers |
 | :--- | :--- |
 | [Features](docs/features.md) | Full capability list — hydrology, agriculture, ML, spatial, I/O |
-| [Data sources](docs/data_sources.md) | All 20 sources, endpoints, API-key requirements |
+| [Data sources](docs/data_sources.md) | All 22 sources, endpoints, API-key requirements |
 | [Theory guide](docs/theory.md) | Equations, DOI citations, decision trees for every method |
 | [Methodology matrix](docs/methodology_matrix.md) | When to use which method |
 | [Architecture](docs/guides/architecture.md) | How AquaScope is structured internally |

--- a/docs/guides/adding_data_source.md
+++ b/docs/guides/adding_data_source.md
@@ -118,8 +118,8 @@ Create `tests/test_collectors/test_your_source.py` with:
 
 ## Guidelines
 
-- **Use `CachedHTTPClient`** — It provides caching and rate limiting out of the box
+- **Use `CachedHTTPClient`** — It provides caching and rate limiting out of the box. Exception: one-time bulk-download sources (a single static archive rather than a paginated API, e.g. `grdc.py`, `camels_cl.py`) skip it and stream the file into `data/cache/` instead — see those collectors for the pattern
 - **Handle errors gracefully** — Skip invalid records with `logger.debug()`, don't crash
 - **Include geographic data** — Set `GeoLocation` when lat/lon are available
-- **Respect rate limits** — Configure `RateLimiter` based on the API's actual limits
+- **Respect rate limits** — Configure `RateLimiter` based on the API's actual limits (not applicable to bulk downloads)
 - **Document the API** — Include the API docs URL and any key requirements

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -1,0 +1,45 @@
+"""Guard against collector-count drift between the docs table and every
+place the count is stated in prose (see issue #117).
+
+The canonical count is the number of rows in the data-sources table in
+docs/data_sources.md; every hand-written mention must match it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+README_PATTERNS = [
+    r"unifies \*\*(\d+) global water-data sources\*\*",
+    r"\| (\d+) unified data collectors \|",
+    r"any of the (\d+) sources",
+    r"(\d+) data collectors spanning four regions",
+    r"All (\d+) sources",
+]
+
+
+def _table_row_count() -> int:
+    text = (ROOT / "docs" / "data_sources.md").read_text(encoding="utf-8")
+    return len(re.findall(r"^\| \[", text, flags=re.MULTILINE))
+
+
+def test_docs_intro_count_matches_table():
+    text = (ROOT / "docs" / "data_sources.md").read_text(encoding="utf-8")
+    match = re.search(r"\*\*(\d+) collectors\*\*", text)
+    assert match is not None, "count sentence missing from docs/data_sources.md intro"
+    assert int(match.group(1)) == _table_row_count()
+
+
+def test_readme_counts_match_table():
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+    expected = _table_row_count()
+    for pattern in README_PATTERNS:
+        match = re.search(pattern, text)
+        assert match is not None, f"README no longer contains the phrase for {pattern!r}"
+        assert int(match.group(1)) == expected, (
+            f"README says {match.group(1)} for {pattern!r} but the "
+            f"docs/data_sources.md table has {expected} rows"
+        )


### PR DESCRIPTION
Rebased onto main after #116 and expanded to cover #117.

## The problem

The collector count was stated in six places with four different numbers (README headline 20, feature table 15, quickstart 20, at-a-glance 17, resources table 20, docs intro 22). Every new collector PR bumps whichever number the contributor happens to touch, so the drift compounds; @adjenk flagged it independently in #116.

## The fix

- Canonical count = the `docs/data_sources.md` table, which is self-evidently countable: **22 rows** post CAMELS-CL (7 Taiwan sources + 15 others). All five README mentions now say 22; the docs intro already did.
- New `tests/test_docs_counts.py` asserts every hand-written mention matches the table row count, so CI fails on the next drift instead of letting it compound.
- The adding-a-data-source guidelines now note that one-time bulk-download sources (`grdc.py`, `camels_cl.py`) intentionally skip `CachedHTTPClient`/`RateLimiter` and stream into `data/cache/` instead (the other item @adjenk flagged in #116).

Note: 22 counts *sources* (table rows). The registry exports 24 collector classes across 21 modules; the user-facing number follows the table.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nURygQXfEnjk5KWXewHxp
