### PR TITLE
ci: ignore bot authors in the contributors-board guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,11 @@ jobs:
         run: |
           out=$(npx --yes all-contributors-cli check)
           echo "$out"
-          if echo "$out" | grep -q "Missing contributors"; then
-            echo "::error::The contributors board is missing the people listed above. Comment '@all-contributors please add @<username> for <contribution>' on their merged PR (needs the all-contributors GitHub App), or run 'npx all-contributors-cli add <username> <contribution>' locally."
+          # Bot authors (e.g. allcontributors[bot], which authors the board PRs
+          # themselves) are never credited on the board, so ignore them.
+          missing=$(echo "$out" | sed -n '/Missing contributors/,$p' | tail -n +2 \
+            | sed 's/^[[:space:]]*//' | grep -v '\[bot\]$' | grep -v '^$' || true)
+          if [ -n "$missing" ]; then
+            echo "::error::The contributors board is missing: $missing. Comment '@all-contributors please add @<username> for <contribution>' on their merged PR (needs the all-contributors GitHub App), or run 'npx all-contributors-cli add <username> <contribution>' locally."
             exit 1
           fi


### PR DESCRIPTION
## Problem

`contributors-board` currently fails on `main`. Merging #151 (the all-contributors bot's own credit PR) put a commit authored by `allcontributors[bot]` in the history, and the guard flags every commit author missing from the board:

```
Missing contributors in .all-contributorsrc:
    allcontributors[bot]
```

Every earlier board commit (#141, #136, #135) was authored by the maintainer, so this is the first time a bot-authored commit has landed. The job is not a required check, so nothing is blocked, but it shows red on every PR and that erodes the signal.

## Fix

Filter `[bot]` authors out of the missing list before deciding to fail. Bots are never credited on the board, so they can never satisfy the check.

Verified both directions against the live `all-contributors-cli check` output:

- bot-only missing → passes
- a real username in the list → still fails, and the error names them

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K1sqw11XmKCwVDFdRiERt9