### PR TITLE
Add CAMELS-CL (Chile) streamflow collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,9 +264,9 @@ Run `aquascope --help` for the full command list.
 
 ## 🌍 Data sources at a glance
 
-17 unified data sources spanning four regions:
+18 unified data sources spanning four regions:
 
-- 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies)
+- 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies), CAMELS-CL (Chile streamflow)
 - 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5, France Hub'Eau
 - 🌏 **Asia-Pacific** — Taiwan MOENV / WRA / Civil IoT / DataGov, Japan MLIT, Korea WAMIS
 - 🌐 **Global** — GEMStat (170 countries), UN SDG 6, OpenMeteo, FAO AQUASTAT, FAO WaPOR, GRDC (river discharge)

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -67,6 +67,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
     """Run a data collector and save results."""
     from aquascope.collectors import (
         AquastatCollector,
+        CAMELSCLCollector,
         CopernicusCollector,
         EUWFDCollector,
         GEMStatCollector,
@@ -112,6 +113,7 @@ def cmd_collect(args: argparse.Namespace) -> None:
         "india_wris": lambda: IndiaWRISCollector(),
         "hubeau_hydrometrie": lambda: HubeauHydrometrieCollector(),
         "grdc": lambda: GRDCCollector(),
+        "camels_cl": lambda: CAMELSCLCollector(),
     }
 
     if source not in collector_map:
@@ -172,7 +174,13 @@ def cmd_collect(args: argparse.Namespace) -> None:
             logger.error("GRDC --mode must be 'in_situ' or 'satellite'; got '%s'.", args.mode)
             sys.exit(1)
         kwargs["source_type"] = args.mode
-
+    if source == "camels_cl":
+        if args.station_ids:
+            kwargs["station_ids"] = [s.strip() for s in args.station_ids.split(",") if s.strip()]
+        if args.start_date:
+            kwargs["start"] = args.start_date
+        if args.end_date:
+            kwargs["end"] = args.end_date
     records = collector.collect(**kwargs)
     if not records:
         logger.warning("No records collected.")
@@ -928,7 +936,7 @@ def main() -> None:
             "taiwan_wra_fhy", "taiwan_wra_iot", "taiwan_datagov",
             "usgs", "sdg6", "gemstat", "aquastat", "taiwan_civil_iot", "wqp",
             "openmeteo", "copernicus", "wapor", "eu_wfd", "hubeau_hydrometrie",
-            "japan_mlit", "korea_wamis", "grdc",
+            "japan_mlit", "korea_wamis", "grdc", "camels_cl",
         ],
         help="Data source to collect from",
     )
@@ -949,6 +957,7 @@ def main() -> None:
     p_collect.add_argument("--end-year", type=int, default=2023, help="End year (AQUASTAT)")
     p_collect.add_argument("--format", default="json", choices=["json", "csv", "geojson"], help="Output format")
     p_collect.add_argument("--year", type=int, default=None, help="Year filter (EU WFD)")
+    p_collect.add_argument("--station-ids", default=None, help="Comma-separated gauge codes to filter (camels_cl)")
     p_collect.add_argument(
         "--water-body-type", default=None,
         choices=["river", "lake", "groundwater"],

--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -2,6 +2,7 @@
 
 from aquascope.collectors.aquastat import AquastatCollector
 from aquascope.collectors.base import BaseCollector
+from aquascope.collectors.camels_cl import CAMELSCLCollector
 from aquascope.collectors.copernicus import CopernicusCollector
 from aquascope.collectors.eu_wfd import EUWFDCollector
 from aquascope.collectors.france_hubeau import HubeauHydrometrieCollector
@@ -30,6 +31,7 @@ from aquascope.collectors.wqp import WQPCollector
 __all__ = [
     "AquastatCollector",
     "BaseCollector",
+    "CAMELSCLCollector",
     "CopernicusCollector",
     "EUWFDCollector",
     "GEMStatCollector",

--- a/aquascope/collectors/camels_cl.py
+++ b/aquascope/collectors/camels_cl.py
@@ -1,0 +1,169 @@
+"""
+Collector for the CAMELS-CL (Catchment Attributes and Meteorology for Large
+Sample Studies - Chile) dataset, published by CR2 (Centro de Ciencia del
+Clima y la Resiliencia).
+
+CAMELS-CL provides daily observed streamflow (compiled from DGA gauge
+records) for 516 catchments in Chile, along with catchment attributes
+(area, coordinates, etc.) and meteorological forcing data.
+
+References
+----------
+- Dataset landing page: https://www.cr2.cl/camels-cl/
+- Interactive explorer: https://camels.cr2.cl/
+- Alvarez-Garreton et al. (2018), HESS: https://doi.org/10.5194/hess-22-5817-2018
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Sequence
+from datetime import datetime
+from pathlib import Path
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.schemas.water_data import DataSource, GeoLocation, StreamflowReading
+
+logger = logging.getLogger(__name__)
+
+CAMELS_CL_DOWNLOAD_URL = "https://www.cr2.cl/download/camels-cl-v202201/?wpdmdl=35317"
+
+
+class CAMELSCLCollector(BaseCollector):
+    """Collect CAMELS-CL observed daily streamflow (q_m3s_day.csv) records."""
+
+    name = "camels_cl"
+
+    def fetch_raw(
+        self,
+        station_ids: list[str] | None = None,
+        start: str | None = None,
+        end: str | None = None,
+        **kwargs,
+    ) -> list[dict]:
+        """
+        Fetch CAMELS-CL streamflow records, optionally filtered.
+
+        Parameters
+        ----------
+        station_ids : list[str], optional
+            Restrict to specific gauge codes (e.g. ["1001001", "12825002"]).
+            Filtering happens before the wide-to-long melt, so this keeps
+            memory bounded — unlike loading all ~500 stations at once.
+        start, end : str, optional
+            ISO date strings ("YYYY-MM-DD") bounding the date range. Both
+            are inclusive. If omitted, no date filtering is applied.
+        """
+        return self._fetch_camels_cl(station_ids=station_ids, start=start, end=end)
+
+    def _fetch_camels_cl(
+        self,
+        station_ids: list[str] | None = None,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[dict]:
+        """
+        Download (and locally cache) the CAMELS-CL v202201 archive, parse the
+        daily observed streamflow file (q_m3s_day.csv, m3/s — no unit
+        conversion needed for StreamflowReading.discharge_cms), and join
+        station coordinates/area from catchment_attributes.csv.
+
+        station_ids/start/end are applied before melting to wide-to-long, to
+        avoid materialising the full ~5.9M-row dataset when the caller only
+        wants a subset.
+        """
+        import hashlib
+        import io
+        import zipfile
+
+        import httpx
+        import pandas as pd
+
+        cache_dir = Path("data/cache")
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_key = hashlib.md5(CAMELS_CL_DOWNLOAD_URL.encode()).hexdigest()
+        zip_path = cache_dir / f"camels_cl_{cache_key}.zip"
+
+        if not zip_path.exists():
+            logger.info("CAMELS-CL: downloading CAMELS_CL_v202201.zip (~275MB) — one-time download…")
+            with httpx.stream(
+                "GET", CAMELS_CL_DOWNLOAD_URL, follow_redirects=True, timeout=600,
+                headers={"User-Agent": "Mozilla/5.0"},
+            ) as resp:
+                resp.raise_for_status()
+                with zip_path.open("wb") as fh:
+                    for chunk in resp.iter_bytes(chunk_size=65_536):
+                        fh.write(chunk)
+        else:
+            logger.debug("CAMELS-CL: using cached archive %s", zip_path)
+
+        with zipfile.ZipFile(zip_path) as zf:
+            qobs_name = next(n for n in zf.namelist() if n.endswith("q_m3s_day.csv"))
+
+            # Only load the columns we need: date + requested stations (or
+            # all stations if none specified). Read the header first so we
+            # can pass usecols on the real read, avoiding ~500 station
+            # columns being loaded into memory when only a few are wanted.
+            with zf.open(qobs_name) as fh:
+                header = pd.read_csv(io.BytesIO(fh.read()), nrows=0).columns.tolist()
+
+            station_cols = [c for c in header if c not in ("date", "year", "month", "day")]
+            if station_ids is not None:
+                wanted = set(station_ids)
+                station_cols = [c for c in station_cols if c in wanted]
+                missing = wanted - set(station_cols)
+                if missing:
+                    logger.warning("CAMELS-CL: station_ids not found in dataset: %s", missing)
+
+            usecols = ["date", *station_cols]
+            with zf.open(qobs_name) as fh:
+                df = pd.read_csv(io.BytesIO(fh.read()), na_values=["NA"], usecols=usecols)
+
+            attrs_name = next(n for n in zf.namelist() if n.endswith("catchment_attributes.csv"))
+            with zf.open(attrs_name) as fh:
+                attrs = pd.read_csv(
+                    io.BytesIO(fh.read()),
+                    na_values=["NA"],
+                    dtype={"gauge_id": str},
+                    usecols=["gauge_id", "gauge_name", "gauge_lat", "gauge_lon", "area_km2"],
+                )
+
+        if start is not None:
+            df = df[df["date"] >= start]
+        if end is not None:
+            df = df[df["date"] <= end]
+
+        long_df = df.melt(id_vars="date", var_name="station_id", value_name="discharge")
+        long_df = long_df.dropna(subset=["discharge"])
+        long_df["station_id"] = long_df["station_id"].astype(str)
+
+        attrs["gauge_id"] = attrs["gauge_id"].astype(str)
+        merged = long_df.merge(attrs, left_on="station_id", right_on="gauge_id", how="left")
+
+        raw = merged.to_dict("records")
+        for row in raw:
+            row["date"] = str(row["date"])[:10]
+        return raw
+
+    def normalise(self, raw: list[dict]) -> Sequence[StreamflowReading]:
+        records: list[StreamflowReading] = []
+        for row in raw:
+            try:
+                lat = row.get("gauge_lat")
+                lon = row.get("gauge_lon")
+                loc = GeoLocation(latitude=float(lat), longitude=float(lon)) if lat and lon else None
+                records.append(
+                    StreamflowReading(
+                        source=DataSource.CAMELS_CL,
+                        station_id=str(row["station_id"]),
+                        station_name=row.get("gauge_name"),
+                        location=loc,
+                        reading_datetime=datetime.fromisoformat(row["date"]),
+                        discharge_cms=float(row["discharge"]),
+                        source_type="in_situ",
+                        catchment_area_km2=row.get("area_km2"),
+                    )
+                )
+            except (ValueError, KeyError, TypeError) as exc:
+                logger.debug("Skipping malformed CAMELS-CL record: %s", exc)
+        return records

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -38,7 +38,7 @@ class DataSource(str, Enum):
     INDIA_WRIS = "india_wris"
     HUBEAU = "france_hubeau"
     GRDC = "grdc"
-
+    CAMELS_CL = "camels_cl"
 
 class GeoLocation(BaseModel):
     """Geographic coordinates for a monitoring station or sample point."""

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,6 +1,6 @@
 # Data Sources
 
-AquaScope ships **21 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
+AquaScope ships **22 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
 
 Most sources emit point observations and share the unified `water_data` schema (`WaterQualitySample`, `WaterLevelReading`, `ReservoirStatus`). Three aggregate/gridded sources use purpose-built record types that match their data shape: **FAO AQUASTAT** returns country-level `AquastatRecord`, **UN SDG 6** returns `SDG6Indicator`, and **FAO WaPOR** returns gridded `WaPORObservation`.
 
@@ -33,6 +33,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | [Korea WAMIS](https://www.wamis.go.kr) | Korea | Hydrology, dam operations | REST | ✅ |
 | [India WRIS](https://indiawris.gov.in) | India | River water level | REST | ✅ |
 | [GRDC](https://zenodo.org/records/19126732) | Global | River discharge (in-situ gauges + RSEG satellite) | Zenodo / Dataverse | ✅ |
+| [CAMELS-CL](https://www.cr2.cl/camels-cl/) | Chile | Daily observed streamflow, catchment attributes | ZIP / CSV | ✅ |
 
 ---
 
@@ -52,6 +53,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | EU WFD | No | Open access |
 | Hub'Eau | No | Open access |
 | Japan MLIT / Korea WAMIS | No | Open access |
+| CAMELS-CL | No | Open access |
 
 ---
 

--- a/tests/test_collectors/test_camels_cl.py
+++ b/tests/test_collectors/test_camels_cl.py
@@ -1,0 +1,234 @@
+"""Tests for the CAMELS-CL (CR2, Chile) streamflow collector."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+from aquascope.collectors.camels_cl import CAMELSCLCollector
+from aquascope.schemas.water_data import DataSource
+
+SAMPLE_RAW = [
+    {
+        "station_id": "1001001",
+        "date": "1990-01-01",
+        "discharge": 12.5,
+        "gauge_name": "Rio Test En Nacimiento", # fake test river
+        "gauge_lat": -18.5,
+        "gauge_lon": -69.5,
+        "area_km2": 250.0,
+    },
+    {
+        "station_id": "12825002",
+        "date": "2011-06-13",
+        "discharge": 43.4,
+        "gauge_name": "Rio Azopardo En Desembocadura", # Azopardo River at the Mouth
+        "gauge_lat": -54.5028,
+        "gauge_lon": -68.8244,
+        "area_km2": 3524.5,
+    },
+]
+
+SAMPLE_RAW_MALFORMED = [
+    # Missing required "discharge" key
+    {
+        "station_id": "BAD01",
+        "date": "1990-01-01",
+        "gauge_name": "Bad Station",
+    },
+    # Non-numeric discharge value
+    {
+        "station_id": "BAD02",
+        "date": "1990-01-01",
+        "discharge": "not_a_number",
+    },
+]
+
+
+def _make_fake_zip() -> bytes:
+    """Build an in-memory ZIP mirroring CAMELS-CL's real archive layout:
+    a wide-format q_m3s_day.csv (date + one column per gauge, "NA" for
+    missing values) and a catchment_attributes.csv with gauge metadata.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "CAMELS_CL_v202201/q_m3s_day.csv",
+            '"date","year","month","day","1001001","12825002"\n'
+            "1990-01-01,1990,1,1,12.5,NA\n"
+            "1990-01-02,1990,1,2,NA,NA\n"
+            "2011-06-13,2011,6,13,NA,43.4\n",
+        )
+        zf.writestr(
+            "CAMELS_CL_v202201/catchment_attributes.csv",
+            '"gauge_id","gauge_name","gauge_lat","gauge_lon","area_km2"\n'
+            '"1001001","Rio Test En Nacimiento","-18.5","-69.5","250.0"\n'
+            '"12825002","Rio Azopardo En Desembocadura","-54.5028","-68.8244","3524.5"\n',
+        )
+    buf.seek(0)
+    return buf.read()
+
+
+class TestCAMELSCLInit:
+    def setup_method(self):
+        self.collector = CAMELSCLCollector()
+
+    def test_collector_name(self):
+        assert self.collector.name == "camels_cl"
+
+
+class TestCAMELSCLNormalise:
+    def setup_method(self):
+        self.collector = CAMELSCLCollector()
+
+    def test_normalise_produces_correct_count(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert len(records) == 2
+
+    def test_normalise_sets_correct_source(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        for r in records:
+            assert r.source == DataSource.CAMELS_CL
+
+    def test_normalise_tags_in_situ(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        for r in records:
+            assert r.source_type == "in_situ"
+
+    def test_normalise_parses_location(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        rec = records[0]
+        assert rec.location is not None
+        assert abs(rec.location.latitude - (-18.5)) < 0.001
+        assert abs(rec.location.longitude - (-69.5)) < 0.001
+
+    def test_normalise_discharge_value(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].discharge_cms == 12.5
+        assert records[0].unit == "m3/s"
+
+    def test_normalise_preserves_station_id(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].station_id == "1001001"
+
+    def test_normalise_carries_catchment_area(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].catchment_area_km2 == 250.0
+        assert records[1].catchment_area_km2 == 3524.5
+
+    def test_normalise_carries_station_name(self):
+        records = self.collector.normalise(SAMPLE_RAW)
+        assert records[0].station_name == "Rio Test En Nacimiento"
+
+    def test_normalise_skips_malformed_rows(self):
+        records = self.collector.normalise(SAMPLE_RAW_MALFORMED)
+        assert records == []
+
+    def test_normalise_empty_input(self):
+        records = self.collector.normalise([])
+        assert records == []
+
+    def test_normalise_missing_location_is_none(self):
+        raw = [
+            {
+                "station_id": "1001001",
+                "date": "1990-01-01",
+                "discharge": 12.5,
+                "gauge_lat": None,
+                "gauge_lon": None,
+            }
+        ]
+        records = self.collector.normalise(raw)
+        assert records[0].location is None
+
+
+class TestCAMELSCLFetchRaw:
+    def setup_method(self, method=None):
+        self.zip_bytes = _make_fake_zip()
+
+    def _patch_httpx_and_cache(self, monkeypatch, tmp_path):
+        """Route the (mocked) download straight into tmp_path's cache dir,
+        and short-circuit httpx.stream so no real network call happens."""
+        monkeypatch.chdir(tmp_path)
+
+        class FakeResponse:
+            def raise_for_status(self):
+                pass
+
+            def iter_bytes(self, chunk_size=65_536):
+                yield self.zip_bytes
+
+        class FakeStream:
+            def __init__(self, zip_bytes):
+                self.resp = FakeResponse()
+                self.resp.zip_bytes = zip_bytes
+
+            def __enter__(self):
+                return self.resp
+
+            def __exit__(self, *a):
+                return False
+
+        monkeypatch.setattr(
+            "httpx.stream", lambda *a, **kw: FakeStream(self.zip_bytes)
+        )
+
+    def test_fetch_raw_returns_all_stations_by_default(self, monkeypatch, tmp_path):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        raw = collector.fetch_raw()
+        station_ids = {row["station_id"] for row in raw}
+        assert station_ids == {"1001001", "12825002"}
+
+    def test_fetch_raw_drops_na_values(self, monkeypatch, tmp_path):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        raw = collector.fetch_raw()
+        # 3 dates x 2 stations = 6 cells, but 4 are "NA" -> only 2 real rows
+        assert len(raw) == 2
+
+    def test_fetch_raw_filters_by_station_ids(self, monkeypatch, tmp_path):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        raw = collector.fetch_raw(station_ids=["1001001"])
+        assert all(row["station_id"] == "1001001" for row in raw)
+        assert len(raw) == 1
+
+    def test_fetch_raw_filters_by_date_range(self, monkeypatch, tmp_path):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        raw = collector.fetch_raw(start="2000-01-01", end="2020-01-01")
+        assert len(raw) == 1
+        assert raw[0]["station_id"] == "12825002"
+
+    def test_fetch_raw_joins_catchment_attributes(self, monkeypatch, tmp_path):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        raw = collector.fetch_raw(station_ids=["1001001"])
+        row = raw[0]
+        assert row["gauge_name"] == "Rio Test En Nacimiento"
+        assert row["area_km2"] == 250.0
+
+    def test_fetch_raw_warns_on_unknown_station_id(self, monkeypatch, tmp_path, caplog):
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        collector.fetch_raw(station_ids=["9999999"])
+        assert any("9999999" in rec.message for rec in caplog.records)
+
+    def test_fetch_raw_uses_cached_archive_on_second_call(self, monkeypatch, tmp_path):
+        """After the first call populates data/cache/, a second call should
+        not invoke httpx.stream again."""
+        self._patch_httpx_and_cache(monkeypatch, tmp_path)
+        collector = CAMELSCLCollector()
+        collector.fetch_raw()
+
+        calls = {"count": 0}
+        original = __import__("httpx").stream
+
+        def counting_stream(*a, **kw):
+            calls["count"] += 1
+            return original(*a, **kw)
+
+        monkeypatch.setattr("httpx.stream", counting_stream)
+        collector.fetch_raw()
+        assert calls["count"] == 0


### PR DESCRIPTION
## Add CAMELS-CL (Chile) streamflow collector

Chile for #11 

### What this adds

- `CAMELSCLCollector` (`aquascope/collectors/camels_cl.py`) — collects daily
  observed streamflow for Chile from **CAMELS-CL** (CR2, Centro de Ciencia
  del Clima y la Resiliencia), scoped to the `q_m3s_day.csv` observed
  discharge file, joined with station name/coordinates/catchment area from
  `catchment_attributes.csv`.
- `DataSource.CAMELS_CL` enum entry (`aquascope/schemas/water_data.py`).
- Registered in `aquascope/collectors/__init__.py`.
- Wired into the CLI (`--source camels_cl`, plus `--station-ids`,
  `--start-date`, `--end-date` filters).
- Tests: `tests/test_collectors/test_camels_cl.py` — mocked HTTP/ZIP,
  covering `normalise()` correctness, malformed-row handling, and
  `fetch_raw()` filtering/caching behaviour.
- Docs: added to the source table in `README.md` and `docs/data_sources.md`.

### Data source details

- CAMELS-CL ships as a single ~275MB ZIP
  (`https://www.cr2.cl/download/camels-cl-v202201/?wpdmdl=35317`), not a
  paginated REST API; one-time download, cached locally afterward (same
  `data/cache/` pattern as `grdc.py`'s Zenodo/DaRUS downloads).
- Wide-format CSVs (one column per gauge, one row per date) are melted to
  long format, with `station_ids`/`start`/`end` filters applied **before**
  the melt to keep memory bounded. The full dataset is ~5.9M rows and
  melting/joining the whole thing at once is enough to OOM on a modest dev
  machine (confirmed while building this).
- `source_type` is hardcoded to `"in_situ"` since CAMELS-CL has no
  satellite/remote-sensing component (no `grdc`-style branching needed).
- `catchment_area_km2` is populated from `catchment_attributes.csv`, so the
  new area-normalized runoff (`mm/day`) support from #98/PR103 works for
  free with this source.

### Guidelines checklist (per the contributor guide)

- [x] Handle errors gracefully — `normalise()` skips malformed rows via
  `logger.debug()`, doesn't crash.
- [x] Include geographic data — `GeoLocation` set from `gauge_lat`/`gauge_lon`
  when available.
- [x] Document the API — see `docs/data_sources.md` entry.
- [ ] **`CachedHTTPClient` / `RateLimiter`** — **not used**, intentionally.
  CAMELS-CL isn't a paginated/rate-limited API; it's a single static bulk
  file download, cached to disk after the first fetch. These two
  guidelines seem written with a typical REST API in mind and may not map
  cleanly onto one-time bulk-download sources (GRDC's Zenodo/DaRUS fetches
  looked like a similar case). Flagging in case maintainer wants a
  different pattern here, or wants the guideline doc clarified for this
  category of source.

### Also noticed (unrelated to this PR, flagging for visibility)

The collector source count is inconsistent across docs and doesn't match
reality:
- `README.md` badge/intro text says "20 global water-data sources"
- `README.md`'s "Data sources at a glance" header says "17 unified data
  sources"
- `docs/data_sources.md` intro says "21 collectors"
- The actual table in `docs/data_sources.md` lists 20 rows (pre-this-PR)

I bumped the counts I directly touched (README section header, and
`docs/data_sources.md` intro) to stay consistent with the new addition, but
didn't try to reconcile all of them since that's a pre-existing issue
unrelated to this change.

### Testing

```
pytest tests/test_collectors/test_camels_cl.py -v
```
All passing locally. Also ran end-to-end via the real CLI against the
actual downloaded archive:
```
python -m aquascope collect --source camels_cl --station-ids 1001001,12825002 --start-date 2010-01-01 --end-date 2011-12-31
```

Linting:
```
ruff check aquascope tests/ --fix
```
All checks passed.