### PR TITLE
docs: Zenodo concept DOI in README, docs and CITATION.cff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to AquaScope are documented here.
 ### Added
 
 ### Changed
+- README, docs and `CITATION.cff` carry the Zenodo concept DOI `10.5281/zenodo.21903143` (v0.11.0: `10.5281/zenodo.21989509`).
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -17,6 +17,14 @@ authors:
     affiliation: "National Central University, Taiwan"
 version: 0.11.0
 date-released: "2026-08-18"
+doi: 10.5281/zenodo.21903143
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.21903143
+    description: Concept DOI, resolves to the latest archived version
+  - type: doi
+    value: 10.5281/zenodo.21989509
+    description: Version DOI for v0.11.0
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
 url: https://rekin226.github.io/aquascope
@@ -57,6 +65,7 @@ preferred-citation:
       orcid: "https://orcid.org/0000-0002-4616-4153"
   version: 0.11.0
   date-released: "2026-08-18"
+  doi: 10.5281/zenodo.21903143
   license: MIT
   repository-code: https://github.com/Rekin226/aquascope
   url: https://rekin226.github.io/aquascope

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -18,13 +18,6 @@ authors:
 version: 0.11.0
 date-released: "2026-08-18"
 doi: 10.5281/zenodo.21903143
-identifiers:
-  - type: doi
-    value: 10.5281/zenodo.21903143
-    description: Concept DOI, resolves to the latest archived version
-  - type: doi
-    value: 10.5281/zenodo.21989509
-    description: Version DOI for v0.11.0
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
 url: https://rekin226.github.io/aquascope
@@ -40,6 +33,12 @@ keywords:
   - artificial intelligence
   - Python
 identifiers:
+  - type: doi
+    value: 10.5281/zenodo.21903143
+    description: Concept DOI, resolves to the latest archived version
+  - type: doi
+    value: 10.5281/zenodo.21989509
+    description: Version DOI for v0.11.0
   - type: url
     value: https://github.com/Rekin226/aquascope
     description: GitHub repository

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/aquascope.svg?color=blue&cacheSeconds=300&v=2)](https://pypi.org/project/aquascope/)
 [![Python](https://img.shields.io/pypi/pyversions/aquascope.svg?color=informational&cacheSeconds=300&v=2)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.21903143.svg)](https://doi.org/10.5281/zenodo.21903143)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-261230.svg)](https://github.com/astral-sh/ruff)
 [![Tests](https://img.shields.io/badge/tests-1000%2B%20passing-brightgreen.svg)](#)
 [![Live demo](https://img.shields.io/badge/%F0%9F%8C%8A%20Live%20demo-Hugging%20Face%20Space-blue)](https://huggingface.co/spaces/Rekin226/aquascope-dashboard)
@@ -420,13 +421,15 @@ If you use AquaScope in your research, please cite:
   year    = {2026},
   url     = {https://github.com/Rekin226/aquascope},
   version = {0.11.0},
+  doi     = {10.5281/zenodo.21903143},
   license = {MIT}
 }
 ```
 
 Machine-readable metadata lives in [CITATION.cff](CITATION.cff); GitHub's "Cite this
 repository" button renders it in APA and BibTeX. Every tagged release is archived on
-Zenodo with a version DOI.
+Zenodo; `10.5281/zenodo.21903143` is the concept DOI that always resolves to the latest
+version (v0.11.0 is [10.5281/zenodo.21989509](https://doi.org/10.5281/zenodo.21989509)).
 
 ## 📄 License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,6 +93,7 @@ pip install "aquascope[all]"       # everything: ML, viz, spatial, dashboard
   year    = {2026},
   url     = {https://github.com/Rekin226/aquascope},
   version = {0.11.0},
+  doi     = {10.5281/zenodo.21903143},
   license = {MIT}
 }
 ```


### PR DESCRIPTION
Zenodo archived v0.11.0 as 10.5281/zenodo.21989509 under the concept DOI 10.5281/zenodo.21903143 (v0.10.0 was 10.5281/zenodo.21903144). This puts the concept DOI badge and `doi` field into README, `docs/index.md` and `CITATION.cff` (top-level and `preferred-citation`, plus `identifiers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB