### PR TITLE
release: 0.9.0 - four new countries, Dashboard 2.0, and an in-browser demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,56 @@ All notable changes to AquaScope are documented here.
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-08-04
+
+Four new countries, a rebuilt dashboard, and a live in-browser demo. AquaScope
+now reaches 25 data sources, and the Streamlit app went from a single-file
+monolith to a multipage workspace that runs client-side in a browser with the
+collectors still working.
+
+Most of this release came from the community: seven external contributors wrote
+all four new collectors and most of the new analysis and plotting features.
+Thank you.
+
 ### Added
+- **NOAA NWPS collector** (`collectors/noaa_nwps.py`): the US National Water
+  Prediction Service, covering streamflow forecasts, stream observations, crest
+  history, flood impacts, low-water history, flood-category levels, and gauge
+  metadata. No API key required. Available as
+  `aquascope collect --source noaa_nwps`. Thanks @AB1775 (#138).
+- **Ireland OPW collector** (`collectors/ireland_opw.py`): real-time river and
+  lake water level from waterlevel.ie at 15-minute resolution, across hundreds
+  of Office of Public Works stations. Station geometry comes from the OPW
+  GeoJSON index and series from the per-station CSV exports, with column names
+  resolved defensively since the endpoint serves more than one CSV shape.
+  Station refs outside the 1-41000 republication range are filtered out per
+  OPW's terms. No API key required. Thanks @laishettikarthik-tech
+  (#130, closes #123).
 - **Germany PEGELONLINE collector** (`collectors/pegelonline.py`): recent water
   level and discharge observations from federal waterway gauges, emitted as
   `WaterLevelReading` and `StreamflowReading`. Supports station UUIDs, W/Q
   selection, CLI collection, and the upstream 31-day history limit. No API key
-  required.
+  required. Thanks @taran-dev4u (#131).
+- **CAMELS-CL collector** (`collectors/camels_cl.py`): daily observed streamflow
+  for 516 Chilean catchments from the CR2 large-sample dataset, joined with
+  catchment attributes (area, coordinates). AquaScope's first South American
+  source. Thanks @adjenk (#116).
+- **Area-normalized streamflow** (`hydrology.streamflow`): `stage_to_runoff`
+  chains a rating curve straight through to mm/day, and
+  `discharge_cms_to_runoff_mm_day` converts a single discharge value given a
+  catchment area. `StreamflowReading` gained `catchment_area_km2`, and both
+  catchment area and runoff now route into the xarray export. Thanks
+  @laishettikarthik-tech (#103, closes #98).
+- **Double-mass plot** (`viz.diagnostics.double_mass_plot`): the classic
+  cumulative-versus-cumulative consistency check for spotting station shifts or
+  instrument changes in paired records. Thanks @aobaruwa (#107).
+- **Optional Plotly backend for `plot_hydrograph`** (`viz/hydro.py`): pass
+  `backend="plotly"` for an interactive figure instead of matplotlib. The
+  default stays matplotlib, so existing code is unaffected. Thanks @adjenk
+  (#134, closes #25).
 - **Canonical SPI drought classification** (`climate.indices.drought_class`):
   McKee et al. category labels with explicit boundary and missing-value
-  handling. `SPIModel` now delegates SPI calculation and classification to the
-  climate-index implementation instead of maintaining a divergent gamma fit.
+  handling. Thanks @taran-dev4u (#132).
 - **Dashboard 2.0** (`aquascope/dashboard/`): the Streamlit dashboard was rebuilt
   from a 2,100-line monolith into a multipage workspace app (`st.navigation`)
   with a shared dataset flowing through every page.
@@ -22,12 +62,14 @@ All notable changes to AquaScope are documented here.
     detected), quality-scored, quietly screened against WHO guidelines, and
     answered with one-click "suggested next steps" that navigate to the right
     analysis page.
-  - **All 21 collectors in the UI** (`views/collect.py`): the Collect page now
-    exposes every registered source (previously 15), including GRDC, Hub'Eau,
-    India WRIS, Taiwan data.gov.tw, Taiwan WRA IoT and FHY, with per-source
-    parameter forms, a region filter, CSV/JSON upload, and two demo datasets.
-    Nested `location` objects are flattened to `latitude`/`longitude` so maps
-    work out of the box.
+  - **21 collectors in the UI** (`views/collect.py`): the Collect page went from
+    15 sources to 21, adding GRDC, Hub'Eau, India WRIS, Taiwan data.gov.tw, and
+    Taiwan WRA IoT and FHY, with per-source parameter forms, a region filter,
+    CSV/JSON upload, and two demo datasets. Nested `location` objects are
+    flattened to `latitude`/`longitude` so maps work out of the box. The four
+    sources added later in this release (NOAA NWPS, Ireland OPW, PEGELONLINE,
+    CAMELS-CL) are reachable from the Python API and the CLI but are not wired
+    into the Collect page yet.
   - **Interactive Plotly charts everywhere** (`_charts.py`): time series, box
     plots, correlation heatmaps, histograms, FDCs (with direct Q50/Q95 labels),
     hydrographs with baseflow fill, SPI timelines, return-level curves with
@@ -46,17 +88,39 @@ All notable changes to AquaScope are documented here.
   (closes the "hosted Streamlit demo" roadmap gap, #34).
 - **Colorblind-safe palette** (`viz/styles.py`): `apply_aqua_style(palette="colorblind")`
   switches the `axes.prop_cycle` to the Okabe-Ito / Color Universal Design
-  8-colour palette. The default behaviour is unchanged.
+  8-colour palette. The default behaviour is unchanged. Thanks @sairajkasam
+  (#110).
+- **Baseflow edge-case tests**: Lyne-Hollick and Eckhardt are now pinned on
+  their invariants (baseflow bounded by total flow, BFI in [0, 1], steady-state
+  behaviour, filter-parameter boundaries, index preservation with NaNs, and the
+  empty-series case). Thanks @widjajs (#112).
 
 ### Changed
+- `SPIModel` now delegates SPI calculation and classification to
+  `climate.indices` instead of maintaining its own divergent gamma fit. SPI
+  values and drought classes are consistent across the two entry points; if you
+  compared them before, expect small numerical differences from `SPIModel`.
+  Thanks @taran-dev4u (#132).
 - `.streamlit/config.toml` now pins the dashboard's categorical chart colors
   (`chartCategoricalColors`) so native Streamlit charts match the Plotly theme,
   and disables usage-stats gathering.
 - `apply_aqua_style()` now explicitly sets `axes.prop_cycle` to `SERIES_COLOURS`
   on every call (previously the cycle was not set, inheriting Matplotlib's
   default). Visually identical for existing code.
+- Documentation: README examples, source counts, and ROADMAP issue links were
+  audited and corrected against the actual code, with CI drift guards so the
+  counts cannot silently go stale again (#128; CLI command count by
+  @navaneethsankar07 in #129). The contributors board is now maintained by the
+  all-contributors bot.
 
 ### Fixed
+- **USGS keyless queries work again.** The collector falls back to the legacy
+  REST API when a query runs without an API key, instead of failing. Thanks
+  @taran-dev4u (#137).
+- **CAMELS-CL records are no longer silently dropped** when catchment attributes
+  are missing. NaN from a missed `catchment_attributes.csv` join is truthy, so
+  it reached Pydantic validation and the resulting error discarded the whole
+  record. NaN now maps to `None` for gauge name, coordinates, and area (#118).
 - **Live collectors now work in the in-browser (WASM) demo.** `CachedHTTPClient`
   detects Pyodide/Emscripten and routes requests through `urllib` (patched to
   browser XHR by pyodide-http) instead of httpx's socket transport, which hangs

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Abdoul Rachid
     orcid: "https://orcid.org/0000-0002-4616-4153"
     affiliation: "National Central University, Taiwan"
-version: 0.8.1
-date-released: "2026-07-17"
+version: 0.9.0
+date-released: "2026-08-04"
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
 url: https://rekin226.github.io/aquascope
@@ -55,8 +55,8 @@ preferred-citation:
     - family-names: Ouédraogo
       given-names: Abdoul Rachid
       orcid: "https://orcid.org/0000-0002-4616-4153"
-  version: 0.8.1
-  date-released: "2026-07-17"
+  version: 0.9.0
+  date-released: "2026-08-04"
   license: MIT
   repository-code: https://github.com/Rekin226/aquascope
   url: https://rekin226.github.io/aquascope

--- a/aquascope/__init__.py
+++ b/aquascope/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.8.1"
+__version__ = "0.9.0"
 __author__ = "AquaScope Contributors"
 __license__ = "MIT"
 

--- a/paper.bib
+++ b/paper.bib
@@ -141,6 +141,17 @@
   doi     = {10.5194/hess-21-5293-2017}
 }
 
+@article{AlvarezGarreton2018,
+  author  = {Alvarez-Garreton, Camila and Mendoza, Pablo A. and Boisier, Juan Pablo and Addor, Nans and Galleguillos, Mauricio and Zambrano-Bigiarini, Mauricio and Lara, Antonio and Puelma, Cristóbal and Cortes, Gonzalo and Garreaud, René and McPhee, James and Ayala, Alvaro},
+  title   = {The {CAMELS-CL} Dataset: Catchment Attributes and Meteorology for Large Sample Studies -- {Chile} Dataset},
+  journal = {Hydrology and Earth System Sciences},
+  year    = {2018},
+  volume  = {22},
+  number  = {11},
+  pages   = {5817--5846},
+  doi     = {10.5194/hess-22-5817-2018}
+}
+
 @inproceedings{McKinney2010,
   author    = {McKinney, Wes},
   title     = {Data Structures for Statistical Computing in {Python}},

--- a/paper.md
+++ b/paper.md
@@ -16,14 +16,14 @@ authors:
 affiliations:
   - name: National Central University, Taiwan
     index: 1
-date: 21 July 2026
+date: 4 August 2026
 bibliography: paper.bib
 ---
 
 # Summary
 
-AquaScope is an open-source Python toolkit (v0.8.1, MIT license) that unifies water
-data collection from 21 global sources, comprehensive hydrological and statistical
+AquaScope is an open-source Python toolkit (v0.9.0, MIT license) that unifies water
+data collection from 25 global sources, comprehensive hydrological and statistical
 analysis, agricultural water management, and AI-powered research methodology
 recommendations into a single, coherent package. It addresses a persistent challenge
 in water resources research: the fragmentation of data access, analytical methods, and
@@ -34,7 +34,8 @@ frequency analysis, baseflow separation, extreme value theory, drought indices, 
 FAO-56 evapotranspiration, and includes a knowledge-base-driven AI engine that
 recommends appropriate research methodologies based on dataset characteristics. Unlike
 existing unified data clients, which focus on United States services, AquaScope's
-collectors span East and South Asia, Europe, and global FAO/UN sources. The toolkit is
+collectors span East and South Asia, Europe, South America, and global FAO/UN sources.
+The toolkit is
 available at <https://github.com/Rekin226/aquascope>, with a zero-install live demo
 that runs entirely in the browser at
 <https://huggingface.co/spaces/Rekin226/aquascope-dashboard>.
@@ -67,10 +68,11 @@ Second, no single toolkit couples multi-source data collection with a comprehens
 hydrological analysis suite, agricultural water management, advanced statistical and
 machine-learning methods, and intelligent methodology guidance.
 
-AquaScope addresses both. Its 21 collectors span East and South Asia (Taiwan MOENV and
+AquaScope addresses both. Its 25 collectors span East and South Asia (Taiwan MOENV and
 WRA networks, Japan MLIT, Korea WAMIS, India WRIS), Europe (EU Water Framework
-Directive, France Hub'Eau), the United States (USGS, Water Quality Portal), and global
-providers (GEMStat, GRDC river discharge, Open-Meteo, Copernicus, UN SDG 6, FAO
+Directive, France Hub'Eau, Germany PEGELONLINE, Ireland OPW), the Americas (USGS, Water
+Quality Portal, NOAA National Water Prediction Service, and CAMELS-CL for Chile), and
+global providers (GEMStat, GRDC river discharge, Open-Meteo, Copernicus, UN SDG 6, FAO
 AQUASTAT and WaPOR). On top of this it
 provides an end-to-end workflow, from raw data ingestion through analysis to methodology
 recommendation, in a single, well-tested Python package with a unified API. It targets
@@ -81,15 +83,18 @@ patchwork of incompatible tools.
 
 # Key Features
 
-**Data aggregation.** AquaScope implements collectors for 21 water data sources, each
+**Data aggregation.** AquaScope implements collectors for 25 water data sources, each
 subclassing a common `BaseCollector` and normalising responses into shared Pydantic
 schemas. Coverage spans Asia (Taiwan MOENV and WRA networks, including a daily
 groundwater-level series reachable only through the WRA HydroInfo portal, Taiwan Civil
 IoT via the OGC SensorThings API, Japan MLIT, Korea WAMIS, India WRIS), Europe (EU
-Water Framework Directive, France's Hub'Eau hydrometry), the United States (USGS NWIS
-[@USGS_NWIS]; the Water Quality Portal, aggregating 400+ agencies), and global
-providers (GEMStat, GRDC river discharge combining in-situ gauges with satellite RSEG
-estimates, UN SDG 6, Open-Meteo, Copernicus ERA5, FAO AQUASTAT and WaPOR). A shared
+Water Framework Directive, France's Hub'Eau hydrometry, Germany's PEGELONLINE waterway
+gauges, Ireland's OPW hydrometric network), the Americas (USGS NWIS [@USGS_NWIS]; the
+Water Quality Portal, aggregating 400+ agencies; the NOAA National Water Prediction
+Service for forecasts and flood-category levels; and CAMELS-CL [@AlvarezGarreton2018],
+daily streamflow for 516 Chilean catchments), and global providers (GEMStat, GRDC river
+discharge combining in-situ gauges with satellite RSEG estimates, UN SDG 6, Open-Meteo,
+Copernicus ERA5, FAO AQUASTAT and WaPOR). A shared
 `httpx`-based HTTP client [@HTTPX2024] provides caching, retries with exponential
 back-off, and rate limiting, and transparently switches to a browser-native transport
 when running under WebAssembly.
@@ -141,7 +146,7 @@ integration on Python 3.10–3.12, linting (Ruff), and type checking (mypy).
 
 | Feature                        | AquaScope | HyRiver | dataretrieval | hydrostats | pySTEPS |
 |--------------------------------|:---------:|:-------:|:-------------:|:----------:|:-------:|
-| Multi-source data collection   | 21        | U.S.    | U.S.          | —          | —       |
+| Multi-source data collection   | 25        | U.S.    | U.S.          | —          | —       |
 | Non-U.S. / global coverage     | ✓         | —       | —             | —          | —       |
 | Unified data schemas           | ✓         | ✓       | —             | —          | —       |
 | Conceptual rainfall-runoff (GR4J)| ✓       | —       | —             | —          | —       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aquascope"
-version = "0.8.1"
+version = "0.9.0"
 description = "Open-source water data aggregation toolkit with AI-powered research methodology recommendations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
Cuts 0.9.0. AquaScope now reaches **25 data sources**, up from 21, and the Streamlit app is a multipage workspace that runs client-side in a browser with the collectors still working.

Most of this release came from the community: seven external contributors wrote all four new collectors and most of the new analysis and plotting features.

## What's in it

**Four new countries**
- NOAA NWPS, USA (#138, @AB1775)
- Ireland OPW waterlevel.ie (#130, @laishettikarthik-tech)
- Germany PEGELONLINE (#131, @taran-dev4u)
- CAMELS-CL, Chile, our first South American source (#116, @adjenk)

**New analysis and plotting**
- Area-normalized streamflow, mm/day (#103, @laishettikarthik-tech)
- Double-mass diagnostic plot (#107, @aobaruwa)
- Optional Plotly backend for `plot_hydrograph` (#134, @adjenk)
- Canonical SPI drought classification (#132, @taran-dev4u)
- Colorblind-safe palette (#110, @sairajkasam)
- Baseflow edge-case tests (#112, @widjajs)

**Dashboard 2.0 and the WASM demo**, plus fixes for USGS keyless queries (#137, @taran-dev4u) and silently dropped CAMELS-CL records (#118).

## Release mechanics

| File | Change |
|---|---|
| `pyproject.toml`, `aquascope/__init__.py` | 0.8.1 -> 0.9.0, in sync |
| `CHANGELOG.md` | `[Unreleased]` rolled to `[0.9.0] - 2026-08-04` |
| `CITATION.cff` | 0.9.0 / 2026-08-04, both occurrences |
| `paper.md` | v0.9.0, 21 -> 25 sources, geography updated |
| `paper.bib` | added the CAMELS-CL reference (Alvarez-Garreton et al. 2018) |

## Two things worth a look

1. The `[Unreleased]` section had gone stale and was missing eight merged PRs (#103, #107, #112, #116, #118, #130, #134, #137). All are now written up with contributor credit.
2. The old text claimed "All 21 collectors in the UI". The registry now has 25 but the dashboard's Collect page still wires up 21, so the notes now say that plainly and name the four that aren't in the UI yet. Worth a follow-up issue.

Merging this does not publish anything. PyPI fires later, from the GitHub Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UUme88C6Mcn4yDKexqGWL5