### PR TITLE
fix(usgs): keep other agencies' station ids on both fetch paths

### DIFF
--- a/aquascope/collectors/usgs.py
+++ b/aquascope/collectors/usgs.py
@@ -229,7 +229,21 @@ class USGSCollector(BaseCollector):
                 "format": "json",
             }
             if sites:
-                params["sites"] = sites
+                # Accept "01646500", "USGS-01646500" or another agency's "CA574-09527500":
+                # NWIS wants the bare number plus agencyCd for non-USGS sites.
+                site_str = ",".join(sites) if isinstance(sites, (list, tuple)) else str(sites)
+                numbers, agencies = [], set()
+                for part in site_str.split(","):
+                    part = part.strip()
+                    if "-" in part:
+                        agency, number = part.split("-", 1)
+                        agencies.add(agency.upper())
+                        numbers.append(number)
+                    elif part:
+                        numbers.append(part)
+                params["sites"] = ",".join(numbers)
+                if len(agencies) == 1 and next(iter(agencies)) != "USGS":
+                    params["agencyCd"] = next(iter(agencies))
             if parameter_cd:
                 params["parameterCd"] = parameter_cd
             if bbox_val:
@@ -326,7 +340,7 @@ class USGSCollector(BaseCollector):
         # legacy NWIS kwargs onto them instead of silently crawling the nation.
         if sites:
             site_list = [str(x).strip() for x in (sites if isinstance(sites, (list, tuple)) else str(sites).split(","))]
-            params["monitoring_location_id"] = ",".join(x if x.startswith("USGS-") else f"USGS-{x}" for x in site_list if x)
+            params["monitoring_location_id"] = ",".join(x if "-" in x else f"USGS-{x}" for x in site_list if x)
         if parameter_cd:
             params["parameter_code"] = parameter_cd
         if state_cd:

--- a/aquascope/explore.py
+++ b/aquascope/explore.py
@@ -188,13 +188,14 @@ def fetch_series(source: str, station_id: str, *, years: int = 40, prefer_archiv
                 }
 
     if source == "usgs":
-        number = station_id.split("-", 1)[-1]
+        # Pass the catalog id as-is ("USGS-01646500" or another agency's "CA574-09527500");
+        # the collector maps it onto NWIS (number + agencyCd) or the OGC monitoring_location_id.
         c = build_collector("usgs")
         span = int(years * 365.25)
-        recs = c.collect(station_id=number, days=span, collection="daily", parameter="00060", max_items=None)
+        recs = c.collect(station_id=station_id, days=span, collection="daily", parameter="00060", max_items=None)
         s, var, unit = _records_to_series(recs)
         if s is None:
-            recs = c.collect(station_id=number, days=span, collection="daily", parameter="00065", max_items=None)
+            recs = c.collect(station_id=station_id, days=span, collection="daily", parameter="00065", max_items=None)
             s, var, unit = _records_to_series(recs)
         note = "USGS daily values (NWIS), full period requested."
     elif source == "uk_ea":

--- a/tests/test_collectors/test_usgs_wra_config.py
+++ b/tests/test_collectors/test_usgs_wra_config.py
@@ -379,3 +379,33 @@ class TestUSGSOGCPagination:
         second_call = c.client.get_json.call_args_list[1]
         assert second_call.args[0] == "https://x/items?cursor=abc&f=json"
         assert second_call.kwargs["params"] is None
+
+
+class TestUSGSAgencyPrefixedIds:
+    def test_keyed_path_keeps_other_agency_prefixes(self):
+        from unittest.mock import MagicMock
+
+        from aquascope.collectors.usgs import USGSCollector
+
+        c = USGSCollector(api_key="a-real-key")
+        c.client = MagicMock()
+        c.client.get_json.return_value = {"features": [], "links": []}
+        c.fetch_raw(station_id="CA574-09527500", days=3, collection="daily", parameter="00060", max_items=None)
+        assert c.client.get_json.call_args.kwargs["params"]["monitoring_location_id"] == "CA574-09527500"
+        c.fetch_raw(station_id="01646500", days=3, collection="daily", max_items=None)
+        assert c.client.get_json.call_args.kwargs["params"]["monitoring_location_id"] == "USGS-01646500"
+
+    def test_keyless_path_splits_agency_and_number(self):
+        from unittest.mock import MagicMock
+
+        from aquascope.collectors.usgs import USGSCollector
+
+        c = USGSCollector(api_key="DEMO_KEY")
+        c.client = MagicMock()
+        c.client.get_json.return_value = {"value": {"timeSeries": []}}
+        c.fetch_raw(station_id="CA574-09527500", days=3, collection="daily", parameter="00060", max_items=None)
+        params = c.client.get_json.call_args.kwargs["params"]
+        assert params["sites"] == "09527500" and params["agencyCd"] == "CA574"
+        c.fetch_raw(station_id="USGS-01646500", days=3, collection="daily", max_items=None)
+        params = c.client.get_json.call_args.kwargs["params"]
+        assert params["sites"] == "01646500" and "agencyCd" not in params

--- a/tests/test_explore.py
+++ b/tests/test_explore.py
@@ -105,7 +105,7 @@ def test_analyze_station_usgs_end_to_end_with_fake_collector():
     with patch.object(analysis, "build_collector", return_value=fake):
         store = {}
         out = analysis.analyze_station("usgs", "USGS-01646500", years=15, store=store)
-    assert fake.calls[0]["station_id"] == "01646500"  # prefix stripped for NWIS
+    assert fake.calls[0]["station_id"] == "USGS-01646500"  # the collector maps the id for NWIS / OGC itself
     assert out["source"] == "usgs" and out["agency"].startswith("U.S. Geological")
     assert out["license"] == "US-PD" and "public domain" in out["attribution"]
     assert out["n"] > 5000 and "ffa" in out


### PR DESCRIPTION
The USGS catalog (OGC `time-series-metadata`) carries 22 stations from other agencies (`CA574-09527500`, `CAX01-...`, `VA087-...`). `explore.fetch_series` stripped the prefix and the keyed OGC path re-prefixed `USGS-`, which pointed at a different (in the case I checked, co-located) site. Now the id is passed as-is: NWIS gets `sites=<number>&agencyCd=<agency>`, the OGC path gets the id unchanged. Tests for both paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB