### PR TITLE
fix: keep CAMELS-CL records when catchment attrs are missing (NaN)

### DIFF
--- a/aquascope/collectors/camels_cl.py
+++ b/aquascope/collectors/camels_cl.py
@@ -17,6 +17,7 @@ References
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Sequence
 from datetime import datetime
 from pathlib import Path
@@ -27,6 +28,17 @@ from aquascope.schemas.water_data import DataSource, GeoLocation, StreamflowRead
 logger = logging.getLogger(__name__)
 
 CAMELS_CL_DOWNLOAD_URL = "https://www.cr2.cl/download/camels-cl-v202201/?wpdmdl=35317"
+
+
+def _clean(value):
+    """Map NaN (a gauge missing from the catchment_attributes.csv join) to None.
+
+    NaN is truthy, so without this it reaches the pydantic validators and the
+    resulting ValidationError silently drops the whole record in normalise().
+    """
+    if value is None or (isinstance(value, float) and math.isnan(value)):
+        return None
+    return value
 
 
 class CAMELSCLCollector(BaseCollector):
@@ -149,19 +161,23 @@ class CAMELSCLCollector(BaseCollector):
         records: list[StreamflowReading] = []
         for row in raw:
             try:
-                lat = row.get("gauge_lat")
-                lon = row.get("gauge_lon")
-                loc = GeoLocation(latitude=float(lat), longitude=float(lon)) if lat and lon else None
+                lat = _clean(row.get("gauge_lat"))
+                lon = _clean(row.get("gauge_lon"))
+                loc = (
+                    GeoLocation(latitude=float(lat), longitude=float(lon))
+                    if lat is not None and lon is not None
+                    else None
+                )
                 records.append(
                     StreamflowReading(
                         source=DataSource.CAMELS_CL,
                         station_id=str(row["station_id"]),
-                        station_name=row.get("gauge_name"),
+                        station_name=_clean(row.get("gauge_name")),
                         location=loc,
                         reading_datetime=datetime.fromisoformat(row["date"]),
                         discharge_cms=float(row["discharge"]),
                         source_type="in_situ",
-                        catchment_area_km2=row.get("area_km2"),
+                        catchment_area_km2=_clean(row.get("area_km2")),
                     )
                 )
             except (ValueError, KeyError, TypeError) as exc:

--- a/tests/test_collectors/test_camels_cl.py
+++ b/tests/test_collectors/test_camels_cl.py
@@ -128,6 +128,30 @@ class TestCAMELSCLNormalise:
         records = self.collector.normalise([])
         assert records == []
 
+    def test_normalise_nan_attrs_record_survives(self):
+        # A gauge missing from catchment_attributes.csv comes out of the
+        # left merge with NaN in every attrs column; the discharge record
+        # itself must survive with the optional fields set to None.
+        nan = float("nan")
+        raw = [
+            {
+                "station_id": "7777777",
+                "date": "2000-01-01",
+                "discharge": 5.0,
+                "gauge_name": nan,
+                "gauge_lat": nan,
+                "gauge_lon": nan,
+                "area_km2": nan,
+            }
+        ]
+        records = self.collector.normalise(raw)
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.discharge_cms == 5.0
+        assert rec.location is None
+        assert rec.station_name is None
+        assert rec.catchment_area_km2 is None
+
     def test_normalise_missing_location_is_none(self):
         raw = [
             {


### PR DESCRIPTION
Follow-up to #116 (thanks again @adjenk!). Closes off the NaN edge case noted after merge.

### The bug

A gauge missing from the `catchment_attributes.csv` join comes out of the left merge with NaN metadata. NaN is truthy in Python, so `if lat and lon` let it through to `GeoLocation(latitude=nan)`, which fails the `ge=-90` bound; the ValidationError (a ValueError subclass) was swallowed by the broad except and the entire record disappeared at debug level, valid discharge and all. `station_name` (NaN fails `str | None`) had the same failure mode, and a NaN `area_km2` passed validation and would have poisoned `runoff_mm_day`.

### The fix

A small `_clean()` helper maps NaN to None for `gauge_name`, `gauge_lat`/`gauge_lon`, and `area_km2` before constructing the record. The location guard is now `is not None` rather than truthiness (which also fixes the 0.0-coordinate falsy edge, moot for Chile but correct).

### Tests

New `test_normalise_nan_attrs_record_survives`: a NaN-attrs row now yields one record with `location`, `station_name`, and `catchment_area_km2` all None and the discharge intact. Before the fix it yielded zero records. All 20 collector tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011nURygQXfEnjk5KWXewHxp
