### PR TITLE
docs: credit AB1775 on the contributors board

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -127,6 +127,16 @@
         "code",
         "test"
       ]
+    },
+    {
+      "login": "AB1775",
+      "name": "Anthony",
+      "avatar_url": "https://avatars.githubusercontent.com/u/66264218?v=4",
+      "profile": "https://github.com/AB1775",
+      "contributions": [
+        "code",
+        "test"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -360,6 +360,7 @@ Thanks to these wonderful people who make AquaScope possible ([emoji key](CONTRI
     <tr>
       <td align="center" valign="top" width="20%"><a href="https://github.com/taran-dev4u"><img src="https://avatars.githubusercontent.com/u/78680216?v=4?s=100" width="100px;" alt="Taran"/><br /><sub><b>Taran</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=taran-dev4u" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=taran-dev4u" title="Tests">⚠️</a></td>
       <td align="center" valign="top" width="20%"><a href="https://github.com/aobaruwa"><img src="https://avatars.githubusercontent.com/u/28014016?v=4?s=100" width="100px;" alt="Ahmed Baruwa"/><br /><sub><b>Ahmed Baruwa</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=aobaruwa" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=aobaruwa" title="Tests">⚠️</a></td>
+      <td align="center" valign="top" width="20%"><a href="https://github.com/AB1775"><img src="https://avatars.githubusercontent.com/u/66264218?v=4?s=100" width="100px;" alt="Anthony"/><br /><sub><b>Anthony</b></sub></a><br /><a href="https://github.com/Rekin226/aquascope/commits?author=AB1775" title="Code">💻</a> <a href="https://github.com/Rekin226/aquascope/commits?author=AB1775" title="Tests">⚠️</a></td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
Adds @AB1775 to the contributors board (code, test) for the NOAA NWPS collector (#138). Done via `all-contributors-cli add` since the GitHub App isn't installed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwafNkv43Ad5jDheN9VDYm