### PR TITLE
fix(usgs): implement legacy REST API fallback for keyless queries

### DIFF
--- a/aquascope/collectors/usgs.py
+++ b/aquascope/collectors/usgs.py
@@ -131,6 +131,108 @@ class USGSCollector(BaseCollector):
                 f"{end.strftime('%Y-%m-%dT%H:%M:%SZ')}"
             )
 
+        if self.api_key == "DEMO_KEY" or not self.api_key:
+            if collection not in ("daily", "sta"):
+                raise ValueError(
+                    f"Collection '{collection}' is not supported on the keyless legacy USGS API path. "
+                    "Only 'daily' and 'sta' collections are supported without an API key. "
+                    "Please provide a valid USGS_API_KEY to use the OGC API path. "
+                    "For a reliable keyless demo source, use OpenMeteoCollector."
+                )
+
+            sites = kwargs.get("station_id") or kwargs.get("sites") or kwargs.get("monitoring_location_id")
+            parameter_cd = kwargs.get("parameter") or kwargs.get("parameterCd") or kwargs.get("parameter_code")
+            bbox_val = bbox or kwargs.get("bBox")
+            state_cd = kwargs.get("stateCd")
+            county_cd = kwargs.get("countyCd")
+            huc_val = kwargs.get("huc")
+
+            if not any([sites, bbox_val, state_cd, county_cd, huc_val]):
+                raise ValueError(
+                    "USGS keyless path requires a filter parameter (station_id, bbox, stateCd, countyCd, or huc). "
+                    "To request unfiltered data, you must provide a valid USGS_API_KEY via api_key or the "
+                    "USGS_API_KEY environment variable. For a reliable keyless demo source, use OpenMeteoCollector."
+                )
+
+            parts = datetime_range.split("/")
+            start_date = parts[0].split("T")[0] if len(parts) == 2 else None
+            end_date = parts[1].split("T")[0] if len(parts) == 2 else None
+
+            endpoint = "dv" if collection == "daily" else "iv"
+            url = f"https://waterservices.usgs.gov/nwis/{endpoint}/"
+
+            params = {
+                "format": "json",
+            }
+            if sites:
+                params["sites"] = sites
+            if parameter_cd:
+                params["parameterCd"] = parameter_cd
+            if bbox_val:
+                params["bBox"] = bbox_val
+            if state_cd:
+                params["stateCd"] = state_cd
+            if county_cd:
+                params["countyCd"] = county_cd
+            if huc_val:
+                params["huc"] = huc_val
+
+            if start_date:
+                params["startDT"] = start_date
+            if end_date:
+                params["endDT"] = end_date
+
+            response = self.client.get_json(url, params=params)
+            time_series_list = response.get("value", {}).get("timeSeries", [])
+
+            all_features = []
+            for ts in time_series_list:
+                source_info = ts.get("sourceInfo", {})
+                site_codes = source_info.get("siteCode", [])
+                site_id = site_codes[0].get("value", "unknown") if site_codes else "unknown"
+
+                geo_loc = source_info.get("geoLocation", {}).get("geogLocation", {})
+                latitude = geo_loc.get("latitude")
+                longitude = geo_loc.get("longitude")
+
+                var_info = ts.get("variable", {})
+                var_codes = var_info.get("variableCode", [])
+                param_code = var_codes[0].get("value", "") if var_codes else ""
+                unit = var_info.get("unit", {}).get("unitCode", "")
+                no_data_val = var_info.get("noDataValue")
+
+                for values_block in ts.get("values", []):
+                    for value in values_block.get("value", []):
+                        val = value.get("value")
+                        dt = value.get("dateTime")
+                        if val is None or dt is None:
+                            continue
+
+                        try:
+                            float_val = float(val)
+                            if no_data_val is not None and abs(float_val - no_data_val) < 1e-3:
+                                continue
+                        except (ValueError, TypeError):
+                            continue
+
+                        all_features.append({
+                            "geometry": {
+                                "coordinates": [longitude, latitude]
+                            },
+                            "properties": {
+                                "monitoring_location_id": site_id,
+                                "parameter_code": param_code,
+                                "value": val,
+                                "time": dt,
+                                "unit_of_measure": unit
+                            }
+                        })
+
+            if max_items is not None and len(all_features) >= max_items:
+                all_features = all_features[:max_items]
+
+            return all_features
+
         all_features: list[dict] = []
         params: dict[str, Any] = {
             "f": "json",

--- a/tests/test_collectors/test_usgs_wra_config.py
+++ b/tests/test_collectors/test_usgs_wra_config.py
@@ -3,6 +3,10 @@ water-level location extraction added in 0.6.0. These do not hit the network."""
 
 from __future__ import annotations
 
+from unittest.mock import Mock
+
+import pytest
+
 from aquascope.collectors.taiwan_wra import (
     TaiwanWRAWaterLevelCollector,
     _extract_location,
@@ -76,3 +80,154 @@ class TestWRANormaliseUsesLocation:
         readings = collector.normalise(raw)
         assert len(readings) == 1
         assert readings[0].location is None
+
+
+class TestUSGSCollectorKeyless:
+    def test_keyless_raises_error_for_unsupported_collection(self, monkeypatch):
+        monkeypatch.delenv("USGS_API_KEY", raising=False)
+        collector = USGSCollector()
+        with pytest.raises(ValueError, match="Collection 'discrete' is not supported"):
+            collector.fetch_raw(collection="discrete", station_id="01646500")
+
+    def test_keyless_raises_error_without_filter(self, monkeypatch):
+        monkeypatch.delenv("USGS_API_KEY", raising=False)
+        collector = USGSCollector()
+        with pytest.raises(ValueError, match="USGS keyless path requires a filter parameter"):
+            collector.fetch_raw(collection="daily")
+
+    def test_keyless_daily_fetch_and_normalise(self, monkeypatch):
+        monkeypatch.delenv("USGS_API_KEY", raising=False)
+        collector = USGSCollector()
+
+        mock_response = {
+            "value": {
+                "timeSeries": [
+                    {
+                        "sourceInfo": {
+                            "siteName": "Test Site",
+                            "siteCode": [{"value": "01646500"}],
+                            "geoLocation": {
+                                "geogLocation": {
+                                    "latitude": 38.9,
+                                    "longitude": -77.1
+                                }
+                            }
+                        },
+                        "variable": {
+                            "variableCode": [{"value": "00060"}],
+                            "unit": {"unitCode": "ft3/s"},
+                            "noDataValue": -999999.0
+                        },
+                        "values": [
+                            {
+                                "value": [
+                                    {"value": "2960", "dateTime": "2026-07-20T00:00:00.000"},
+                                    {"value": "-999999", "dateTime": "2026-07-21T00:00:00.000"},
+                                    {"value": "2430", "dateTime": "2026-07-22T00:00:00.000"}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        mock_get_json = Mock(return_value=mock_response)
+        collector.client.get_json = mock_get_json
+
+        raw = collector.fetch_raw(collection="daily", station_id="01646500", days=5)
+
+        assert len(raw) == 2
+        assert raw[0]["properties"]["value"] == "2960"
+        assert raw[0]["properties"]["monitoring_location_id"] == "01646500"
+        assert raw[1]["properties"]["value"] == "2430"
+
+        mock_get_json.assert_called_once()
+        args, kwargs = mock_get_json.call_args
+        assert args[0].startswith("https://waterservices.usgs.gov/nwis/dv/")
+        assert kwargs["params"]["sites"] == "01646500"
+
+        samples = collector.normalise(raw)
+        assert len(samples) == 2
+        assert samples[0].value == 2960.0
+        assert samples[0].location.latitude == 38.9
+        assert samples[0].location.longitude == -77.1
+        assert samples[1].value == 2430.0
+
+    def test_keyless_sta_fetch_and_normalise(self, monkeypatch):
+        monkeypatch.delenv("USGS_API_KEY", raising=False)
+        collector = USGSCollector()
+
+        mock_response = {
+            "value": {
+                "timeSeries": [
+                    {
+                        "sourceInfo": {
+                            "siteName": "Test Site",
+                            "siteCode": [{"value": "01646500"}],
+                            "geoLocation": {
+                                "geogLocation": {
+                                    "latitude": 38.9,
+                                    "longitude": -77.1
+                                }
+                            }
+                        },
+                        "variable": {
+                            "variableCode": [{"value": "00065"}],
+                            "unit": {"unitCode": "ft"},
+                            "noDataValue": -999999.0
+                        },
+                        "values": [
+                            {
+                                "value": [
+                                    {"value": "12.3", "dateTime": "2026-07-24T20:10:00.000-04:00"}
+                                ]
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+
+        mock_get_json = Mock(return_value=mock_response)
+        collector.client.get_json = mock_get_json
+
+        raw = collector.fetch_raw(collection="sta", bbox="-77.2,38.8,-77.0,39.0", days=1)
+        assert len(raw) == 1
+        assert raw[0]["properties"]["value"] == "12.3"
+
+        mock_get_json.assert_called_once()
+        args, kwargs = mock_get_json.call_args
+        assert args[0].startswith("https://waterservices.usgs.gov/nwis/iv/")
+        assert kwargs["params"]["bBox"] == "-77.2,38.8,-77.0,39.0"
+
+
+class TestUSGSCollectorKeyed:
+    def test_keyed_uses_ogc_api(self, monkeypatch):
+        collector = USGSCollector(api_key="valid-key")
+
+        mock_response = {
+            "features": [
+                {
+                    "geometry": {"coordinates": [-77.1, 38.9]},
+                    "properties": {
+                        "monitoring_location_id": "01646500",
+                        "parameter_code": "00060",
+                        "value": 2960.0,
+                        "time": "2026-07-20T00:00:00Z",
+                        "unit_of_measure": "ft3/s"
+                    }
+                }
+            ]
+        }
+
+        mock_get_json = Mock(return_value=mock_response)
+        collector.client.get_json = mock_get_json
+
+        raw = collector.fetch_raw(collection="daily", station_id="01646500")
+        assert len(raw) == 1
+        assert raw[0]["properties"]["value"] == 2960.0
+
+        mock_get_json.assert_called_once()
+        args, kwargs = mock_get_json.call_args
+        assert args[0] == "collections/daily/items"


### PR DESCRIPTION
This pull request implements a fallback to the legacy USGS Water Services REST API (waterservices.usgs.gov) for keyless data collection requests, resolving timeouts and HTTP 400 errors. Closes #120