### PR TITLE
docs: credit aobaruwa on the contributors board

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -117,6 +117,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "aobaruwa",
+      "name": "Ahmed Baruwa",
+      "avatar_url": "https://avatars.githubusercontent.com/u/28014016?v=4",
+      "profile": "https://github.com/aobaruwa",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRI
     </tr>
     <tr>
       <td align="center" valign="top" width="20%"><a href="https://github.com/taran-dev4u"><img src="https://avatars.githubusercontent.com/u/78680216?v=4?s=100" width="100px;" alt="Taran"/><br /><sub><b>Taran</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=taran-dev4u" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=taran-dev4u" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/aobaruwa"><img src="https://avatars.githubusercontent.com/u/28014016?v=4?s=100" width="100px;" alt="Ahmed Baruwa"/><br /><sub><b>Ahmed Baruwa</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=aobaruwa" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=aobaruwa" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds **aobaruwa** (code, test: double-mass diagnostic plot #107) to the contributors board.

Added manually with `all-contributors-cli` because the all-contributors GitHub App isn't installed, so the comment-triggered bot doesn't respond. Keeps the `contributors-board` CI guard green now that #107 has merged.

Board-only change (`.all-contributorsrc` + README contributors section); docs-count guards still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)