### PR TITLE
CLI: add `aquascope completion` for bash/zsh/fish shell completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 19-command CLI for the most common workflows:
+AquaScope ships a 20-command CLI for the most common workflows:
 
 ```bash
 # Collect data
@@ -257,6 +257,9 @@ aquascope solve --problem "Assess flood risk for a 100-year return period"
 # Interactive Streamlit dashboard — multipage workspace with 21 live sources,
 # smart auto-insights, and fully interactive Plotly charts
 aquascope dashboard
+
+# Shell tab-completion
+eval "$(aquascope completion bash)"   # add this to ~/.bashrc (or .zshrc / config.fish)
 ```
 
 Run `aquascope --help` for the full command list.

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 20-command CLI for the most common workflows:
+AquaScope ships a 19-command CLI for the most common workflows:
 
 ```bash
 # Collect data

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -11,11 +11,13 @@ Usage
     aquascope agri plan --crop maize --planting-date 2026-04-01 --eto-file eto.csv --precip-file precip.csv
     aquascope list-methods
     aquascope list-sources
+    aquascope completion bash
 """
-
+# PYTHON_ARGCOMPLETE_OK
 from __future__ import annotations
 
 import argparse
+import argcomplete
 import json
 import logging
 import sys
@@ -502,6 +504,12 @@ def cmd_list_sources(args: argparse.Namespace) -> None:
         print(f"    Data   : {info[2]}")
         print(f"    URL    : {info[3]}")
         print()
+
+
+def cmd_completion(args: argparse.Namespace) -> None:
+    """Print the shell activation line for tab-completion."""
+    from argcomplete.shell_integration import shellcode
+    print(shellcode(["aquascope"], shell=args.shell))
 
 
 def cmd_solve(args: argparse.Namespace) -> None:
@@ -1141,6 +1149,10 @@ def main() -> None:
     p_run.add_argument("--config", default=None, help="Pipeline config as JSON string")
     p_run.add_argument("--output", default=None, help="Path to save results JSON")
 
+    # ── completion  ────────────────────────────────────────────────────
+    p_completion = sub.add_parser("completion", help="Print shell tab-completion activation script")
+    p_completion.add_argument("shell", choices=["bash", "zsh", "fish"], help="Shell to generate completion for")
+
     # ── list-methods ─────────────────────────────────────────────────
     sub.add_parser("list-methods", help="List all available research methodologies and pipelines")
 
@@ -1321,7 +1333,8 @@ def main() -> None:
     p_hydro.add_argument("--output", default=None, help="Save results to CSV")
     p_hydro.add_argument("--n-day", type=int, default=None, help="N-day window for low-flow (default: 7)")
     p_hydro.add_argument("--return-period", type=int, default=None, help="Return period for low-flow (default: 10)")
-
+    
+    argcomplete.autocomplete(parser)
     args = parser.parse_args()
     commands = {
         "collect": cmd_collect,
@@ -1340,6 +1353,7 @@ def main() -> None:
         "agri": cmd_agri,
         "groundwater": cmd_groundwater,
         "climate": cmd_climate,
+        "completion": cmd_completion,
     }
 
     handler = commands.get(args.command)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dependencies = [
     "pandas>=2.0",
     "numpy>=1.24",
     "scipy>=1.11",
+    "argcomplete>=3.1",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_cli/test_completion.py
+++ b/tests/test_cli/test_completion.py
@@ -1,0 +1,18 @@
+"""Tests for the `aquascope completion` subcommand."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from aquascope.cli import main
+
+
+@pytest.mark.parametrize("shell", ("bash", "zsh", "fish"))
+def test_completion_prints_a_nonempty_script(shell, capsys, monkeypatch):
+    """`aquascope completion <shell>` prints a non-empty activation script."""
+    monkeypatch.setattr(sys, "argv", ["aquascope", "completion", shell])
+    main()
+    out = capsys.readouterr().out
+    assert out.strip() != ""


### PR DESCRIPTION
Closes #28

## Changes
- Add `argcomplete` to core dependencies in `pyproject.toml`
- Add `# PYTHON_ARGCOMPLETE_OK` hook and `argcomplete.autocomplete(parser)` in `aquascope/cli.py`
- Add `aquascope completion bash|zsh|fish` subcommand, printing the activation script via `argcomplete.shell_integration.shellcode`
- Document usage in README CLI section (`eval "$(aquascope completion bash)"`) and update the docstring usage list
- Add a smoke test (`tests/test_cli/test_completion.py`) covering all three shells

## Testing
- `aquascope completion bash|zsh|fish` prints a non-empty, working snippet
- Verified tab-completion manually after `eval "$(aquascope completion bash)"` — subcommands complete correctly
- Add 3 new tests (`tests/test_cli/test_completion.py`, parametrized over bash/zsh/fish), all passing
- Full test suite passes (1181 passed, up from 1178)

## Acceptance criteria
- [x] `aquascope completion bash|zsh|fish` prints a working snippet
- [x] Tab-completion works after sourcing it
- [x] Documented