### PR TITLE
fix(harvest): publish on manual runs (boolean input), accumulate last_run.json

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -81,7 +81,9 @@ jobs:
           set -e
 
       - name: Publish to the Hugging Face dataset
-        if: env.HF_TOKEN != '' && (github.event_name == 'schedule' || inputs.publish == 'true' || inputs.publish == '')
+        # inputs.publish is a boolean input: compare it as one (a string compare
+        # against 'true' is always false and silently skipped the first CI runs).
+        if: env.HF_TOKEN != '' && (github.event_name == 'schedule' || inputs.publish == true)
         run: |
           python - <<'EOF'
           import os

--- a/aquascope/archive/observations.py
+++ b/aquascope/archive/observations.py
@@ -241,7 +241,19 @@ def harvest_observations(
         )
 
     save_manifest(out, manifest)
-    (out / "obs" / "last_run.json").write_text(json.dumps(report.to_dict(), indent=1), encoding="utf-8")
+    # last_run.json accumulates the sources of every invocation in a run
+    # (the workflow calls harvest obs once per budget group).
+    last_path = out / "obs" / "last_run.json"
+    merged = report.to_dict()
+    if last_path.exists():
+        try:
+            previous = json.loads(last_path.read_text(encoding="utf-8"))
+            if previous.get("run_at", "")[:10] == merged["run_at"][:10]:
+                mine = {s["source"] for s in merged["sources"]}
+                merged["sources"] = [s for s in previous.get("sources", []) if s["source"] not in mine] + merged["sources"]
+        except (json.JSONDecodeError, KeyError, TypeError):
+            pass
+    last_path.write_text(json.dumps(merged, indent=1), encoding="utf-8")
     return report
 
 

--- a/aquascope/archive/observations.py
+++ b/aquascope/archive/observations.py
@@ -250,7 +250,8 @@ def harvest_observations(
             previous = json.loads(last_path.read_text(encoding="utf-8"))
             if previous.get("run_at", "")[:10] == merged["run_at"][:10]:
                 mine = {s["source"] for s in merged["sources"]}
-                merged["sources"] = [s for s in previous.get("sources", []) if s["source"] not in mine] + merged["sources"]
+                kept = [s for s in previous.get("sources", []) if s["source"] not in mine]
+                merged["sources"] = kept + merged["sources"]
         except (json.JSONDecodeError, KeyError, TypeError):
             pass
     last_path.write_text(json.dumps(merged, indent=1), encoding="utf-8")


### PR DESCRIPTION
The first successful CI harvest run (32043212727: 270 station files) skipped the publish step because `inputs.publish == 'true'` compares a boolean input to a string (always false in Actions expressions). Compare as a boolean. Also `last_run.json` now accumulates the per-source tallies of both `harvest obs` invocations in a run instead of keeping only the last one. The artifact of that run was published by hand meanwhile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB