### PR TITLE
docs: update CLI command count and add drift guard test

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 14-command CLI for the most common workflows:
+AquaScope ships a 19-command CLI for the most common workflows:
 
 ```bash
 # Collect data

--- a/tests/test_docs_counts.py
+++ b/tests/test_docs_counts.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 
+CLI_PATTERN = r"AquaScope ships a (\d+)-command CLI"
+
 README_PATTERNS = [
     r"unifies \*\*(\d+) global water-data sources\*\*",
     r"\| (\d+) unified data collectors \|",
@@ -24,6 +26,11 @@ README_PATTERNS = [
 def _table_row_count() -> int:
     text = (ROOT / "docs" / "data_sources.md").read_text(encoding="utf-8")
     return len(re.findall(r"^\| \[", text, flags=re.MULTILINE))
+
+
+def _cli_command_count() -> int:
+    text = (ROOT / "aquascope" / "cli.py").read_text(encoding="utf-8")
+    return len(re.findall(r"\.add_parser\(", text))
 
 
 def test_docs_intro_count_matches_table():
@@ -43,3 +50,17 @@ def test_readme_counts_match_table():
             f"README says {match.group(1)} for {pattern!r} but the "
             f"docs/data_sources.md table has {expected} rows"
         )
+
+
+def test_readme_cli_count_matches_cli():
+    text = (ROOT / "README.md").read_text(encoding="utf-8")
+
+    match = re.search(CLI_PATTERN, text)
+    assert match is not None, "README CLI count sentence missing"
+
+    expected = _cli_command_count()
+
+    assert int(match.group(1)) == expected, (
+        f"README says {match.group(1)} CLI commands but "
+        f"cli.py defines {expected}"
+    )


### PR DESCRIPTION
## Summary

This PR updates the documented CLI command count in the README and adds a regression test to ensure it stays synchronized with the actual CLI implementation.

### Changes

- Update the README CLI section to reflect the current command count (14 → 19).
- Add a drift-guard test that compares the documented CLI count against the number of CLI parser registrations in `aquascope/cli.py`.

### Why

This helps prevent the README from becoming outdated as new CLI commands are added in the future.

Closes #121