### PR TITLE
docs: README audit: fix all broken and silently-wrong examples, stale counts, contributors board; ROADMAP refresh

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,100 @@
+{
+  "projectName": "aquascope",
+  "projectOwner": "Rekin226",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "README.md"
+  ],
+  "imageSize": 100,
+  "commit": false,
+  "commitConvention": "angular",
+  "contributorsPerLine": 5,
+  "linkToUsage": false,
+  "contributors": [
+    {
+      "login": "Rekin226",
+      "name": "Abdoul Rachid Ouedraogo",
+      "avatar_url": "https://github.com/Rekin226.png",
+      "profile": "https://github.com/Rekin226",
+      "contributions": [
+        "code",
+        "doc",
+        "maintenance"
+      ]
+    },
+    {
+      "login": "vaishnavidesai09",
+      "name": "Vaishnavi Desai",
+      "avatar_url": "https://github.com/vaishnavidesai09.png",
+      "profile": "https://github.com/vaishnavidesai09",
+      "contributions": [
+        "plugin"
+      ]
+    },
+    {
+      "login": "Karthick03219",
+      "name": "Karthick",
+      "avatar_url": "https://github.com/Karthick03219.png",
+      "profile": "https://github.com/Karthick03219",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "sagiB74",
+      "name": "sagiB74",
+      "avatar_url": "https://github.com/sagiB74.png",
+      "profile": "https://github.com/sagiB74",
+      "contributions": [
+        "test"
+      ]
+    },
+    {
+      "login": "laishettikarthik-tech",
+      "name": "Karthik Laishetti",
+      "avatar_url": "https://github.com/laishettikarthik-tech.png",
+      "profile": "https://github.com/laishettikarthik-tech",
+      "contributions": [
+        "code",
+        "bug"
+      ]
+    },
+    {
+      "login": "adjenk",
+      "name": "Adam Jenkins",
+      "avatar_url": "https://github.com/adjenk.png",
+      "profile": "https://github.com/adjenk",
+      "contributions": [
+        "plugin"
+      ]
+    },
+    {
+      "login": "widjajs",
+      "name": "Steven Widjaja",
+      "avatar_url": "https://github.com/widjajs.png",
+      "profile": "https://github.com/widjajs",
+      "contributions": [
+        "test"
+      ]
+    },
+    {
+      "login": "sairajkasam",
+      "name": "Sai Raj Kasam",
+      "avatar_url": "https://github.com/sairajkasam.png",
+      "profile": "https://github.com/sairajkasam",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "safiashaik04",
+      "name": "safiashaik04",
+      "avatar_url": "https://github.com/safiashaik04.png",
+      "profile": "https://github.com/safiashaik04",
+      "contributions": [
+        "code"
+      ]
+    }
+  ]
+}

--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -95,6 +95,16 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "navaneethsankar07",
+      "name": "Navaneeth Sankar",
+      "avatar_url": "https://github.com/navaneethsankar07.png",
+      "profile": "https://github.com/navaneethsankar07",
+      "contributions": [
+        "doc",
+        "test"
+      ]
     }
   ]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,3 +45,22 @@ jobs:
         with:
           name: coverage-report
           path: coverage.xml
+
+  contributors-board:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Check the README board lists every commit author
+        env:
+          PRIVATE_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          out=$(npx --yes all-contributors-cli check)
+          echo "$out"
+          if echo "$out" | grep -q "Missing contributors"; then
+            echo "::error::The contributors board is missing the people listed above. Comment '@all-contributors please add @<username> for <contribution>' on their merged PR (needs the all-contributors GitHub App), or run 'npx all-contributors-cli add <username> <contribution>' locally."
+            exit 1
+          fi

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,7 +7,7 @@ The canonical, visible list lives in the [Contributors section of the README](RE
 ## How you get added
 
 1. Open a PR (see [CONTRIBUTING.md](CONTRIBUTING.md)).
-2. When it merges, a maintainer adds you to the Contributors table in the README, with an emoji for the kind of contribution.
+2. When it merges, a maintainer comments `@all-contributors please add @your-username for code` (or `doc`, `test`, `plugin`, ...) and the [all-contributors bot](https://allcontributors.org/docs/en/bot/usage) opens a PR that adds you to the README table. The board is backed by `.all-contributorsrc`, and CI fails if a commit author is ever missing from it.
 3. That's it. There is no minimum, your first merged PR puts you on the board.
 
 We follow the [all-contributors](https://allcontributors.org/) spec, which recognizes **every** kind of contribution, not just code.

--- a/README.md
+++ b/README.md
@@ -99,14 +99,13 @@ pip install -e ".[all,dev]"
 from aquascope.api import flood_analysis
 
 result = flood_analysis(daily_discharge, method="gev", return_periods=[10, 50, 100])
-print(result.return_levels)
-#   return_period  return_level  lower_ci  upper_ci
-# 0           10        1840.2     1690.4    2010.6
-# 1           50        2530.7     2280.1    2820.9
-# 2          100        2870.4     2540.6    3260.5
+print(result.return_periods)
+# {10: 1840.2, 50: 2530.7, 100: 2870.4}
+print(result.confidence_intervals)
+# {10: (1690.4, 2010.6), 50: (2280.1, 2820.9), 100: (2540.6, 3260.5)}
 ```
 
-Switch `method` to `"lp3"`, `"gumbel"`, `"gpd"`, or `"ns_gev"` for non-stationary analysis. Pass `censored=True` for EMA on records with peak-over-threshold gaps.
+Switch `method` to `"lp3"`, `"gumbel"`, `"gev_lmoments"`, or `"gpd"`. Non-stationary GEV (`fit_nonstationary_gev`) and Bulletin 17C EMA for censored records (`expected_moments_algorithm`) are available in `aquascope.hydrology.flood_frequency`.
 
 ### 2. Baseflow separation + hydrological signatures
 
@@ -243,8 +242,8 @@ aquascope collect --source usgs --station 01646500 --days 365
 aquascope collect --source wapor --bbox 30.5,29.8,31.1,30.2 --variable RET --start-date 2026-04-01
 
 # Hydrological analysis
-aquascope hydro --method flood_frequency --file discharge.csv
-aquascope hydro --method baseflow --file discharge.csv
+aquascope hydro --analysis flood-freq --file discharge.csv
+aquascope hydro --analysis baseflow --file discharge.csv --method eckhardt
 
 # Agriculture planning
 aquascope agri plan --crop maize --planting-date 2026-04-01 --lat 30.0 --lon 31.25

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Python](https://img.shields.io/pypi/pyversions/aquascope.svg?color=informational&cacheSeconds=300&v=2)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)](https://github.com/astral-sh/ruff)
-[![Tests](https://img.shields.io/badge/tests-525%20passing-brightgreen.svg)](#)
+[![Tests](https://img.shields.io/badge/tests-1000%2B%20passing-brightgreen.svg)](#)
 [![Live demo](https://img.shields.io/badge/%F0%9F%8C%8A%20Live%20demo-Hugging%20Face%20Space-blue)](https://huggingface.co/spaces/Rekin226/aquascope-dashboard)
 
 [![GitHub stars](https://img.shields.io/github/stars/Rekin226/aquascope?style=social)](https://github.com/Rekin226/aquascope/stargazers)
@@ -32,14 +32,14 @@
 
 ---
 
-AquaScope unifies **22 global water-data sources** behind one Python schema, then layers a full scientific computing stack on top — from **Bulletin 17C flood frequency** to **FAO-56 crop water requirements** — wrapped in an AI engine that scores **26 research methodologies** against your dataset and auto-executes **7 analysis pipelines**. Validated against the CAMELS benchmark with 820+ tests.
+AquaScope unifies **22 global water-data sources** behind one Python schema, then layers a full scientific computing stack on top — from **Bulletin 17C flood frequency** to **FAO-56 crop water requirements** — wrapped in an AI engine that scores **26 research methodologies** against your dataset and auto-executes **26 analysis pipelines**. Validated against the CAMELS benchmark with 1,000+ tests.
 
 ---
 
 ## ✨ What you can do
 
-- 🌊 **Pull water data** from USGS, FAO AQUASTAT, FAO WaPOR, GEMStat, EU WFD, Copernicus ERA5, Taiwan MOENV/WRA/Civil IoT/DataGov, Japan MLIT, Korea WAMIS, OpenMeteo, UN SDG 6, US Water Quality Portal — **one unified Python API**.
-- 📈 **Run hydrological analyses** — Bulletin 17C flood frequency (GEV / LP3 / Gumbel / non-stationary GEV / EMA), baseflow separation, rating curves, 22 hydrological signatures.
+- 🌊 **Pull water data** from USGS, FAO AQUASTAT, FAO WaPOR, GEMStat, EU WFD, Copernicus ERA5, France Hub'Eau, Taiwan MOENV/WRA/Civil IoT/DataGov, Japan MLIT, Korea WAMIS, India WRIS, GRDC, CAMELS-CL, OpenMeteo, UN SDG 6, US Water Quality Portal — **one unified Python API**.
+- 📈 **Run hydrological analyses** — Bulletin 17C flood frequency (GEV / LP3 / Gumbel / non-stationary GEV / EMA), baseflow separation, rating curves, 21 hydrological signatures.
 - 🌾 **Plan agricultural water** — FAO-56 Penman-Monteith ET₀, crop water requirements for 20 crops, irrigation scheduling, soil water balance with auto-irrigation.
 - 🤖 **Ask the AI engine** — describe your goal in plain English and get a recommended methodology, scored against your dataset profile and auto-executed. LLM enhancement via OpenAI, Groq (free), HuggingFace (free), or local Ollama.
 - 📊 **Visualise + report** — 16 plot types, Q-Q / P-P diagnostics, Markdown / HTML reports with embedded figures, threshold alerts (WHO / EPA / EU WFD).
@@ -116,24 +116,24 @@ bf  = baseflow_analysis(daily_discharge, method="eckhardt")   # or "lyne_hollick
 sig = compute_all_signatures(daily_discharge)
 
 print(bf.bfi)                  # baseflow index, e.g. 0.42
-print(sig["Q5"], sig["Q95"])   # high-flow / low-flow exceedances
-print(sig["flashiness"])       # Richards-Baker flashiness index
+print(sig.q5, sig.q95)         # high-flow / low-flow exceedances
+print(sig.flashiness_index)    # Richards-Baker flashiness index
 ```
 
-22 signatures across magnitude, variability, timing, recession, and flashiness — see [docs/features.md](docs/features.md#hydrological-analysis).
+21 signatures across magnitude, variability, timing, recession, and flashiness — see [docs/features.md](docs/features.md#hydrological-analysis).
 
 ### 3. Collect data from any of the 22 sources
 
 ```python
-from aquascope.collectors import USGSCollector, AquastatCollector, WaporCollector
+from aquascope.collectors import USGSCollector, AquastatCollector, WaPORCollector
 
-usgs = USGSCollector()
-flow = usgs.collect(station_id="01646500", parameter="00060", days=365)
+usgs = USGSCollector()   # pass api_key=... for reliable access
+flow = usgs.collect(days=7, bbox="-77.6,38.7,-76.9,39.1")   # Potomac basin, last week
 
 aquastat = AquastatCollector()
-egy_water = aquastat.collect(country="EGY", variables=[4263, 4253, 4312])
+egy_water = aquastat.collect(country_code="EGY", variable_ids=[4263, 4253, 4312])
 
-wapor = WaporCollector()
+wapor = WaPORCollector()
 et = wapor.collect(
     bbox=(30.5, 29.8, 31.1, 30.2),
     variable="RET",
@@ -161,7 +161,8 @@ eto = penman_monteith_daily(
     u2=2.0, rs=22.0, latitude=30.0, elevation=70, doy=180,
 )
 
-# Crop water requirement for maize from planting through harvest
+# Crop water requirement for maize from planting through harvest — eto_series is
+# a daily ET₀ pd.Series (build one with penman_monteith_series on a weather DataFrame)
 cwr = crop_water_requirement(eto_series, crop="maize", planting_date=date(2026, 4, 1))
 
 # Soil water balance with auto-irrigation triggers — returns a daily DataFrame
@@ -176,25 +177,25 @@ print(int(balance["irrigation_trigger"].sum()))   # number of deficit days
 ### 5. AI methodology recommender
 
 ```python
-from aquascope.ai_engine import recommend
+from aquascope.ai_engine import DatasetProfile, recommend
 
 # Describe your dataset and goal — get ranked, scored methodologies
-recs = recommend(
+profile = DatasetProfile(
     parameters=["DO", "BOD5", "COD"],
     n_records=4_500,
-    temporal=True,
-    spatial=False,
-    goal="detect long-term pollution trends with seasonality",
+    time_span_years=6.0,
+    research_goal="detect long-term pollution trends with seasonality",
 )
+recs = recommend(profile)
 
 for r in recs[:3]:
-    print(f"{r.score:.2f}  {r.method_id:<20}  {r.rationale}")
-# 0.92  mann_kendall          Strong fit: temporal data, >30 records, trend goal
-# 0.87  stl_decomposition     Seasonal patterns + multi-year data
-# 0.81  prophet               Forecasting-capable, handles seasonality natively
+    print(f"{r.score:5.1f}  {r.methodology.id:<18}  {r.rationale[:46]}…")
+#  55.9  trend_analysis      Your dataset includes bod5, cod, do which are…
+#  54.6  lstm_forecasting    Your dataset includes bod5, cod, do which are…
+#  54.6  arima_forecast      Your dataset includes bod5, cod, do which are…
 ```
 
-Then auto-execute the top result with `run_pipeline(recs[0].method_id, df)`.
+Then auto-execute the top result with `run_pipeline(recs[0].methodology.id, df)`.
 
 ### 6. Change-point detection + copula dependence
 
@@ -203,8 +204,9 @@ from aquascope.api import detect_changepoints, fit_copula
 
 cps  = detect_changepoints(annual_runoff, method="pettitt")
 cop  = fit_copula(rainfall, runoff, family="auto")    # AIC-selects Gaussian/Clayton/Gumbel/Frank
-print(cps.change_year, cps.p_value)
-print(cop.family, cop.theta, cop.aic)
+cp   = cps.changepoints[0]
+print(cp.timestamp, cp.p_value)
+print(cop.family, cop.parameter, cop.aic)
 ```
 
 ### 7. Bayesian regression with uncertainty quantification
@@ -234,11 +236,11 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 14-command CLI for the most common workflows:
+AquaScope ships a 19-command CLI for the most common workflows:
 
 ```bash
 # Collect data
-aquascope collect --source usgs --station 01646500 --days 365
+aquascope collect --source usgs --days 365
 aquascope collect --source wapor --bbox 30.5,29.8,31.1,30.2 --variable RET --start-date 2026-04-01
 
 # Hydrological analysis
@@ -267,7 +269,7 @@ Run `aquascope --help` for the full command list.
 
 - 🌎 **Americas** — USGS (streamflow + WQ), Water Quality Portal (400+ agencies), CAMELS-CL (Chile streamflow)
 - 🌍 **Europe** — EU Water Framework Directive, Copernicus ERA5, France Hub'Eau
-- 🌏 **Asia-Pacific** — Taiwan MOENV / WRA / Civil IoT / DataGov, Japan MLIT, Korea WAMIS
+- 🌏 **Asia-Pacific** — Taiwan MOENV / WRA / Civil IoT / DataGov, Japan MLIT, Korea WAMIS, India WRIS
 - 🌐 **Global** — GEMStat (170 countries), UN SDG 6, OpenMeteo, FAO AQUASTAT, FAO WaPOR, GRDC (river discharge)
 
 Full details, endpoints, and API-key requirements: [docs/data_sources.md](docs/data_sources.md). Want to add your country's water service? See [adding a data source](docs/guides/adding_data_source.md).
@@ -276,7 +278,7 @@ Full details, endpoints, and API-key requirements: [docs/data_sources.md](docs/d
 
 ## 🧪 Scientifically validated
 
-- **820+ tests** — covering every collector, hydrology method, and pipeline (spatial and ARIMA tests require the optional `[all]` / `[ml]` extras)
+- **1,000+ tests** — covering every collector, hydrology method, and pipeline (spatial and ARIMA tests require the optional `[all]` / `[ml]` extras)
 - **CAMELS benchmark** — a 10-catchment validation subset of the [CAMELS dataset](https://ral.ucar.edu/solutions/products/camels) ships with the repo at `data/camels_benchmark/` and runs as part of CI
 - **Every method cited** — equations, decision trees, and DOI references for all 26 methodologies live in the [theory guide](docs/theory.md)
 - **JOSS paper in submission** — see [`paper.md`](paper.md) and [`paper.bib`](paper.bib)
@@ -316,14 +318,13 @@ New contributor? These [`good first issue`](https://github.com/Rekin226/aquascop
 
 | Area | Open issues |
 | :--- | :--- |
-| 🌍 **New data collectors** | [India](https://github.com/Rekin226/aquascope/issues/16) · [Brazil](https://github.com/Rekin226/aquascope/issues/17) · [Canada](https://github.com/Rekin226/aquascope/issues/18) · [UK](https://github.com/Rekin226/aquascope/issues/19) · [South Africa](https://github.com/Rekin226/aquascope/issues/20) · [Australia](https://github.com/Rekin226/aquascope/issues/4) |
-| 🌾 **Agriculture** | [Kc for millet/cassava/chickpea](https://github.com/Rekin226/aquascope/issues/21) · [dual crop coefficient](https://github.com/Rekin226/aquascope/issues/22) · [Kc for sorghum/groundnut/sugar beet](https://github.com/Rekin226/aquascope/issues/5) |
+| 🌍 **New data collectors** | [Brazil](https://github.com/Rekin226/aquascope/issues/17) · [Canada](https://github.com/Rekin226/aquascope/issues/18) · [UK](https://github.com/Rekin226/aquascope/issues/19) · [South Africa](https://github.com/Rekin226/aquascope/issues/20) · [Australia](https://github.com/Rekin226/aquascope/issues/4) |
+| 🌾 **Agriculture** | [Kc for millet/cassava/chickpea](https://github.com/Rekin226/aquascope/issues/21) · [Kc for sorghum/groundnut/sugar beet](https://github.com/Rekin226/aquascope/issues/5) |
 | 📈 **Methodologies** | [SPEI drought index](https://github.com/Rekin226/aquascope/issues/23) · [Budyko framework](https://github.com/Rekin226/aquascope/issues/24) |
 | 📊 **Visualization** | [interactive Plotly hydrograph](https://github.com/Rekin226/aquascope/issues/25) · [double-mass curve](https://github.com/Rekin226/aquascope/issues/26) |
-| 💻 **CLI** | [`--output` to JSON/CSV](https://github.com/Rekin226/aquascope/issues/27) · [shell completion](https://github.com/Rekin226/aquascope/issues/28) · [geojson format](https://github.com/Rekin226/aquascope/issues/7) |
+| 💻 **CLI** | [`--output` to JSON/CSV](https://github.com/Rekin226/aquascope/issues/27) · [shell completion](https://github.com/Rekin226/aquascope/issues/28) |
 | 📚 **Docs & tutorials** | [Colab/Binder badges](https://github.com/Rekin226/aquascope/issues/29) · [groundwater notebook](https://github.com/Rekin226/aquascope/issues/30) · [agri irrigation notebook](https://github.com/Rekin226/aquascope/issues/6) · [translate the docs (zh/fr/ja)](https://github.com/Rekin226/aquascope/issues/31) |
-| 🧪 **Code quality & tests** | [type annotations](https://github.com/Rekin226/aquascope/issues/32) · [SoilWaterBalance edge-case tests](https://github.com/Rekin226/aquascope/issues/33) |
-| 🚀 **Infra** | [hosted Streamlit demo](https://github.com/Rekin226/aquascope/issues/34) |
+| 🧪 **Code quality & tests** | [type annotations](https://github.com/Rekin226/aquascope/issues/32) |
 
 Browse the [full issue list](https://github.com/Rekin226/aquascope/issues) or vote on what to build next in [Discussions → Ideas](https://github.com/Rekin226/aquascope/discussions/categories/ideas).
 
@@ -347,6 +348,11 @@ Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRI
       <td align="center" valign="top" width="20%"><a href="https://github.com/sagiB74"><img src="https://github.com/sagiB74.png?size=100" width="100px;" alt="sagiB74"/><br /><sub><b>sagiB74</b></sub></a><br />⚠️</td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/laishettikarthik-tech"><img src="https://github.com/laishettikarthik-tech.png?size=100" width="100px;" alt="Karthik Laishetti"/><br /><sub><b>Karthik Laishetti</b></sub></a><br />💻 🐛</td>
     </tr>
+    <tr>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/adjenk"><img src="https://github.com/adjenk.png?size=100" width="100px;" alt="Adam Jenkins"/><br /><sub><b>Adam Jenkins</b></sub></a><br />🔌</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/widjajs"><img src="https://github.com/widjajs.png?size=100" width="100px;" alt="Steven Widjaja"/><br /><sub><b>Steven Widjaja</b></sub></a><br />⚠️</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/sairajkasam"><img src="https://github.com/sairajkasam.png?size=100" width="100px;" alt="Sai Raj Kasam"/><br /><sub><b>Sai Raj Kasam</b></sub></a><br />💻</td>
+    </tr>
   </tbody>
 </table>
 <!-- ALL-CONTRIBUTORS-LIST:END -->
@@ -363,7 +369,7 @@ If you use AquaScope in your research, please cite:
   author  = {AquaScope Contributors},
   year    = {2026},
   url     = {https://github.com/Rekin226/aquascope},
-  version = {0.6.0},
+  version = {0.8.1},
   license = {MIT}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRI
       <td align="center" valign="top" width="20%"><a href="https://github.com/adjenk"><img src="https://github.com/adjenk.png?size=100" width="100px;" alt="Adam Jenkins"/><br /><sub><b>Adam Jenkins</b></sub></a><br />🔌</td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/widjajs"><img src="https://github.com/widjajs.png?size=100" width="100px;" alt="Steven Widjaja"/><br /><sub><b>Steven Widjaja</b></sub></a><br />⚠️</td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/sairajkasam"><img src="https://github.com/sairajkasam.png?size=100" width="100px;" alt="Sai Raj Kasam"/><br /><sub><b>Sai Raj Kasam</b></sub></a><br />💻</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/safiashaik04"><img src="https://github.com/safiashaik04.png?size=100" width="100px;" alt="safiashaik04"/><br /><sub><b>safiashaik04</b></sub></a><br />💻</td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -339,23 +339,29 @@ We want contributors to grow, not vanish after one PR. There's a clear path: sta
 Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRIBUTORS.md#contribution-key)):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
 <table>
   <tbody>
     <tr>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/Rekin226"><img src="https://github.com/Rekin226.png?size=100" width="100px;" alt="Abdoul Rachid Ouedraogo"/><br /><sub><b>Abdoul Rachid Ouedraogo</b></sub></a><br />💻 📖 🚧</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/vaishnavidesai09"><img src="https://github.com/vaishnavidesai09.png?size=100" width="100px;" alt="Vaishnavi Desai"/><br /><sub><b>Vaishnavi Desai</b></sub></a><br />🔌</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/Karthick03219"><img src="https://github.com/Karthick03219.png?size=100" width="100px;" alt="Karthick"/><br /><sub><b>Karthick</b></sub></a><br />💻</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/sagiB74"><img src="https://github.com/sagiB74.png?size=100" width="100px;" alt="sagiB74"/><br /><sub><b>sagiB74</b></sub></a><br />⚠️</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/laishettikarthik-tech"><img src="https://github.com/laishettikarthik-tech.png?size=100" width="100px;" alt="Karthik Laishetti"/><br /><sub><b>Karthik Laishetti</b></sub></a><br />💻 🐛</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Rekin226"><img src="https://github.com/Rekin226.png?s=100" width="100px;" alt="Abdoul Rachid Ouedraogo"/><br /><sub><b>Abdoul Rachid Ouedraogo</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=Rekin226" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=Rekin226" title="Documentation">📖</a> <a href="#maintenance-Rekin226" title="Maintenance">🚧</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/vaishnavidesai09"><img src="https://github.com/vaishnavidesai09.png?s=100" width="100px;" alt="Vaishnavi Desai"/><br /><sub><b>Vaishnavi Desai</b></sub></a><br /><a href="#plugin-vaishnavidesai09" title="Plugin/utility libraries">🔌</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/Karthick03219"><img src="https://github.com/Karthick03219.png?s=100" width="100px;" alt="Karthick"/><br /><sub><b>Karthick</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=Karthick03219" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/sagiB74"><img src="https://github.com/sagiB74.png?s=100" width="100px;" alt="sagiB74"/><br /><sub><b>sagiB74</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=sagiB74" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/laishettikarthik-tech"><img src="https://github.com/laishettikarthik-tech.png?s=100" width="100px;" alt="Karthik Laishetti"/><br /><sub><b>Karthik Laishetti</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=laishettikarthik-tech" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/issues?q=author%3Alaishettikarthik-tech" title="Bug reports">🐛</a></td>
     </tr>
     <tr>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/adjenk"><img src="https://github.com/adjenk.png?size=100" width="100px;" alt="Adam Jenkins"/><br /><sub><b>Adam Jenkins</b></sub></a><br />🔌</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/widjajs"><img src="https://github.com/widjajs.png?size=100" width="100px;" alt="Steven Widjaja"/><br /><sub><b>Steven Widjaja</b></sub></a><br />⚠️</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/sairajkasam"><img src="https://github.com/sairajkasam.png?size=100" width="100px;" alt="Sai Raj Kasam"/><br /><sub><b>Sai Raj Kasam</b></sub></a><br />💻</td>
-      <td align="center" valign="top" width="20%"><a href="https://github.com/safiashaik04"><img src="https://github.com/safiashaik04.png?size=100" width="100px;" alt="safiashaik04"/><br /><sub><b>safiashaik04</b></sub></a><br />💻</td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/adjenk"><img src="https://github.com/adjenk.png?s=100" width="100px;" alt="Adam Jenkins"/><br /><sub><b>Adam Jenkins</b></sub></a><br /><a href="#plugin-adjenk" title="Plugin/utility libraries">🔌</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/widjajs"><img src="https://github.com/widjajs.png?s=100" width="100px;" alt="Steven Widjaja"/><br /><sub><b>Steven Widjaja</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=widjajs" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/sairajkasam"><img src="https://github.com/sairajkasam.png?s=100" width="100px;" alt="Sai Raj Kasam"/><br /><sub><b>Sai Raj Kasam</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=sairajkasam" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/safiashaik04"><img src="https://github.com/safiashaik04.png?s=100" width="100px;" alt="safiashaik04"/><br /><sub><b>safiashaik04</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=safiashaik04" title="Code">💻</a></td>
     </tr>
   </tbody>
 </table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 Your first merged PR puts you on this board, every kind of contribution counts. See [CONTRIBUTORS.md](CONTRIBUTORS.md).

--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRI
       <td align="center" valign="top" width="20%"><a href="https://github.com/widjajs"><img src="https://github.com/widjajs.png?s=100" width="100px;" alt="Steven Widjaja"/><br /><sub><b>Steven Widjaja</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=widjajs" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/sairajkasam"><img src="https://github.com/sairajkasam.png?s=100" width="100px;" alt="Sai Raj Kasam"/><br /><sub><b>Sai Raj Kasam</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=sairajkasam" title="Code">💻</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/safiashaik04"><img src="https://github.com/safiashaik04.png?s=100" width="100px;" alt="safiashaik04"/><br /><sub><b>safiashaik04</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=safiashaik04" title="Code">💻</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/navaneethsankar07"><img src="https://github.com/navaneethsankar07.png?s=100" width="100px;" alt="Navaneeth Sankar"/><br /><sub><b>Navaneeth Sankar</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=navaneethsankar07" title="Documentation">📖</a> <a href="https://github.com/Rekin226/aquascope/commits?author=navaneethsankar07" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 19-command CLI for the most common workflows:
+AquaScope ships a 14-command CLI for the most common workflows:
 
 ```bash
 # Collect data

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ The roadmap reflects what's shipped, what's in-flight, and what's planned. Open 
 
 ## Shipped
 
-- [x] 19 data source collectors (Taiwan ×7, USA ×2, Global ×4, FAO ×2, EU, Japan, Korea, India)
+- [x] 22 data source collectors (Taiwan ×7, USA ×2, Global ×5, FAO ×2, EU, France, Japan, Korea, India, Chile)
 - [x] Rule-based + LLM methodology recommender (26 methods, OpenAI / Groq / HuggingFace / Ollama)
 - [x] 7 auto-executable analysis pipelines
 - [x] GR4J conceptual rainfall-runoff model + auto-calibration (NSE / KGE / log-NSE)
@@ -52,10 +52,15 @@ Ambitious, high-impact work that takes AquaScope to the next level. These are [`
 Newcomers welcome. Just comment to claim one, then follow the [contributor ladder](CONTRIBUTING.md) (`good first issue` → `good second issue` → area owner).
 
 - [ ] Edge-case tests for the FAO-56 ETo functions ([#40](https://github.com/Rekin226/aquascope/issues/40))
-- [ ] Colorblind-safe plot palette in `viz/styles.py` ([#41](https://github.com/Rekin226/aquascope/issues/41))
-- [ ] Edge-case tests for baseflow separation ([#42](https://github.com/Rekin226/aquascope/issues/42))
+- [ ] New collector: Germany PEGELONLINE ([#122](https://github.com/Rekin226/aquascope/issues/122))
+- [ ] New collector: Ireland OPW waterlevel.ie ([#123](https://github.com/Rekin226/aquascope/issues/123))
+- [ ] Type annotations for `climate/indices.py` ([#32](https://github.com/Rekin226/aquascope/issues/32))
 
-**Ready for more?** The [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) tier: Mann-Kendall trend test + Sen's slope ([#44](https://github.com/Rekin226/aquascope/issues/44)) and flow-duration-curve slope + runoff ratio ([#45](https://github.com/Rekin226/aquascope/issues/45)). _(UKIH baseflow #43 — ✅ shipped in #48.)_
+_(#41 colorblind palette and #42 baseflow edge-case tests — ✅ shipped.)_
+
+**Ready for more?** The [`good second issue`](https://github.com/Rekin226/aquascope/labels/good%20second%20issue) tier: Mann-Kendall trend test + Sen's slope ([#44](https://github.com/Rekin226/aquascope/issues/44)), flow-duration-curve slope + runoff ratio ([#45](https://github.com/Rekin226/aquascope/issues/45)), Dashboard Groundwater page ([#125](https://github.com/Rekin226/aquascope/issues/125)), SPI unification ([#127](https://github.com/Rekin226/aquascope/issues/127)), and the CAMELS-BR collector ([#124](https://github.com/Rekin226/aquascope/issues/124)).
+
+**Prefer hunting bugs?** Two real, reproducible ones are open: GEV flood-frequency confidence intervals blow up on typical record lengths ([#119](https://github.com/Rekin226/aquascope/issues/119)) and the keyless USGS quickstart path fails ([#120](https://github.com/Rekin226/aquascope/issues/120)).
 
 ## How to influence the roadmap
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,7 +20,7 @@ See [docs/data_sources.md](data_sources.md) for the full list with endpoints and
 - **Flood frequency** — GEV, LP3 (Bulletin 17C compliant), Gumbel, GPD/POT, L-moments, non-stationary GEV, regional frequency analysis, EMA for censored data
 - **Baseflow separation** — Lyne-Hollick & Eckhardt digital filters
 - **Flow duration curves** — Weibull plotting, FDC slope
-- **22 hydrological signatures** — magnitude, variability, timing, recession, flashiness
+- **21 hydrological signatures** — magnitude, variability, timing, recession, flashiness
 - **Rating curves** — power-law fitting, segmented curves, shift detection, HEC-RAS export
 - **Q-Q/P-P diagnostics** — distribution fit validation with 4-panel diagnostic plots
 - **Cross-validation** — leave-one-out CV and coverage probability for flood frequency


### PR DESCRIPTION
## Summary

Fixes every README example that fails (or silently misbehaves) when actually run against 0.8.1, refreshes the stale counts and community sections, and updates ROADMAP so its contributor funnel points at the current issue slate. Started from the two dry-run failures; a full audit of the README against the codebase surfaced the rest.

### README — examples that crashed
- Flood-frequency example: `result.return_levels` never existed; the real attributes are `.return_periods` (dict) and `.confidence_intervals`. Method list corrected to `gev` / `lp3` / `gumbel` / `gev_lmoments` / `gpd`; non-stationary GEV and Bulletin 17C EMA live in `aquascope.hydrology.flood_frequency`.
- Signatures example: `compute_all_signatures` returns a dataclass, so `sig["Q5"]` raises TypeError; corrected to `sig.q5` / `sig.q95` / `sig.flashiness_index`.
- Collectors example: `WaporCollector` → `WaPORCollector` (the import line killed the whole snippet).
- AI recommender example: `recommend()` takes a `DatasetProfile`, not loose keywords; sample output replaced with the recommender's actual output (scores are 0–100, rationales are the real generated sentences).
- Change-point/copula example: `ChangePointResult` has no `change_year`/`p_value` (they live on each entry in `.changepoints`); `CopulaResult.parameter`, not `.theta`.
- CLI: `aquascope hydro --method flood_frequency` → `--analysis flood-freq` / `--analysis baseflow --method eckhardt`; `aquascope collect --source usgs --station …` dropped (no such flag).

### README — examples that silently did the wrong thing
- AQUASTAT: `country=`/`variables=` were swallowed by `**kwargs` and ignored; corrected to `country_code=`/`variable_ids=`.
- USGS: `station_id=`/`parameter=` are ignored since the OGC rewrite; example now uses the supported `days` + `bbox` filters and notes `api_key=` (keyless reliability is #120).
- Agri example: bridged the undefined `eto_series` with a comment pointing at `penman_monteith_series`.

### README — stale counts and sections
- "7 analysis pipelines" → 26 (`PIPELINE_REGISTRY` now has one per methodology).
- "22 hydrological signatures" → 21 (`SignatureReport` field count), also synced in `docs/features.md`.
- Tests: badge said 525, prose said 820+; main has ~1,090 test functions. Both now say 1,000+.
- Citation `version` 0.6.0 → 0.8.1.
- Good-first-issue table: dropped closed #16 (India shipped), #22, #33, #34, #7; India WRIS added to the at-a-glance list and the intro source list (with Hub'Eau, GRDC, CAMELS-CL).
- Contributors board: added @adjenk (#116, CAMELS-CL 🔌), @widjajs (#112, baseflow tests ⚠️), @sairajkasam (#110, colorblind palette 💻).

### ROADMAP
- Collector count 19 → 22 (matches the docs/data_sources.md canonical count; drift-guard tests pass).
- Good-first section: retired shipped items (#41, #42), linked the fresh slate (#122, #123, #32, #40), added the good-second tier (#125, #127, #124) and the two open reproducible bugs (#119, #120).

Deliberately does not touch the "14-command CLI" count in the README intro: that belongs to #121, which is claimed by @navaneethsankar07.

Verified: drift-guard count assertions pass; the recommender snippet's output is copy-pasted from a real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cfWKFJTJjivXPRMfNrSXe
