### PR TITLE
ci: contributors-board guard splits the missing list on commas

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,10 @@ jobs:
           echo "$out"
           # Bot authors (e.g. allcontributors[bot], which authors the board PRs
           # themselves) are never credited on the board, so ignore them.
+          # The CLI prints the missing logins comma-separated on one line, so
+          # split them first or a bot name hides behind a human one.
           missing=$(echo "$out" | sed -n '/Missing contributors/,$p' | tail -n +2 \
-            | sed 's/^[[:space:]]*//' | grep -v '\[bot\]$' | grep -v '^$' || true)
+            | tr ',' '\n' | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' | grep -v '\[bot\]$' | grep -v '^$' || true)
           if [ -n "$missing" ]; then
             echo "::error::The contributors board is missing: $missing. Comment '@all-contributors please add @<username> for <contribution>' on their merged PR (needs the all-contributors GitHub App), or run 'npx all-contributors-cli add <username> <contribution>' locally."
             exit 1


### PR DESCRIPTION
The all-contributors CLI prints missing logins comma-separated on one line (`allcontributors[bot], khyahahati`), so the `[bot]$` filter only worked when the bot was alone. Split on commas first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB