### PR TITLE
docs: French quickstart English link points at the docs index (from #186)

### DIFF
--- a/docs/i18n/README.fr.md
+++ b/docs/i18n/README.fr.md
@@ -1,6 +1,6 @@
 # AquaScope, démarrage rapide
 
-[English](https://github.com/Rekin226/aquascope/blob/main/README.md)
+[English](../index.md)
 
 ## ⚡ Installation
 ```bash


### PR DESCRIPTION
Folds in the nicer form from @Prakshal0809's #186: the English link in `docs/i18n/README.fr.md` now targets `../index.md` (in-tree, works on the built site) instead of the GitHub URL I used in #200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB