### PR TITLE
fix(ai_engine): stop the LLM recommender from degrading silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,47 @@ All notable changes to AquaScope are documented here.
 - **Taiwan CWA climate collector** (`collectors/taiwan_cwa.py`): daily station climate observations (rainfall, temperature mean/max/min, humidity, solar radiation, wind, Class-A pan evaporation) from Taiwan's official weather network via the keyless CODIS archive, with history verified back to 1960. Records use the new `ClimateReading` schema, which pivots through the existing xarray interop path unchanged. This is the observed-forcing layer for the CAMELS-TW epic. (#177, closes #177; contributes to #100)
 - **`relax_strict_tls` option on `CachedHTTPClient`**: Taiwan government certificate chains lack the Subject Key Identifier extension that Python 3.13+ requires by default; the new flag relaxes only the strict profile check while keeping full chain and hostname verification, replacing any need for `verify=False` on these hosts. Root cause and the one-line fix for `taiwan_wra_iot` are documented in #169.
 - **Flow Duration Curve (FDC) slope signature** (`aquascope.hydrology.fdc_slope`): added log-space percentile slope signature function and `fdc_slope` field on `SignatureReport` (#45).
+- **Deployment-supplied free AI.** `hosted_llm_config()` reads one API token
+  from the environment (`HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, or
+  `AQUASCOPE_LLM_API_KEY` with `AQUASCOPE_LLM_BASE_URL` / `AQUASCOPE_LLM_MODEL`).
+  When present, the dashboard offers **✨ Free AI — hosted for this demo, no key
+  needed** as the default provider, so visitors to a public deployment get
+  LLM-backed recommendations without an account. On Streamlit Community Cloud
+  the same names work as `st.secrets`. No credential is ever bundled in the
+  package, and when none is configured the recommender stays rule-based
+  exactly as before.
+- `RecommendationResult` and `recommend_with_llm_detailed()` in
+  `aquascope.ai_engine.recommender`: recommendations plus `mode`
+  (`"llm"` / `"rule_based"`), `provider`, `model`, and a human-readable
+  `error`. `recommend_with_llm()` keeps its existing signature and return type.
+- Troubleshooting guide section for the AI recommender.
 
 ### Fixed
 - **USGS discharge now normalises into `StreamflowReading`** (`collectors/usgs.py`): discharge (00060) values from both API endpoints are emitted as `StreamflowReading` instead of `WaterQualitySample`, with unit conversion (ft³/s → m³/s for discharge, miles² → km² for catchment area), significant-figure preservation, and a helper to fetch catchment area when not already present. Water quality sample normalisation for non-discharge parameters is unchanged. (#155, contributes to #97 and #104)
 - **USGS CLI `--days` and kwarg handling fixed** (`cli`): corrected bugs in how `--days` and other USGS-specific parameters were passed through as kwargs to the collector, with new test coverage for valid-parameter acceptance, rejection of unrecognised parameters, and implicit/explicit API key selection. (#159)
 - **Hub'Eau water level and discharge now normalise into `WaterLevelReading` and `StreamflowReading`** (`collectors/france_hubeau.py`): both reading types are migrated off `WaterQualitySample` — water level (H) is emitted in metres, and discharge (Q) as `discharge_cms` (converted from L/s via an integer divisor that avoids a floating-point rounding error) tagged `source_type="in_situ"` with `catchment_area_km2` populated, so `runoff_mm_day` works for Hub'Eau. Catchment areas come from a single batched `referentiel/sites` lookup (one call no matter how many stations are requested, and only made when discharge rows actually need it), degrading gracefully to `None` with a warning when site metadata is missing. Station-filtered fetches now send `code_entite` (Hub'Eau v2's only accepted station parameter) instead of `code_station`, which the API silently ignored — a "single station" request was quietly returning data from across the whole national network. Multi-page pagination also no longer contaminates results: after page one the collector passed `params={}`, which httpx interprets as "rebuild the query string", stripping the cursor, station and grandeur filters off Hub'Eau's absolute `next` link so every subsequent page silently hit the unfiltered national dataset (39M+ records); it now passes `params=None` and sends the `next` URL as-is. Other Hub'Eau grandeurs still fall back to `WaterQualitySample`. (#164, closes #97 and #104)
+- **AI recommender no longer degrades silently.** `recommend_with_llm` caught
+  every exception, logged a warning, and returned rule-based results, so a
+  missing `openai` package, a bad API key, a dead endpoint, or an unparseable
+  reply all looked identical to a successful LLM call. The dashboard and CLI
+  now say which engine produced the list and, when the LLM was requested but
+  not used, why.
+- **HuggingFace provider could never work.** `PROVIDER_BASE_URLS["huggingface"]`
+  pointed at `api-inference.huggingface.co`, a host that has been retired and no
+  longer resolves. Now points at `router.huggingface.co/v1`.
+- **LLM output contract was self-contradictory.** The prompt asked for a bare
+  JSON array while `response_format={"type": "json_object"}` forced an object,
+  so valid replies were often dropped. The prompt now asks for
+  `{"recommendations": [...]}`, and parsing accepts arrays, the documented
+  wrapper, arbitrary wrapper keys, and JSON embedded in prose. A missing `id`
+  no longer raises `KeyError` into the silent fallback.
+
+- **Every shipped HuggingFace model was unserved.** `Mistral-7B-Instruct-v0.3`,
+  `zephyr-7b-beta`, and `Meta-Llama-3-8B-Instruct` are not in
+  `router.huggingface.co`'s catalogue, so the HuggingFace provider returned 404
+  for every request even with a valid token. Replaced with models verified
+  against the live `/v1/models` list. Groq's decommissioned
+  `mixtral-8x7b-32768` likewise replaced with `llama-3.3-70b-versatile`.
 
 ## [0.10.0] - 2026-08-12
 

--- a/aquascope/ai_engine/__init__.py
+++ b/aquascope/ai_engine/__init__.py
@@ -12,8 +12,10 @@ from aquascope.ai_engine.planner import ChallengePlanner, ChallengeSpec
 from aquascope.ai_engine.recommender import (
     DatasetProfile,
     Recommendation,
+    RecommendationResult,
     recommend,
     recommend_with_llm,
+    recommend_with_llm_detailed,
 )
 
 __all__ = [
@@ -23,8 +25,10 @@ __all__ = [
     "search_methodologies",
     "DatasetProfile",
     "Recommendation",
+    "RecommendationResult",
     "recommend",
     "recommend_with_llm",
+    "recommend_with_llm_detailed",
     "ChallengePlanner",
     "ChallengeSpec",
     "ModelRecommender",

--- a/aquascope/ai_engine/recommender.py
+++ b/aquascope/ai_engine/recommender.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -46,6 +47,34 @@ class Recommendation:
     methodology: ResearchMethodology
     score: float           # 0-100
     rationale: str = ""
+
+
+@dataclass
+class RecommendationResult:
+    """
+    Recommendations plus how they were produced.
+
+    ``mode`` is ``"llm"`` when a language model actually answered, and
+    ``"rule_based"`` when the heuristic scorer produced the list.  When the
+    LLM was requested but could not be used, ``error`` holds a human-readable
+    reason so callers can show it instead of silently degrading.
+    """
+
+    recommendations: list[Recommendation]
+    mode: str = "rule_based"      # "llm" | "rule_based"
+    provider: str = ""
+    model: str = ""
+    error: str = ""
+
+    @property
+    def used_llm(self) -> bool:
+        return self.mode == "llm"
+
+    def __iter__(self):
+        return iter(self.recommendations)
+
+    def __len__(self) -> int:
+        return len(self.recommendations)
 
 
 # ── Rule-based scorer ────────────────────────────────────────────────
@@ -172,31 +201,120 @@ def recommend(
 # ── Optional LLM-enhanced recommendation ─────────────────────────────
 
 _OPENAI_HOST = "api.openai.com"
-_HUGGINGFACE_HOST = "api-inference.huggingface.co"
+_HUGGINGFACE_HOST = "huggingface.co"   # matches router.* and the retired api-inference.*
 _GROQ_HOST = "api.groq.com"
 
 # Public constants used by the dashboard UI
 PROVIDER_BASE_URLS: dict[str, str | None] = {
     "openai": None,
-    "huggingface": "https://api-inference.huggingface.co/v1/",
+    # api-inference.huggingface.co was retired and no longer resolves; the
+    # serverless inference API now lives behind router.huggingface.co.
+    "huggingface": "https://router.huggingface.co/v1",
     "groq": "https://api.groq.com/openai/v1",
     "ollama": "http://localhost:11434/v1",
 }
 
 PROVIDER_MODELS: dict[str, list[str]] = {
     "openai": ["gpt-4o-mini", "gpt-4o"],
+    # Checked against https://router.huggingface.co/v1/models — the previous
+    # defaults (Mistral-7B-Instruct-v0.3, zephyr-7b-beta, Meta-Llama-3-8B)
+    # are no longer served and returned 404 for every request.
     "huggingface": [
-        "mistralai/Mistral-7B-Instruct-v0.3",
-        "HuggingFaceH4/zephyr-7b-beta",
-        "meta-llama/Meta-Llama-3-8B-Instruct",
+        "Qwen/Qwen2.5-7B-Instruct",
+        "meta-llama/Llama-3.1-8B-Instruct",
+        "Qwen/Qwen3-8B",
+        "google/gemma-3-12b-it",
+        "microsoft/phi-4",
     ],
     "groq": [
         "llama-3.1-8b-instant",
-        "mixtral-8x7b-32768",
+        "llama-3.3-70b-versatile",
         "llama3-8b-8192",
     ],
     "ollama": ["mistral", "llama3.2", "qwen2.5:7b"],
 }
+
+# ── Deployment-supplied ("hosted") credentials ───────────────────────
+#
+# A deployment can put ONE free API token in the environment so that visitors
+# get LLM-backed recommendations without creating an account of their own.
+# This is how the public HuggingFace Space demo works: the Space owner adds
+# HF_TOKEN as a Space secret.  No key is ever bundled in the package.
+
+HOSTED_HF_ENV_KEYS = ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN")
+HOSTED_GENERIC_ENV_KEY = "AQUASCOPE_LLM_API_KEY"
+
+# Small, fast, reliable at structured output, and cheap on a free quota.
+HOSTED_DEFAULT_HF_MODEL = "Qwen/Qwen2.5-7B-Instruct"
+
+
+def hosted_llm_config() -> dict[str, Any] | None:
+    """
+    Return an LLM config supplied by the deployment's environment, or None.
+
+    Resolution order:
+
+    1. ``AQUASCOPE_LLM_API_KEY`` with optional ``AQUASCOPE_LLM_BASE_URL`` and
+       ``AQUASCOPE_LLM_MODEL`` — any OpenAI-compatible provider.
+    2. ``HF_TOKEN`` / ``HUGGING_FACE_HUB_TOKEN`` — HuggingFace serverless
+       inference, the convention a HuggingFace Space secret already follows.
+
+    Returns None when nothing is configured, which is the normal case for a
+    plain ``pip install``: the recommender then stays rule-based unless the
+    user supplies their own key in the UI.
+    """
+    base_url_override = os.environ.get("AQUASCOPE_LLM_BASE_URL", "").strip()
+    model_override = os.environ.get("AQUASCOPE_LLM_MODEL", "").strip()
+
+    generic_key = os.environ.get(HOSTED_GENERIC_ENV_KEY, "").strip()
+    if generic_key:
+        base_url = base_url_override or None
+        return {
+            "provider": _detect_provider(base_url),
+            "model": model_override or "gpt-4o-mini",
+            "api_key": generic_key,
+            "base_url": base_url,
+            "hosted": True,
+        }
+
+    hf_key = next(
+        (os.environ[k].strip() for k in HOSTED_HF_ENV_KEYS if os.environ.get(k, "").strip()),
+        "",
+    )
+    if hf_key:
+        base_url = base_url_override or PROVIDER_BASE_URLS["huggingface"]
+        return {
+            "provider": _detect_provider(base_url),
+            "model": model_override or HOSTED_DEFAULT_HF_MODEL,
+            "api_key": hf_key,
+            "base_url": base_url,
+            "hosted": True,
+        }
+
+    return None
+
+
+class LLMOutputError(ValueError):
+    """The LLM replied, but the reply could not be turned into recommendations."""
+
+
+class LLMDependencyError(ImportError):
+    """A Python package required to reach the chosen provider is missing."""
+
+
+def _detect_provider(base_url: str | None) -> str:
+    """Map a base_url onto a provider name used for request tuning and messages."""
+    if not base_url:
+        return "openai"
+    if _HUGGINGFACE_HOST in base_url:
+        return "huggingface"
+    if _GROQ_HOST in base_url:
+        return "groq"
+    if "localhost" in base_url or "127.0.0.1" in base_url:
+        return "ollama"
+    if _OPENAI_HOST in base_url:
+        return "openai"
+    return "openai-compatible"
 
 
 def _build_prompts(profile: DatasetProfile, top_k: int) -> tuple[str, str]:
@@ -217,12 +335,16 @@ def _build_prompts(profile: DatasetProfile, top_k: int) -> tuple[str, str]:
     ]
     kb_json = json.dumps(compact_kb, ensure_ascii=False)
 
+    # A JSON *object* wrapper, not a bare array: providers that support
+    # response_format={"type": "json_object"} reject a top-level array, and
+    # _parse_llm_output accepts either shape anyway.
     system_prompt = (
         "You are a water-resources research advisor. "
-        "Output ONLY a JSON array — no markdown, no explanation, no code fences. "
+        "Output ONLY a JSON object — no markdown, no explanation, no code fences. "
         f"Pick the top {top_k} methodologies from the catalogue that best fit the dataset. "
-        "Each element must have exactly: "
-        "\"id\" (string), \"score\" (integer 0-100), \"rationale\" (one sentence)."
+        'Reply with {"recommendations": [...]} where each element has exactly: '
+        '"id" (string, copied verbatim from the catalogue), '
+        '"score" (integer 0-100), "rationale" (one sentence).'
     )
     user_prompt = (
         f"Dataset: {profile_json}\n\n"
@@ -231,25 +353,156 @@ def _build_prompts(profile: DatasetProfile, top_k: int) -> tuple[str, str]:
     return system_prompt, user_prompt
 
 
+def _coerce_items(parsed: Any) -> list[Any]:
+    """Pull the recommendation list out of whatever JSON shape the model returned."""
+    if isinstance(parsed, list):
+        return parsed
+    if isinstance(parsed, dict):
+        # Preferred key first, then any other list-of-objects value — models
+        # routinely rename the wrapper to "methodologies", "results", "items"…
+        preferred = parsed.get("recommendations")
+        if isinstance(preferred, list):
+            return preferred
+        for value in parsed.values():
+            if isinstance(value, list) and all(isinstance(v, dict) for v in value):
+                return value
+        # A single recommendation returned unwrapped.
+        if "id" in parsed:
+            return [parsed]
+    return []
+
+
 def _parse_llm_output(raw_text: str, top_k: int) -> list[Recommendation]:
+    """
+    Turn a raw model reply into Recommendations.
+
+    Raises
+    ------
+    LLMOutputError
+        If the reply is not JSON, or contains no id that matches the catalogue.
+    """
     import re as _re
 
-    raw_text = _re.sub(r"```(?:json)?\s*", "", raw_text).strip().rstrip("`").strip()
-    parsed = json.loads(raw_text)
-    items = parsed if isinstance(parsed, list) else parsed.get("recommendations", [])
+    text = _re.sub(r"```(?:json)?\s*", "", raw_text or "").strip().rstrip("`").strip()
+    if not text:
+        raise LLMOutputError("the model returned an empty reply")
 
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError:
+        # Some models wrap JSON in prose; salvage the first object or array.
+        match = _re.search(r"[\[{].*[\]}]", text, _re.DOTALL)
+        if not match:
+            raise LLMOutputError(
+                f"the model did not return JSON (got: {text[:120]!r})"
+            ) from None
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError as exc:
+            raise LLMOutputError(f"the model returned malformed JSON ({exc})") from None
+
+    items = _coerce_items(parsed)
+    if not items:
+        raise LLMOutputError("the model returned JSON with no recommendation list")
+
+    by_id = {m.id: m for m in METHODOLOGIES}
     results: list[Recommendation] = []
     for item in items[:top_k]:
-        method = next((m for m in METHODOLOGIES if m.id == item["id"]), None)
-        if method:
-            results.append(
-                Recommendation(
-                    methodology=method,
-                    score=float(item.get("score", 50)),
-                    rationale=item.get("rationale", ""),
-                )
+        if not isinstance(item, dict):
+            continue
+        method = by_id.get(str(item.get("id", "")))
+        if method is None:
+            continue
+        try:
+            score = float(item.get("score", 50))
+        except (TypeError, ValueError):
+            score = 50.0
+        results.append(
+            Recommendation(
+                methodology=method,
+                score=score,
+                rationale=str(item.get("rationale", "")),
             )
+        )
+
+    if not results:
+        raise LLMOutputError(
+            "the model returned no methodology id matching the catalogue"
+        )
     return results
+
+
+def _describe_llm_error(exc: BaseException, provider: str, model: str) -> str:
+    """Turn an exception from the LLM path into a short, actionable sentence."""
+    text = str(exc).strip()
+    lowered = text.lower()
+    label = provider or "the provider"
+
+    if isinstance(exc, LLMDependencyError):
+        return text
+    if isinstance(exc, LLMOutputError):
+        return f"{label} replied, but {text}."
+    if "401" in text or "unauthorized" in lowered or "invalid api key" in lowered:
+        return f"{label} rejected the API key (authentication failed)."
+    if "403" in text or "forbidden" in lowered or "permission" in lowered:
+        return f"{label} refused the request (check the key's permissions)."
+    if "402" in text or "payment required" in lowered or "credits" in lowered:
+        return f"{label} reports the account is out of inference credits."
+    if "429" in text or "rate limit" in lowered or "quota" in lowered:
+        return f"{label} rate limit or quota exceeded — retry later."
+    if "404" in text or "does not exist" in lowered or "not found" in lowered:
+        return f"{label} does not serve the model '{model}' — pick a different model."
+    if "timeout" in lowered or "timed out" in lowered:
+        return f"{label} did not respond before the timeout."
+    if any(
+        w in lowered
+        for w in ("could not resolve", "name or service", "nodename", "connect", "refused", "unreachable")
+    ):
+        return f"Could not reach {label}: {text[:160]}"
+
+    detail = text[:200] or type(exc).__name__
+    return f"{label} call failed: {type(exc).__name__}: {detail}"
+
+
+def _call_openai_compatible(
+    provider: str,
+    model: str,
+    api_key: str | None,
+    base_url: str | None,
+    system_prompt: str,
+    user_prompt: str,
+    timeout: float,
+) -> str:
+    """Call any OpenAI-compatible chat endpoint and return the raw reply text."""
+    try:
+        import httpx
+        from openai import OpenAI
+    except ImportError as exc:
+        raise LLMDependencyError(
+            "The 'openai' package is not installed, so LLM providers are "
+            "unavailable. Install it with:  pip install 'aquascope[llm]'"
+        ) from exc
+
+    client = OpenAI(
+        api_key=api_key or "dummy",
+        base_url=base_url or None,
+        timeout=httpx.Timeout(timeout, connect=10.0),
+    )
+    kwargs: dict[str, Any] = dict(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ],
+        temperature=0.3,
+        max_tokens=1024,
+    )
+    # json_object mode is reliable on OpenAI and Groq; other endpoints vary.
+    if provider in ("openai", "groq"):
+        kwargs["response_format"] = {"type": "json_object"}
+
+    resp = client.chat.completions.create(**kwargs)
+    return resp.choices[0].message.content or ""
 
 
 def _call_ollama_native(
@@ -295,6 +548,63 @@ def _call_ollama_native(
     return resp.json()["message"]["content"]
 
 
+def recommend_with_llm_detailed(
+    profile: DatasetProfile,
+    top_k: int = 5,
+    model: str = "gpt-4o-mini",
+    api_key: str | None = None,
+    base_url: str | None = None,
+    timeout: float = 120.0,
+) -> RecommendationResult:
+    """
+    Use an LLM for nuanced methodology recommendations, reporting what happened.
+
+    Unlike :func:`recommend_with_llm`, this never degrades silently: on any
+    failure it still returns rule-based recommendations, but ``mode`` is
+    ``"rule_based"`` and ``error`` explains why the LLM was not used, so a UI
+    or CLI can show the reason to the user.
+
+    Supported providers (detected from base_url):
+    - OpenAI (base_url=None or api.openai.com)
+    - HuggingFace serverless inference (router.huggingface.co) — free tier
+    - Groq (api.groq.com) — free tier
+    - Ollama local (localhost) — uses native /api/chat to avoid openai-client quirks
+    - Any other OpenAI-compatible endpoint
+    """
+    provider = _detect_provider(base_url)
+    system_prompt, user_prompt = _build_prompts(profile, top_k)
+
+    try:
+        if provider == "ollama":
+            raw_text = _call_ollama_native(
+                base_url or PROVIDER_BASE_URLS["ollama"],  # type: ignore[arg-type]
+                model,
+                system_prompt,
+                user_prompt,
+                timeout,
+            )
+        else:
+            raw_text = _call_openai_compatible(
+                provider, model, api_key, base_url, system_prompt, user_prompt, timeout
+            )
+
+        recs = _parse_llm_output(raw_text, top_k)
+        return RecommendationResult(
+            recommendations=recs, mode="llm", provider=provider, model=model
+        )
+
+    except Exception as exc:
+        reason = _describe_llm_error(exc, provider, model)
+        logger.warning("LLM recommendation failed (%s); falling back to rule-based.", reason)
+        return RecommendationResult(
+            recommendations=recommend(profile, top_k=top_k),
+            mode="rule_based",
+            provider=provider,
+            model=model,
+            error=reason,
+        )
+
+
 def recommend_with_llm(
     profile: DatasetProfile,
     top_k: int = 5,
@@ -306,61 +616,15 @@ def recommend_with_llm(
     """
     Use an LLM to provide more nuanced methodology recommendations.
 
-    Falls back to rule-based if the LLM call fails.
-
-    Supported providers (detected from base_url):
-    - OpenAI (base_url=None or api.openai.com)
-    - HuggingFace Inference API (api-inference.huggingface.co) — free tier
-    - Groq (api.groq.com) — free tier
-    - Ollama local (localhost) — uses native /api/chat to avoid openai-client quirks
+    Falls back to rule-based if the LLM call fails.  Use
+    :func:`recommend_with_llm_detailed` when you need to know whether the LLM
+    actually answered, and why it did not.
     """
-    if base_url and _HUGGINGFACE_HOST in base_url:
-        provider = "huggingface"
-    elif base_url and _GROQ_HOST in base_url:
-        provider = "groq"
-    elif base_url and "localhost" in base_url:
-        provider = "ollama"
-    else:
-        provider = "openai"
-
-    system_prompt, user_prompt = _build_prompts(profile, top_k)
-
-    try:
-        if provider == "ollama":
-            raw_text = _call_ollama_native(
-                base_url, model, system_prompt, user_prompt, timeout  # type: ignore[arg-type]
-            )
-        else:
-            try:
-                import httpx
-                from openai import OpenAI
-            except ImportError:
-                logger.warning("openai package not installed; falling back to rule-based.")
-                return recommend(profile, top_k=top_k)
-
-            client = OpenAI(
-                api_key=api_key or "dummy",
-                base_url=base_url or None,
-                timeout=httpx.Timeout(timeout, connect=10.0),
-            )
-            kwargs: dict[str, Any] = dict(
-                model=model,
-                messages=[
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
-                temperature=0.3,
-                max_tokens=1024,
-            )
-            # json_object mode is reliable on OpenAI and Groq; HF models vary
-            if provider in ("openai", "groq"):
-                kwargs["response_format"] = {"type": "json_object"}
-
-            resp = client.chat.completions.create(**kwargs)
-            raw_text = resp.choices[0].message.content or "[]"
-
-        return _parse_llm_output(raw_text, top_k)
-
-    except Exception as exc:
-        logger.warning("LLM recommendation failed (%s); falling back to rule-based.", exc)
-        return recommend(profile, top_k=top_k)
+    return recommend_with_llm_detailed(
+        profile,
+        top_k=top_k,
+        model=model,
+        api_key=api_key,
+        base_url=base_url,
+        timeout=timeout,
+    ).recommendations

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -276,7 +276,11 @@ def cmd_collect(args: argparse.Namespace) -> None:
 
 def cmd_recommend(args: argparse.Namespace) -> None:
     """Generate methodology recommendations."""
-    from aquascope.ai_engine.recommender import DatasetProfile, recommend, recommend_with_llm
+    from aquascope.ai_engine.recommender import (
+        DatasetProfile,
+        recommend,
+        recommend_with_llm_detailed,
+    )
 
     # Build profile from CLI args or from a data file
     parameters = [p.strip() for p in args.parameters.split(",")] if args.parameters else []
@@ -304,14 +308,22 @@ def cmd_recommend(args: argparse.Namespace) -> None:
                 sources = {r.get("source", "") for r in data if r.get("source")}
                 profile.data_sources = list(sources)
 
+    engine_note = ""
     if args.use_llm:
-        recs = recommend_with_llm(
+        result = recommend_with_llm_detailed(
             profile,
             top_k=args.top_k,
             model=args.model or "gpt-4o-mini",
             api_key=args.llm_api_key,
             base_url=args.llm_base_url,
         )
+        recs = result.recommendations
+        if result.mode == "llm":
+            engine_note = f"  Engine: {result.provider} · {result.model}"
+        else:
+            # Never degrade silently: say the LLM was skipped and why.
+            print(f"⚠️  LLM unavailable — showing rule-based results. {result.error}")
+            engine_note = "  Engine: rule-based (LLM fallback)"
     else:
         recs = recommend(profile, top_k=args.top_k)
 
@@ -321,6 +333,8 @@ def cmd_recommend(args: argparse.Namespace) -> None:
 
     print(f"\n{'=' * 70}")
     print(f"  AquaScope — Top {len(recs)} Research Methodology Recommendations")
+    if engine_note:
+        print(engine_note)
     print(f"{'=' * 70}\n")
     for i, rec in enumerate(recs, 1):
         m = rec.methodology

--- a/aquascope/dashboard/views/ai.py
+++ b/aquascope/dashboard/views/ai.py
@@ -10,9 +10,11 @@ from aquascope.dashboard import _state
 
 logger = logging.getLogger(__name__)
 
+_HOSTED_KEY = "hosted"
+
 _PROVIDER_LABELS = {
     "rule_based": "Rule-based (free, no key needed)",
-    "huggingface": "HuggingFace Inference API (free)",
+    "huggingface": "HuggingFace Inference API (free tier — bring your own token)",
     "groq": "Groq (free tier — fast open-source models)",
     "openai": "OpenAI",
     "ollama": "Ollama (local)",
@@ -61,23 +63,15 @@ def render() -> None:
             if st.button("🔍 Recommend from data", key="btn_rec_auto", type="primary"):
                 with st.spinner("Profiling dataset and generating recommendations…"):
                     try:
-                        from aquascope.ai_engine.recommender import recommend, recommend_with_llm
                         from aquascope.analysis.eda import profile_dataset
 
                         profile = profile_dataset(df)
                         if goal_auto:
                             profile.research_goal = goal_auto
 
-                        if llm_config:
-                            recs = recommend_with_llm(
-                                profile, top_k=top_k_auto,
-                                model=llm_config["model"],
-                                api_key=llm_config["api_key"],
-                                base_url=llm_config["base_url"],
-                            )
-                        else:
-                            recs = recommend(profile, top_k=top_k_auto)
-                        _display_recommendations(recs)
+                        result = _run_recommender(profile, top_k_auto, llm_config)
+                        _display_mode_banner(result, llm_config)
+                        _display_recommendations(result.recommendations)
                     except Exception as exc:  # noqa: BLE001
                         st.error(f"Recommendation failed: {exc}")
                         logger.exception("AI recommender error")
@@ -99,7 +93,7 @@ def render() -> None:
         if st.button("🔍 Get recommendations", key="btn_rec_manual", type="primary"):
             with st.spinner("Generating recommendations…"):
                 try:
-                    from aquascope.ai_engine.recommender import DatasetProfile, recommend, recommend_with_llm
+                    from aquascope.ai_engine.recommender import DatasetProfile
 
                     profile = DatasetProfile(
                         parameters=[p.strip() for p in parameters.split(",") if p.strip()],
@@ -111,35 +105,141 @@ def render() -> None:
                         keywords=[k.strip() for k in keywords.split(",") if k.strip()],
                     )
 
-                    if llm_config:
-                        recs = recommend_with_llm(
-                            profile, top_k=top_k,
-                            model=llm_config["model"],
-                            api_key=llm_config["api_key"],
-                            base_url=llm_config["base_url"],
-                        )
-                    else:
-                        recs = recommend(profile, top_k=top_k)
-                    _display_recommendations(recs)
+                    result = _run_recommender(profile, top_k, llm_config)
+                    _display_mode_banner(result, llm_config)
+                    _display_recommendations(result.recommendations)
                 except Exception as exc:  # noqa: BLE001
                     st.error(f"Recommendation failed: {exc}")
                     logger.exception("AI recommender error")
 
 
+def _run_recommender(profile, top_k: int, llm_config: dict | None):
+    """Run the recommender in whichever mode the user selected."""
+    from aquascope.ai_engine.recommender import (
+        RecommendationResult,
+        recommend,
+        recommend_with_llm_detailed,
+    )
+
+    if llm_config:
+        return recommend_with_llm_detailed(
+            profile,
+            top_k=top_k,
+            model=llm_config["model"],
+            api_key=llm_config["api_key"],
+            base_url=llm_config["base_url"],
+        )
+    return RecommendationResult(
+        recommendations=recommend(profile, top_k=top_k), mode="rule_based"
+    )
+
+
+def _display_mode_banner(result, llm_config: dict | None) -> None:
+    """Say which engine produced the list, and why the LLM was skipped."""
+    is_hosted = bool(llm_config and llm_config.get("hosted"))
+
+    if result.mode == "llm":
+        if is_hosted:
+            st.success(f"✨ Enhanced by the free hosted demo model · `{result.model}`")
+        else:
+            st.success(f"✨ Enhanced by {result.provider} · `{result.model}`")
+        return
+
+    if is_hosted:
+        # The shared free quota is finite; say so and point at the way out.
+        st.warning(
+            f"**Free hosted AI unavailable — showing rule-based results.** {result.error} "
+            "You can add your own free API key under **⚙️ LLM enhancement** above.",
+            icon="⚠️",
+        )
+        return
+
+    if llm_config:
+        # The user asked for an LLM and did not get one — never fail silently.
+        st.warning(
+            f"**LLM unavailable — showing rule-based results.** {result.error}",
+            icon="⚠️",
+        )
+        return
+
+    st.caption("Scored by the built-in rule-based engine (no LLM requested).")
+
+
+_SECRET_KEYS = (
+    "AQUASCOPE_LLM_API_KEY",
+    "AQUASCOPE_LLM_BASE_URL",
+    "AQUASCOPE_LLM_MODEL",
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+)
+
+
+def _hydrate_secrets_into_env() -> None:
+    """
+    Mirror Streamlit secrets into the environment.
+
+    HuggingFace Spaces expose secrets as environment variables, but Streamlit
+    Community Cloud exposes them through ``st.secrets``.  Copying them across
+    lets one deployment-supplied token work on either host, and keeps the
+    library side (``hosted_llm_config``) free of any Streamlit dependency.
+    """
+    import os
+
+    try:
+        secrets = st.secrets
+    except Exception:  # noqa: BLE001 — no secrets file configured is normal
+        return
+
+    for key in _SECRET_KEYS:
+        if os.environ.get(key):
+            continue
+        try:
+            value = secrets[key]
+        except Exception:  # noqa: BLE001 — key simply absent
+            continue
+        if value:
+            os.environ[key] = str(value)
+
+
 def _render_llm_config() -> dict | None:
-    from aquascope.ai_engine.recommender import PROVIDER_BASE_URLS, PROVIDER_MODELS
+    from aquascope.ai_engine.recommender import (
+        PROVIDER_BASE_URLS,
+        PROVIDER_MODELS,
+        hosted_llm_config,
+    )
+
+    # Set by the deployment (e.g. HF_TOKEN as a Space secret), never bundled.
+    _hydrate_secrets_into_env()
+    hosted = hosted_llm_config()
+
+    options = list(_PROVIDER_LABELS.keys())
+    labels = dict(_PROVIDER_LABELS)
+    if hosted:
+        options.insert(0, _HOSTED_KEY)
+        labels[_HOSTED_KEY] = "✨ Free AI — hosted for this demo, no key needed"
 
     with st.expander("⚙️ LLM enhancement (optional)", expanded=False):
-        st.caption(
-            "Augment rule-based scoring with a language model for richer rationales. "
-            "HuggingFace and Groq offer free tiers — no credit card required."
-        )
+        if hosted:
+            st.caption(
+                "This deployment provides a free hosted model, so you can try the "
+                "AI recommender without an account. It runs on a shared free quota — "
+                "add your own key below if you hit a limit or want a different model."
+            )
+        else:
+            st.caption(
+                "Augment rule-based scoring with a language model for richer rationales. "
+                "HuggingFace and Groq offer free tiers — no credit card required."
+            )
+
         provider = st.selectbox(
             "Provider",
-            list(_PROVIDER_LABELS.keys()),
-            format_func=lambda k: _PROVIDER_LABELS[k],
+            options,
+            format_func=lambda k: labels[k],
             key="llm_provider",
         )
+        if provider == _HOSTED_KEY:
+            st.caption(f"Model: `{hosted['model']}` via {hosted['provider']}")
+            return hosted
         if provider == "rule_based":
             return None
 

--- a/deploy/huggingface-space/README.md
+++ b/deploy/huggingface-space/README.md
@@ -23,3 +23,35 @@ recommendations, all in one Streamlit workspace.
 
 To update this Space, push a new commit; `requirements.txt` tracks the `main`
 branch of the GitHub repository.
+
+## Free AI recommender for visitors
+
+The AI Methodology Recommender works with no credentials at all: it falls back
+to a rule-based scorer built into the package. To give visitors the
+LLM-enhanced version without asking them for an account, add one free token as
+a Space secret:
+
+1. Create a free token at <https://huggingface.co/settings/tokens>
+   (read access is enough, no credit card).
+2. In the Space, go to **Settings → Variables and secrets → New secret**.
+3. Name it `HF_TOKEN` and paste the token.
+
+The dashboard detects it at runtime and offers **✨ Free AI — hosted for this
+demo, no key needed** as the default provider. Visitors never see or receive
+the token; only the Space's own server uses it.
+
+Optional overrides, set the same way:
+
+| Secret / variable | Default | Purpose |
+|---|---|---|
+| `HF_TOKEN` | — | Free HuggingFace inference token |
+| `AQUASCOPE_LLM_MODEL` | `Qwen/Qwen2.5-7B-Instruct` | Any model served by `router.huggingface.co` |
+| `AQUASCOPE_LLM_API_KEY` | — | Use a non-HuggingFace provider instead |
+| `AQUASCOPE_LLM_BASE_URL` | — | OpenAI-compatible endpoint for the key above |
+
+The free tier is a shared, rate-limited quota. When it runs out the recommender
+shows rule-based results with a notice telling the visitor to add their own key,
+so the page never breaks.
+
+The same secrets work on Streamlit Community Cloud, set through
+**App settings → Secrets** rather than Space secrets.

--- a/deploy/huggingface-space/deploy.sh
+++ b/deploy/huggingface-space/deploy.sh
@@ -19,3 +19,9 @@ hf upload "$SPACE" "$HERE" . --repo-type space --exclude "deploy.sh"
 
 echo "✓ Deployed. The Space builds in a few minutes at:"
 echo "  https://huggingface.co/spaces/$SPACE"
+echo
+echo "To give visitors the free AI recommender (no key needed on their side),"
+echo "add a read token from https://huggingface.co/settings/tokens as a Space"
+echo "secret named HF_TOKEN:"
+echo "  Settings → Variables and secrets → New secret → HF_TOKEN"
+echo "Without it the recommender still works, using the rule-based scorer."

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -91,6 +91,57 @@ m = plot_station_map(stations)
 display(m)
 ```
 
+## AI Recommender Issues
+
+### How do I try the AI recommender for free?
+Three options, cheapest first:
+
+1. **Do nothing.** The rule-based scorer needs no key, no account, and no
+   network. It is the default and it scores all 26 methodologies.
+2. **Free HuggingFace token.** Create one at
+   <https://huggingface.co/settings/tokens> (read access, no credit card),
+   then paste it under **⚙️ LLM enhancement → HuggingFace**. Models known to
+   be served are listed in the Model dropdown.
+3. **Ollama, fully offline.** `ollama serve`, then select **Ollama (local)**.
+   No account and no data leaves your machine.
+
+There is no anonymous hosted inference: HuggingFace returns 401 without a
+token. If you are running a public deployment for others, see
+[the Space README](https://github.com/Rekin226/aquascope/blob/main/deploy/huggingface-space/README.md)
+for how to supply one token server-side so visitors need no account.
+
+### "Free hosted AI unavailable"
+The deployment's shared free quota is exhausted or its token is invalid. You
+still get rule-based results. Add your own free key under **⚙️ LLM
+enhancement** to bypass the shared quota.
+
+### "LLM unavailable — showing rule-based results"
+The recommender always returns results: if the language model cannot be reached
+it falls back to the built-in rule-based scorer and tells you why. The message
+after the banner is the actual cause:
+
+| Message | Fix |
+|---|---|
+| `The 'openai' package is not installed` | `pip install "aquascope[llm]"` |
+| `rejected the API key (authentication failed)` | Check the key, and that it belongs to the selected provider |
+| `does not serve the model '<name>'` | Pick a different model; provider catalogues change over time |
+| `rate limit or quota exceeded` | Wait, or switch provider |
+| `Could not reach <provider>` | Check network access, or that Ollama is running (`ollama serve`) |
+| `replied, but the model did not return JSON` | Use a stronger instruction-following model |
+
+The rule-based results are still valid, they just come from the heuristic
+scorer rather than a model.
+
+### Recommendations look generic
+Rationales like "This methodology is generally applicable to …" come from the
+rule-based scorer. If you selected an LLM provider and still see these, check
+for the fallback banner above: the model was not used.
+
+### The recommender hangs for a long time
+Local Ollama models have a 120 s timeout. A large model on CPU can use all of
+it. Pick a smaller model (for example `llama3.2`) or run `ollama serve` with GPU
+acceleration.
+
 ## CLI Issues
 
 ### `aquascope: command not found`

--- a/tests/test_ai_engine/test_recommender_llm.py
+++ b/tests/test_ai_engine/test_recommender_llm.py
@@ -1,0 +1,321 @@
+"""Tests for the LLM-enhanced recommender path and its failure reporting.
+
+The point of these tests is that the LLM path must never degrade *silently*:
+whenever it falls back to the rule-based scorer, the result has to say so and
+carry a reason a UI can show.
+"""
+
+import json
+
+import pytest
+
+from aquascope.ai_engine.knowledge_base import METHODOLOGIES
+from aquascope.ai_engine.recommender import (
+    HOSTED_DEFAULT_HF_MODEL,
+    PROVIDER_BASE_URLS,
+    PROVIDER_MODELS,
+    DatasetProfile,
+    LLMOutputError,
+    RecommendationResult,
+    _coerce_items,
+    _describe_llm_error,
+    _detect_provider,
+    _parse_llm_output,
+    hosted_llm_config,
+    recommend_with_llm,
+    recommend_with_llm_detailed,
+)
+
+_HOSTED_ENV = (
+    "AQUASCOPE_LLM_API_KEY",
+    "AQUASCOPE_LLM_BASE_URL",
+    "AQUASCOPE_LLM_MODEL",
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Start from an environment with no deployment-supplied credentials."""
+    for key in _HOSTED_ENV:
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch
+
+PROFILE = DatasetProfile(
+    parameters=["DO", "BOD5", "pH"],
+    n_records=500,
+    n_stations=8,
+    time_span_years=6.0,
+    geographic_scope="Taiwan",
+    research_goal="trend analysis",
+)
+
+
+def _ids(n=3):
+    return [m.id for m in METHODOLOGIES[:n]]
+
+
+class TestProviderDetection:
+    @pytest.mark.parametrize(
+        ("base_url", "expected"),
+        [
+            (None, "openai"),
+            ("https://api.openai.com/v1", "openai"),
+            ("https://router.huggingface.co/v1", "huggingface"),
+            # The retired host must still be recognised as HuggingFace so old
+            # saved configs produce an HF-flavoured error, not an OpenAI one.
+            ("https://api-inference.huggingface.co/v1/", "huggingface"),
+            ("https://api.groq.com/openai/v1", "groq"),
+            ("http://localhost:11434/v1", "ollama"),
+            ("http://127.0.0.1:11434/v1", "ollama"),
+            ("https://my-vllm.internal/v1", "openai-compatible"),
+        ],
+    )
+    def test_detect_provider(self, base_url, expected):
+        assert _detect_provider(base_url) == expected
+
+    def test_huggingface_base_url_is_the_live_host(self):
+        # api-inference.huggingface.co no longer resolves.
+        assert PROVIDER_BASE_URLS["huggingface"] == "https://router.huggingface.co/v1"
+
+
+class TestParsing:
+    def test_parses_bare_array(self):
+        raw = json.dumps([{"id": _ids(1)[0], "score": 88, "rationale": "fits"}])
+        recs = _parse_llm_output(raw, top_k=5)
+        assert len(recs) == 1
+        assert recs[0].score == 88.0
+        assert recs[0].rationale == "fits"
+
+    def test_parses_recommendations_object(self):
+        raw = json.dumps({"recommendations": [{"id": i, "score": 70} for i in _ids(3)]})
+        assert len(_parse_llm_output(raw, top_k=5)) == 3
+
+    def test_parses_object_with_renamed_wrapper_key(self):
+        # json_object mode makes models invent their own wrapper key.
+        raw = json.dumps({"methodologies": [{"id": i, "score": 60} for i in _ids(2)]})
+        assert len(_parse_llm_output(raw, top_k=5)) == 2
+
+    def test_parses_json_wrapped_in_code_fence_and_prose(self):
+        raw = "Sure! Here you go:\n```json\n" + json.dumps(
+            {"recommendations": [{"id": _ids(1)[0], "score": 50}]}
+        ) + "\n```"
+        assert len(_parse_llm_output(raw, top_k=5)) == 1
+
+    def test_respects_top_k(self):
+        raw = json.dumps({"recommendations": [{"id": i, "score": 50} for i in _ids(5)]})
+        assert len(_parse_llm_output(raw, top_k=2)) == 2
+
+    def test_tolerates_non_numeric_score(self):
+        raw = json.dumps([{"id": _ids(1)[0], "score": "high"}])
+        assert _parse_llm_output(raw, top_k=5)[0].score == 50.0
+
+    @pytest.mark.parametrize(
+        "raw",
+        [
+            "",
+            "I'm sorry, I cannot help with that.",
+            "{not json at all",
+            json.dumps({"note": "no list here"}),
+            json.dumps([{"id": "no_such_methodology", "score": 90}]),
+        ],
+    )
+    def test_unusable_output_raises(self, raw):
+        with pytest.raises(LLMOutputError):
+            _parse_llm_output(raw, top_k=5)
+
+    def test_missing_id_does_not_raise_keyerror(self):
+        raw = json.dumps([{"score": 90, "rationale": "no id field"}])
+        with pytest.raises(LLMOutputError):
+            _parse_llm_output(raw, top_k=5)
+
+    def test_coerce_items_handles_single_unwrapped_object(self):
+        assert _coerce_items({"id": "x", "score": 1}) == [{"id": "x", "score": 1}]
+
+
+class TestErrorMessages:
+    @pytest.mark.parametrize(
+        ("message", "needle"),
+        [
+            ("Error code: 401 - invalid_api_key", "authentication failed"),
+            ("Error code: 429 - rate limit reached", "rate limit"),
+            ("Error code: 404 - model_not_found", "does not serve the model"),
+            ("Request timed out.", "timeout"),
+            ("[Errno 8] nodename nor servname provided", "Could not reach"),
+        ],
+    )
+    def test_maps_common_failures_to_readable_text(self, message, needle):
+        described = _describe_llm_error(Exception(message), "groq", "llama-3.1-8b-instant")
+        assert needle in described
+
+    def test_output_error_is_reported_verbatim(self):
+        described = _describe_llm_error(
+            LLMOutputError("the model returned an empty reply"), "openai", "gpt-4o-mini"
+        )
+        assert "empty reply" in described
+
+
+class TestFallbackReporting:
+    def test_missing_openai_package_is_reported(self, monkeypatch):
+        import builtins
+
+        real_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "openai":
+                raise ImportError("No module named 'openai'")
+            return real_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+
+        result = recommend_with_llm_detailed(PROFILE, top_k=3, api_key="sk-test")
+        assert result.mode == "rule_based"
+        assert result.recommendations          # still useful output
+        assert "openai" in result.error
+        assert "aquascope[llm]" in result.error
+
+    def test_transport_failure_is_reported(self, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        def boom(*_args, **_kwargs):
+            raise RuntimeError("Error code: 401 - invalid_api_key")
+
+        monkeypatch.setattr(rec, "_call_openai_compatible", boom)
+
+        result = recommend_with_llm_detailed(
+            PROFILE, top_k=3, base_url="https://api.groq.com/openai/v1", api_key="bad"
+        )
+        assert result.mode == "rule_based"
+        assert result.provider == "groq"
+        assert "authentication failed" in result.error
+        assert not result.used_llm
+
+    def test_successful_llm_call_is_flagged_as_llm(self, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        payload = json.dumps(
+            {"recommendations": [{"id": i, "score": 91, "rationale": "r"} for i in _ids(2)]}
+        )
+        monkeypatch.setattr(rec, "_call_openai_compatible", lambda *a, **k: payload)
+
+        result = recommend_with_llm_detailed(PROFILE, top_k=2, api_key="sk-test")
+        assert result.used_llm
+        assert result.mode == "llm"
+        assert result.error == ""
+        assert [r.score for r in result.recommendations] == [91.0, 91.0]
+
+    def test_unparseable_reply_falls_back_with_reason(self, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        monkeypatch.setattr(rec, "_call_openai_compatible", lambda *a, **k: "no json here")
+
+        result = recommend_with_llm_detailed(PROFILE, top_k=3, api_key="sk-test")
+        assert result.mode == "rule_based"
+        assert "did not return JSON" in result.error
+
+    def test_ollama_uses_native_endpoint(self, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        seen = {}
+
+        def fake_native(base_url, model, *_args, **_kwargs):
+            seen["base_url"] = base_url
+            seen["model"] = model
+            return json.dumps({"recommendations": [{"id": _ids(1)[0], "score": 80}]})
+
+        monkeypatch.setattr(rec, "_call_ollama_native", fake_native)
+
+        result = recommend_with_llm_detailed(
+            PROFILE, top_k=1, model="mistral", base_url="http://localhost:11434/v1"
+        )
+        assert result.used_llm
+        assert result.provider == "ollama"
+        assert seen == {"base_url": "http://localhost:11434/v1", "model": "mistral"}
+
+
+class TestHostedConfig:
+    """A deployment can supply one token so visitors need no account."""
+
+    def test_none_without_credentials(self, clean_env):
+        assert hosted_llm_config() is None
+
+    def test_hf_token_selects_huggingface(self, clean_env):
+        clean_env.setenv("HF_TOKEN", "hf_deployment_token")
+        cfg = hosted_llm_config()
+        assert cfg["provider"] == "huggingface"
+        assert cfg["api_key"] == "hf_deployment_token"
+        assert cfg["base_url"] == PROVIDER_BASE_URLS["huggingface"]
+        assert cfg["model"] == HOSTED_DEFAULT_HF_MODEL
+        assert cfg["hosted"] is True
+
+    def test_legacy_hub_token_name_also_works(self, clean_env):
+        clean_env.setenv("HUGGING_FACE_HUB_TOKEN", "hf_alt")
+        assert hosted_llm_config()["api_key"] == "hf_alt"
+
+    def test_model_override(self, clean_env):
+        clean_env.setenv("HF_TOKEN", "hf_x")
+        clean_env.setenv("AQUASCOPE_LLM_MODEL", "google/gemma-3-12b-it")
+        assert hosted_llm_config()["model"] == "google/gemma-3-12b-it"
+
+    def test_generic_key_takes_precedence_over_hf(self, clean_env):
+        clean_env.setenv("HF_TOKEN", "hf_x")
+        clean_env.setenv("AQUASCOPE_LLM_API_KEY", "sk-generic")
+        clean_env.setenv("AQUASCOPE_LLM_BASE_URL", "https://api.groq.com/openai/v1")
+        cfg = hosted_llm_config()
+        assert cfg["api_key"] == "sk-generic"
+        assert cfg["provider"] == "groq"
+
+    def test_blank_token_is_ignored(self, clean_env):
+        clean_env.setenv("HF_TOKEN", "   ")
+        assert hosted_llm_config() is None
+
+    def test_hosted_default_model_is_actually_served(self):
+        # Guards against the class of bug where the shipped default 404s.
+        assert HOSTED_DEFAULT_HF_MODEL in PROVIDER_MODELS["huggingface"]
+
+    def test_no_credentials_are_bundled_in_the_package(self, clean_env):
+        """The package must never ship a token of its own."""
+        import inspect
+        import re
+
+        import aquascope.ai_engine.recommender as rec
+
+        source = inspect.getsource(rec)
+        token_like = re.findall(r"\b(?:hf_|sk-|gsk_)[A-Za-z0-9]{20,}", source)
+        assert token_like == []
+        assert hosted_llm_config() is None
+
+    def test_quota_exhaustion_is_reported_clearly(self, clean_env, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        def out_of_credits(*_args, **_kwargs):
+            raise RuntimeError("Error code: 402 - You have exceeded your monthly included credits")
+
+        monkeypatch.setattr(rec, "_call_openai_compatible", out_of_credits)
+        clean_env.setenv("HF_TOKEN", "hf_x")
+        cfg = hosted_llm_config()
+
+        result = recommend_with_llm_detailed(
+            PROFILE, top_k=3, model=cfg["model"], api_key=cfg["api_key"], base_url=cfg["base_url"]
+        )
+        assert result.mode == "rule_based"
+        assert result.recommendations           # visitor still gets output
+        assert "out of inference credits" in result.error
+
+
+class TestBackwardCompatibility:
+    def test_recommend_with_llm_still_returns_a_plain_list(self, monkeypatch):
+        import aquascope.ai_engine.recommender as rec
+
+        monkeypatch.setattr(
+            rec, "_call_openai_compatible", lambda *a, **k: "definitely not json"
+        )
+        recs = recommend_with_llm(PROFILE, top_k=3, api_key="sk-test")
+        assert isinstance(recs, list)
+        assert recs  # fell back to rule-based rather than raising
+
+    def test_result_is_iterable_and_sized(self):
+        result = RecommendationResult(recommendations=[], mode="rule_based")
+        assert len(result) == 0
+        assert list(result) == []


### PR DESCRIPTION
## Why

`recommend_with_llm()` caught every exception, logged a warning, and fell back to the rule-based ranking. A missing `openai` package, a bad key, a dead endpoint, and an unparseable reply all looked identical to a successful LLM call, so the "LLM recommender" quietly never ran for most users.

## What changed

- `RecommendationResult` and `recommend_with_llm_detailed()`: recommendations plus `mode` (`llm` / `rule_based`), `provider`, `model`, and a human-readable `error`. The CLI and the dashboard now say which engine produced the list and, when the LLM was requested but not used, why. `recommend_with_llm()` keeps its signature and return type.
- Three dead-on-arrival bugs fixed: the HuggingFace base URL pointed at the retired `api-inference.huggingface.co` host (now `router.huggingface.co/v1`); the prompt asked for a bare JSON array while `response_format={"type": "json_object"}` forbade one; every shipped HF model id was unserved by the router (replaced with ids checked against the live `/v1/models` list, and Groq's decommissioned `mixtral-8x7b-32768` swapped for `llama-3.3-70b-versatile`).
- `hosted_llm_config()`: a deployment can offer LLM-backed recommendations from one env var (`HF_TOKEN`, `HUGGING_FACE_HUB_TOKEN`, or `AQUASCOPE_LLM_API_KEY` + `_BASE_URL` / `_MODEL`). Nothing is bundled in the package; a test asserts that. Documented for the HF Space and Streamlit Community Cloud.
- Troubleshooting guide section, CHANGELOG entries, 29 new tests in `tests/test_ai_engine/test_recommender_llm.py`.

## Verification

- `pytest tests/test_ai_engine tests/test_cli -q`: green locally
- `ruff check` on the touched files: clean

Not in scope: the direction change from #187/#188/#189 (this only makes the existing recommender honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB
