### PR TITLE
Caravan-format export from the Archive (aquascope caravan export)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+- **Caravan-format export from the Archive** (`aquascope caravan export|validate`, `aquascope.archive.caravan`): per-gauge daily forcing (Open-Meteo's ERA5-Land + ERA5 blend at the gauge point) and area-normalised streamflow in mm/d from the discharge bundles, Caravan's climate indices (a port of `caravan_utils.calculate_climate_indices`, FAO-PM variants), HydroATLAS-style attributes from BasinATLAS, `attributes_other` with area and provenance, licences and a `provenance.json`; USGS, UK EA and Hub'Eau, areas from the agency (`drainage_area`, `catchmentArea`, `surface_bv`) else BasinATLAS. The Open-Meteo collector accepts `models=` for the `/archive` endpoint. (#100)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -259,13 +259,14 @@ Switch to MCMC with `degree>1` for polynomial models, or pass `prior_precision` 
 
 ## 💻 CLI
 
-AquaScope ships a 23-command CLI (`agri` and `basins` carry subcommands) for the most common workflows:
+AquaScope ships a 24-command CLI (`agri`, `basins` and `caravan` carry subcommands) for the most common workflows:
 
 ```bash
 # Find stations, then collect data
 aquascope stations --bbox -0.5,51.3,0.3,51.7 --variable discharge --format geojson
 aquascope harvest stations --out archive          # the open gauge catalog (GeoParquet)
 aquascope basins at 48.85 2.35                    # the catchment of any point: area, climate, land cover, soils, dams (BasinATLAS)
+aquascope caravan export --source uk_ea --out caravan_gb   # a Caravan-format large-sample dataset from the archive
 aquascope mcp                                     # serve the same tools to Claude / Cursor over MCP
 aquascope ask "100-year flood of the Seine at Paris?"   # the analyst: tools + a cited Markdown report
 aquascope ingest agency_export.csv --unit cfs     # any CSV/Excel -> clean daily series + QA report

--- a/aquascope/archive/caravan.py
+++ b/aquascope/archive/caravan.py
@@ -1,0 +1,582 @@
+"""Caravan-format export from the Archive: per-basin forcing + streamflow, HydroATLAS attributes, climate indices.
+
+Caravan (Kratzert et al. 2023, Sci. Data) is the layout the large-sample /
+ML hydrology community trains on: one CSV per gauge with daily ERA5-Land
+forcing and area-normalised streamflow (mm/d), plus three attribute tables
+per sub-dataset. Extending it normally means running Earth Engine. The
+Archive already holds every ingredient, so this module writes the same
+layout from it, with two honest differences that every file records:
+
+* forcing is Open-Meteo's reanalysis blend (ERA5-Land where available, ERA5
+  otherwise) **at the gauge point**, not a basin average, and only the daily
+  variables Open-Meteo serves (precipitation, FAO-56 ET0, 2 m temperature
+  mean/min/max, downward shortwave radiation);
+* HydroATLAS attributes are BasinATLAS's own upstream-aggregated values for the
+  level-12 sub-basin containing the gauge (its outlet, not the gauge itself,
+  closes the catchment), written under Caravan's column names, with the raw
+  sub-basin row kept next to them.
+
+Layout written under ``out_dir`` (mirrors the Caravan tree, prefix = the
+sub-dataset name, default ``aquascope_<source>``)::
+
+    attributes/<prefix>/attributes_other_<prefix>.csv
+        gauge_id, gauge_name, gauge_lat, gauge_lon, area, country (+ provenance columns)
+    attributes/<prefix>/attributes_caravan_<prefix>.csv
+        climate indices, computed exactly as caravan_utils.calculate_climate_indices
+    attributes/<prefix>/attributes_hydroatlas_<prefix>.csv
+        catchment values under Caravan/HydroATLAS names
+    attributes/<prefix>/attributes_basinatlas_raw_<prefix>.csv
+        the containing sub-basin's full BasinATLAS row
+    timeseries/csv/<prefix>/<gauge_id>.csv
+        date, forcing columns, streamflow (mm/d), rounded to 2 decimals
+    licenses/<prefix>.md          per-source terms and attributions
+    provenance.json               what came from where, versions, dates
+
+Streamflow comes from the archive bundle for the source (``obs/discharge/<source>.parquet``)
+and, when asked, from the agency for stations the archive has not reached yet.
+Areas come from the agency where it publishes one (USGS drainage area, UK EA
+``catchmentArea``, Hub'Eau ``surface_bv``), else from BasinATLAS ``up_area``
+of the containing sub-basin (flagged).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import re
+import time
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from aquascope import __version__
+from aquascope.registry import SOURCES, build_collector
+
+logger = logging.getLogger(__name__)
+
+# Caravan's reference period for the climate indices (caravan_utils._CARAVAN_START_DATE/_END_DATE).
+CARAVAN_START = pd.Timestamp("1981-01-01")
+CARAVAN_END = pd.Timestamp("2020-12-31")
+
+# Caravan column <- Open-Meteo daily variable, unit, note. Names follow Caravan / ERA5-Land where the
+# quantity is the same; where it is not (downward instead of net radiation) the ERA5 name of what we
+# actually serve is used, so nothing is mislabelled.
+FORCING: list[tuple[str, str, str, str]] = [
+    ("total_precipitation_sum", "precipitation_sum", "mm", "daily precipitation at the gauge point"),
+    ("potential_evaporation_sum_FAO_PENMAN_MONTEITH", "et0_fao_evapotranspiration", "mm",
+     "FAO-56 Penman-Monteith reference ET0 computed by Open-Meteo from the reanalysis"),
+    ("temperature_2m_mean", "temperature_2m_mean", "degC", "daily mean 2 m air temperature"),
+    ("temperature_2m_min", "temperature_2m_min", "degC", "daily minimum 2 m air temperature"),
+    ("temperature_2m_max", "temperature_2m_max", "degC", "daily maximum 2 m air temperature"),
+    ("surface_solar_radiation_downwards_mean", "shortwave_radiation_sum", "W/m2",
+     "daily mean downward shortwave radiation (Open-Meteo MJ/m2/day x 11.574); "
+     "Caravan's net solar radiation is not served"),
+]
+OPEN_METEO_DAILY = [om for _, om, _, _ in FORCING]
+STREAMFLOW_COL = "streamflow"
+
+SUPPORTED_SOURCES = ("usgs", "uk_ea", "hubeau_hydrometrie")
+
+
+@dataclass
+class GaugeExport:
+    gauge_id: str
+    source: str
+    station_id: str
+    ok: bool
+    n_days: int = 0
+    n_streamflow: int = 0
+    area_km2: float | None = None
+    area_source: str = ""
+    hybas_id: int | None = None
+    error: str = ""
+    seconds: float = 0.0
+
+
+@dataclass
+class CaravanReport:
+    prefix: str
+    out_dir: str
+    run_at: str
+    aquascope_version: str
+    gauges: list[GaugeExport] = field(default_factory=list)
+
+    @property
+    def n_ok(self) -> int:
+        return sum(1 for g in self.gauges if g.ok)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {**asdict(self), "n_ok": self.n_ok, "n_failed": len(self.gauges) - self.n_ok}
+
+
+def default_prefix(source: str) -> str:
+    return f"aquascope_{source}"
+
+
+def gauge_id_for(prefix: str, station_id: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(station_id))
+    return f"{prefix}_{safe}"
+
+
+# ── climate indices (port of caravan_utils.calculate_climate_indices, FAO-PM PET only) ─────
+
+
+def _split_runs(idx: np.ndarray) -> list[np.ndarray]:
+    """Consecutive-index runs (caravan_utils._split_list)."""
+    if idx.size == 0:
+        return []
+    breaks = np.where(np.diff(idx) != 1)[0] + 1
+    return [r for r in np.split(idx, breaks) if r.size]
+
+
+def moisture_and_seasonality(precip: pd.Series, pet: pd.Series) -> tuple[float, float]:
+    """Knoben et al. (2018) annual moisture index and seasonality, as Caravan computes them."""
+    mp = precip.groupby(precip.index.month).mean()
+    me = pet.groupby(pet.index.month).mean()
+    gt = 1 - me[mp > me] / mp[mp > me]
+    eq = pd.Series(0.0, index=me.index)[mp == me]
+    lt = mp[mp < me] / me[mp < me] - 1
+    monthly = pd.concat([gt, eq, lt])
+    return float(monthly.mean()), float(monthly.max() - monthly.min())
+
+
+def climate_indices(
+    df: pd.DataFrame, start: pd.Timestamp = CARAVAN_START, end: pd.Timestamp = CARAVAN_END
+) -> dict[str, float]:
+    """Caravan's climate indices from ``total_precipitation_sum``, the FAO-PM PET column and ``temperature_2m_mean``.
+
+    Same definitions and thresholds as ``caravan_utils.calculate_climate_indices``; only the
+    FAO Penman-Monteith variants are produced (Open-Meteo serves no ERA5-Land potential evaporation).
+    """
+    d = df.loc[slice(start, end)]
+    p = d["total_precipitation_sum"].astype(float)
+    pet = d["potential_evaporation_sum_FAO_PENMAN_MONTEITH"].astype(float)
+    t = d["temperature_2m_mean"].astype(float)
+    p_mean = float(p.mean())
+    pet_mean = float(pet.mean())
+    aridity = pet_mean / p_mean if p_mean else float("nan")
+    moisture, seasonality = moisture_and_seasonality(p, pet)
+    mp = p.groupby(p.index.month).mean()
+    mt = t.groupby(t.index.month).mean()
+    frac_snow = float(mp[mt < 0].sum() / mp.sum()) if float(mp.sum()) else float("nan")
+    n = max(len(d), 1)
+    high_freq = float((p >= 5 * p_mean).sum() / n)
+    low_freq = float((p < 1).sum() / n)
+    vals = p.to_numpy()
+    low_runs = _split_runs(np.where(vals < 1)[0])
+    high_runs = _split_runs(np.where(vals >= 5 * p_mean)[0])
+    return {
+        "p_mean": p_mean,
+        "pet_mean_FAO_PM": pet_mean,
+        "aridity_FAO_PM": aridity,
+        "frac_snow": frac_snow,
+        "moisture_index_FAO_PM": moisture,
+        "seasonality_FAO_PM": seasonality,
+        "high_prec_freq": high_freq,
+        "high_prec_dur": float(np.mean([r.size for r in high_runs])) if high_runs else 0.0,
+        "low_prec_freq": low_freq,
+        "low_prec_dur": float(np.mean([r.size for r in low_runs])) if low_runs else 0.0,
+    }
+
+
+# ── inputs ──────────────────────────────────────────────────────────────────
+
+
+RATE_LIMIT_WAIT = 65.0  # Open-Meteo's free tier is metered per minute; a 40-year request weighs a lot
+
+
+def _is_rate_limited(exc: BaseException) -> bool:
+    text = str(exc)
+    return "429" in text or "Too Many" in text or "rate limit" in text.lower()
+
+
+def fetch_forcing(
+    lat: float, lon: float, start: date, end: date, *, models: str | None = "best_match", retries: int = 3
+) -> tuple[pd.DataFrame, str]:
+    """Daily forcing at a point from Open-Meteo, in Caravan column names (local time, like Caravan).
+
+    Returns ``(frame, model_used)``. ``models="best_match"`` is Open-Meteo's blend (ERA5-Land where it
+    has the variable, ERA5 otherwise) and the only option that serves every daily variable
+    (``era5_land`` alone has no precipitation, ET0 or radiation); ERA5 via ``/era5`` is the fallback.
+    A 429 waits :data:`RATE_LIMIT_WAIT` seconds and retries instead of failing the gauge.
+    """
+    weather = build_collector("openmeteo", mode="weather")
+    attempts = [models, None] if models else [None]
+    raw, used, last_exc = None, "", None
+    for model in attempts:
+        for _try in range(retries):
+            try:
+                raw = weather.fetch_raw(latitude=lat, longitude=lon, start_date=start.isoformat(),
+                                        end_date=end.isoformat(), daily=OPEN_METEO_DAILY, models=model)
+                used = model or "era5"
+                break
+            except Exception as exc:  # noqa: BLE001 - retry / fall back, then give up
+                last_exc = exc
+                if _is_rate_limited(exc) and _try < retries - 1:
+                    logger.info("Open-Meteo rate limit, waiting %.0fs", RATE_LIMIT_WAIT)
+                    time.sleep(RATE_LIMIT_WAIT)
+                    continue
+                break
+        if raw is not None:
+            break
+    if raw is None:
+        raise RuntimeError(f"Open-Meteo forcing failed: {last_exc}")
+    daily = raw.get("daily", {})
+    idx = pd.to_datetime(daily.get("time", []))
+    out = pd.DataFrame(index=idx)
+    out.index.name = "date"
+    for col, om, unit, _ in FORCING:
+        vals = pd.Series(daily.get(om, []), index=idx, dtype="float64")
+        if om == "shortwave_radiation_sum":
+            vals = vals * (1e6 / 86400.0)  # MJ/m2/day -> W/m2 mean
+        out[col] = vals
+    return out, used
+
+
+def station_area_km2(source: str, station: dict[str, Any], collectors: dict[str, Any]) -> tuple[float | None, str]:
+    """Catchment area from the agency where it publishes one; ``(None, "")`` otherwise."""
+    sid = station["station_id"]
+    try:
+        if source == "usgs":
+            c = collectors.setdefault("usgs", build_collector("usgs"))
+            area = c._get_monitoring_location_catchment_area(sid)
+            return (float(area), "usgs_drainage_area") if area else (None, "")
+        if source == "uk_ea":
+            c = collectors.setdefault("uk_ea", build_collector("uk_ea"))
+            data = c.client.get_json(f"id/stations/{sid}.json")
+            items = data.get("items") or []
+            st = items[0] if isinstance(items, list) and items else items
+            area = st.get("catchmentArea") if isinstance(st, dict) else None
+            return (float(area), "uk_ea_catchmentArea") if area else (None, "")
+        if source == "hubeau_hydrometrie":
+            c = collectors.setdefault("hubeau_hydrometrie", build_collector("hubeau_hydrometrie"))
+            code_site = (station.get("extra") or {}).get("code_site") or sid[:8]
+            areas = c._get_catchment_areas({code_site})
+            area = areas.get(code_site)
+            return (float(area), "hubeau_surface_bv") if area else (None, "")
+    except Exception as exc:  # noqa: BLE001 - area is optional, fall back to BasinATLAS
+        logger.info("area lookup failed for %s/%s: %s", source, sid, exc)
+    return None, ""
+
+
+def _hydroatlas_catchment_row(raw_row: dict[str, Any]) -> dict[str, Any]:
+    """Caravan/HydroATLAS column names filled with the catchment (upstream) value where BasinATLAS has one.
+
+    ``xxx_yy_s??`` takes the sibling ``xxx_yy_u??`` when present (BasinATLAS's own upstream aggregate),
+    else the local sub-basin value; ``_p??`` (pour point) fields are already catchment values.
+    """
+    out: dict[str, Any] = {}
+    for col, val in raw_row.items():
+        if not re.match(r"^[a-z]{3}_[a-z0-9]{2}_[sp][a-z0-9]{2}$", col):
+            continue
+        if col[7] == "s":
+            sib = col[:7] + "u" + col[8:]
+            v = raw_row.get(sib)
+            out[col] = v if v is not None and not (isinstance(v, float) and math.isnan(v)) else val
+        else:
+            out[col] = val
+    return out
+
+
+# ── export ──────────────────────────────────────────────────────────────────
+
+
+def export_caravan(
+    source: str,
+    out_dir: str | Path,
+    *,
+    station_ids: list[str] | None = None,
+    max_stations: int | None = None,
+    min_years: float = 10.0,
+    start: date | None = None,
+    end: date | None = None,
+    prefix: str | None = None,
+    forcing: bool = True,
+    forcing_models: str | None = "best_match",
+    fetch_missing: bool = False,
+    catalog: list[dict[str, Any]] | None = None,
+    observations: pd.DataFrame | None = None,
+    write_netcdf: bool = False,
+    pause: float = 3.0,
+    on_event: Any = None,
+) -> CaravanReport:
+    """Write a Caravan-format sub-dataset for ``source`` from the Archive.
+
+    Stations: ``station_ids`` when given, else every discharge station of the source that the
+    archive holds observations for (``max_stations`` caps it, longest records first). A station
+    needs ``min_years`` of daily streamflow to be exported. ``start``/``end`` bound the forcing
+    period (defaults: 1981-01-01 to the last observation, capped at seven days ago); the
+    streamflow is NaN outside its own record, like Caravan. ``fetch_missing`` fetches stations
+    the archive has not reached from the agency through ``fetch_series``. ``catalog`` and
+    ``observations`` (a bundle frame) can be injected (tests, offline runs). ``pause`` seconds
+    separate the Open-Meteo calls (its free tier is metered per minute).
+    """
+    from aquascope.archive import basins as basins_mod
+    from aquascope.archive.bundles import load_observations, to_series
+    from aquascope.archive.catalog import load_stations
+
+    if source not in SUPPORTED_SOURCES:
+        raise ValueError(f"{source!r} is not exportable yet; choose from {list(SUPPORTED_SOURCES)}")
+    meta = SOURCES[source]
+    say = on_event or (lambda _m: None)
+    prefix = prefix or default_prefix(source)
+    out = Path(out_dir)
+    ts_dir = out / "timeseries" / "csv" / prefix
+    attr_dir = out / "attributes" / prefix
+    ts_dir.mkdir(parents=True, exist_ok=True)
+    attr_dir.mkdir(parents=True, exist_ok=True)
+    report = CaravanReport(prefix=prefix, out_dir=str(out), aquascope_version=__version__,
+                           run_at=datetime.now(timezone.utc).isoformat(timespec="seconds"))
+
+    catalog = catalog if catalog is not None else load_stations()
+    by_id = {r["station_id"]: r for r in catalog if r["source"] == source}
+    obs = observations if observations is not None else load_observations(source, "discharge")
+    have = set(obs["station_id"].unique()) if not obs.empty else set()
+
+    if station_ids:
+        picked = [s for s in station_ids if s in by_id]
+        missing_ids = [s for s in station_ids if s not in by_id]
+        for s in missing_ids:
+            report.gauges.append(GaugeExport(gauge_id_for(prefix, s), source, s, False, error="not in the catalog"))
+    else:
+        counts = obs.groupby("station_id").size() if not obs.empty else pd.Series(dtype=int)
+        picked = [s for s in counts.sort_values(ascending=False).index if s in by_id]
+        if max_stations:
+            picked = picked[:max_stations]
+
+    end_default = date.today() - timedelta(days=7)
+    collectors: dict[str, Any] = {}
+    other_rows, caravan_rows, hydro_rows, raw_rows = [], [], [], []
+    for sid in picked:
+        t0 = time.perf_counter()
+        st = by_id[sid]
+        gid = gauge_id_for(prefix, sid)
+        g = GaugeExport(gid, source, sid, False)
+        try:
+            # streamflow
+            if sid in have:
+                q = to_series(obs, sid)
+            elif fetch_missing:
+                from aquascope.explore import fetch_series
+
+                fetched = fetch_series(source, sid, years=60, prefer_archive=False, variable="discharge")
+                q = fetched["series"] if fetched["series"] is not None else pd.Series(dtype=float)
+            else:
+                raise RuntimeError("no archived discharge (pass fetch_missing=True to fetch from the agency)")
+            q = q.dropna()
+            q = q[q >= 0]
+            q_daily = q.resample("D").mean()
+            valid = q_daily.dropna()
+            years = (valid.index.max() - valid.index.min()).days / 365.25 if len(valid) > 1 else 0
+            if years < min_years:
+                raise RuntimeError(f"record too short: {years:.1f} years < {min_years}")
+
+            # area
+            area, area_src = station_area_km2(source, st, collectors)
+            # BasinATLAS
+            sb = None
+            hybas_row: dict[str, Any] = {}
+            try:
+                sb = basins_mod.sub_basin_at(float(st["latitude"]), float(st["longitude"]))
+                if sb:
+                    attrs = basins_mod.load_attributes([sb["hybas_id"]])
+                    if not attrs.empty:
+                        hybas_row = {k: (None if isinstance(v, float) and math.isnan(v) else v)
+                                     for k, v in attrs.iloc[0].to_dict().items()}
+            except Exception as exc:  # noqa: BLE001 - attributes are optional per gauge
+                logger.info("BasinATLAS lookup failed for %s: %s", gid, exc)
+            if area is None and sb and sb.get("up_area"):
+                area, area_src = float(sb["up_area"]), "basinatlas_up_area_of_containing_sub_basin"
+            if not area:
+                raise RuntimeError("no catchment area available (agency has none, BasinATLAS lookup failed)")
+
+            # mm/day
+            q_mm = q_daily * 86.4 / float(area)
+            first, last = q_mm.dropna().index.min().date(), q_mm.dropna().index.max().date()
+            f_start = start or CARAVAN_START.date()
+            f_end = end or min(last, end_default)
+            if f_end < f_start:
+                raise RuntimeError(f"empty period {f_start}..{f_end}")
+
+            model_used = ""
+            if forcing:
+                say(f"{gid}: forcing {f_start}..{f_end}")
+                if pause and any(x.ok for x in report.gauges):
+                    time.sleep(pause)
+                frame, model_used = fetch_forcing(float(st["latitude"]), float(st["longitude"]), f_start, f_end,
+                                                  models=forcing_models)
+            else:
+                idx = pd.date_range(f_start, f_end, freq="D", name="date")
+                frame = pd.DataFrame(index=idx)
+            frame[STREAMFLOW_COL] = q_mm.reindex(frame.index)
+            frame = frame.round(2)
+            frame.to_csv(ts_dir / f"{gid}.csv", float_format="%.2f", date_format="%Y-%m-%d")
+            if write_netcdf:
+                try:
+                    nc_dir = out / "timeseries" / "netcdf" / prefix
+                    nc_dir.mkdir(parents=True, exist_ok=True)
+                    frame.to_xarray().to_netcdf(nc_dir / f"{gid}.nc")
+                except Exception as exc:  # noqa: BLE001 - xarray/netCDF4 are optional
+                    logger.info("netcdf skipped for %s: %s", gid, exc)
+
+            other_rows.append({
+                "gauge_id": gid, "gauge_name": st.get("name") or st.get("river") or sid,
+                "gauge_lat": float(st["latitude"]), "gauge_lon": float(st["longitude"]),
+                "area": round(float(area), 2), "country": st.get("country") or meta.country,
+                "area_source": area_src, "source": source, "agency": meta.agency, "station_id": sid,
+                "license": meta.license, "streamflow_start": first.isoformat(), "streamflow_end": last.isoformat(),
+                "hybas_id": sb["hybas_id"] if sb else None,
+                "basinatlas_up_area": sb.get("up_area") if sb else None,
+                "forcing_model": model_used,
+            })
+            if forcing and len(frame) > 30:
+                caravan_rows.append({"gauge_id": gid, **climate_indices(frame)})
+            if hybas_row:
+                hydro_rows.append({"gauge_id": gid, **_hydroatlas_catchment_row(hybas_row)})
+                raw_rows.append({"gauge_id": gid, **hybas_row})
+            g.ok, g.n_days, g.n_streamflow = True, int(len(frame)), int(frame[STREAMFLOW_COL].notna().sum())
+            g.area_km2, g.area_source, g.hybas_id = float(area), area_src, (sb["hybas_id"] if sb else None)
+        except Exception as exc:  # noqa: BLE001 - one gauge must not sink the export
+            g.error = f"{type(exc).__name__}: {exc}"
+            logger.warning("%s skipped: %s", gid, g.error)
+        g.seconds = round(time.perf_counter() - t0, 1)
+        report.gauges.append(g)
+        say(f"{gid}: {'ok' if g.ok else 'skipped'} ({g.seconds}s)")
+
+    if other_rows:
+        pd.DataFrame(other_rows).set_index("gauge_id").sort_index().to_csv(attr_dir / f"attributes_other_{prefix}.csv")
+    if caravan_rows:
+        pd.DataFrame(caravan_rows).set_index("gauge_id").sort_index().sort_index(axis=1).to_csv(
+            attr_dir / f"attributes_caravan_{prefix}.csv")
+    if hydro_rows:
+        pd.DataFrame(hydro_rows).set_index("gauge_id").sort_index().sort_index(axis=1).to_csv(
+            attr_dir / f"attributes_hydroatlas_{prefix}.csv")
+    if raw_rows:
+        pd.DataFrame(raw_rows).set_index("gauge_id").sort_index().to_csv(
+            attr_dir / f"attributes_basinatlas_raw_{prefix}.csv")
+
+    lic_dir = out / "licenses"
+    lic_dir.mkdir(parents=True, exist_ok=True)
+    (lic_dir / f"{prefix}.md").write_text(_license_text(source, forcing), encoding="utf-8")
+    prov_path = out / "provenance.json"
+    prov = json.loads(prov_path.read_text()) if prov_path.exists() else {"subdatasets": {}}
+    prov["subdatasets"][prefix] = {
+        "source": source, "agency": meta.agency, "license": meta.license, "attribution": meta.attribution,
+        "run_at": report.run_at, "aquascope_version": __version__,
+        "streamflow": f"Archive bundle obs/discharge/{source}.parquet (daily means, m3/s) converted to mm/d "
+                      "with the gauge area"
+                      + ("; stations missing from the archive fetched from the agency" if fetch_missing else ""),
+        "forcing": {"provider": "Open-Meteo", "models": forcing_models or "era5",
+                    "at": "gauge point (not basin average)",
+                    "columns": {c: {"open_meteo": om, "unit": u, "note": n} for c, om, u, n in FORCING},
+                    "timezone": "local (Open-Meteo timezone=auto), like Caravan's daily aggregation"}
+        if forcing else None,
+        "climate_indices": "caravan_utils.calculate_climate_indices ported; FAO Penman-Monteith variants only; "
+                           f"period {CARAVAN_START.date()}..{CARAVAN_END.date()} intersected with the forcing",
+        "hydroatlas": "BasinATLAS v1.0 (CC BY 4.0) row of the level-12 sub-basin containing the gauge; "
+                      "attributes_hydroatlas uses the upstream (u) fields under Caravan's column names, "
+                      "attributes_basinatlas_raw keeps the full row",
+        "area": "agency catchment area where published (usgs drainage_area, uk_ea catchmentArea, hubeau surface_bv), "
+                "else BasinATLAS up_area of the containing sub-basin (see area_source)",
+        "n_gauges": report.n_ok,
+    }
+    prov_path.write_text(json.dumps(prov, indent=1, ensure_ascii=False), encoding="utf-8")
+    (out / "README.md").write_text(_readme_text(), encoding="utf-8")
+    return report
+
+
+def _license_text(source: str, forcing: bool) -> str:
+    meta = SOURCES[source]
+    lines = [
+        f"# Terms for the `{default_prefix(source)}` sub-dataset", "",
+        f"- Streamflow: {meta.agency}, licence `{meta.license}`. {meta.attribution}",
+        "- Catchment attributes: HydroATLAS v1.0 / BasinATLAS, CC BY 4.0. Linke, S., Lehner, B., Ouellet Dallaire, C., "
+        "et al. (2019). Global hydro-environmental sub-basin and river reach characteristics at high spatial "
+        "resolution. Scientific Data 6: 283. https://doi.org/10.1038/s41597-019-0300-6",
+    ]
+    if forcing:
+        lines.append("- Forcing: ERA5-Land / ERA5 (Copernicus Climate Change Service) blended and served by "
+                     "Open-Meteo, CC BY 4.0. Hersbach, H. et al. (2020), Munoz-Sabater, J. et al. (2021); "
+                     "Open-Meteo.com.")
+    lines += ["", "Layout after Kratzert, F. et al. (2023). Caravan: a global community dataset for large-sample "
+              "hydrology. Scientific Data 10: 61. https://doi.org/10.1038/s41597-023-01975-w"]
+    return "\n".join(lines) + "\n"
+
+
+def _readme_text() -> str:
+    return (
+        "# Caravan-format export from the AquaScope Archive\n\n"
+        "Written by `aquascope caravan export`. Same folder layout as Caravan (Kratzert et al. 2023): "
+        "`attributes/<prefix>/attributes_{other,caravan,hydroatlas}_<prefix>.csv` and "
+        "`timeseries/csv/<prefix>/<gauge_id>.csv` (date, forcing, `streamflow` in mm/d).\n\n"
+        "Differences from Caravan proper, all recorded in `provenance.json`: forcing is ERA5-Land/ERA5 at the gauge "
+        "point (Open-Meteo's ERA5-Land + ERA5 blend), not a basin average, and only the daily variables "
+        "Open-Meteo serves; the "
+        "potential evaporation is FAO-56 ET0 (`potential_evaporation_sum_FAO_PENMAN_MONTEITH`), there is no "
+        "ERA5-Land PEV; "
+        "radiation is downward shortwave (`surface_solar_radiation_downwards_mean`), not net; HydroATLAS attributes "
+        "are BasinATLAS's upstream values for the level-12 sub-basin containing the gauge "
+        "(`attributes_basinatlas_raw_*` keeps the full row); the area is the agency's where it publishes one, "
+        "else BasinATLAS's (`area_source`). "
+        "No basin shapefiles are written.\n"
+    )
+
+
+# ── validation ──────────────────────────────────────────────────────────────
+
+CARAVAN_OTHER_REQUIRED = ("gauge_lat", "gauge_lon", "gauge_name", "country", "area")
+CARAVAN_INDEX_REQUIRED = ("p_mean", "pet_mean_FAO_PM", "aridity_FAO_PM", "frac_snow", "moisture_index_FAO_PM",
+                          "seasonality_FAO_PM", "high_prec_freq", "high_prec_dur", "low_prec_freq", "low_prec_dur")
+
+
+def validate_caravan(out_dir: str | Path, prefix: str) -> dict[str, Any]:
+    """Structural checks against the Caravan layout; returns ``{"ok": bool, "problems": [...], "n_gauges": int}``."""
+    out = Path(out_dir)
+    problems: list[str] = []
+    attr_dir = out / "attributes" / prefix
+    other_p = attr_dir / f"attributes_other_{prefix}.csv"
+    if not other_p.exists():
+        return {"ok": False, "problems": [f"missing {other_p}"], "n_gauges": 0}
+    other = pd.read_csv(other_p, index_col="gauge_id")
+    for c in CARAVAN_OTHER_REQUIRED:
+        if c not in other.columns:
+            problems.append(f"attributes_other lacks {c}")
+    if other[[c for c in CARAVAN_OTHER_REQUIRED if c in other.columns]].isna().any().any():
+        problems.append("attributes_other has NaN in a required column")
+    ids = list(other.index)
+    if not all(str(i).startswith(prefix + "_") for i in ids):
+        problems.append("gauge_ids do not all carry the prefix")
+    for name in ("caravan", "hydroatlas"):
+        p = attr_dir / f"attributes_{name}_{prefix}.csv"
+        if p.exists():
+            df = pd.read_csv(p, index_col="gauge_id")
+            extra = set(df.index) - set(ids)
+            if extra:
+                problems.append(f"attributes_{name} has gauge_ids not in attributes_other: {sorted(extra)[:3]}")
+            if name == "caravan":
+                for c in CARAVAN_INDEX_REQUIRED:
+                    if c not in df.columns:
+                        problems.append(f"attributes_caravan lacks {c}")
+    ts_dir = out / "timeseries" / "csv" / prefix
+    for gid in ids:
+        p = ts_dir / f"{gid}.csv"
+        if not p.exists():
+            problems.append(f"missing timeseries for {gid}")
+            continue
+        ts = pd.read_csv(p, index_col="date", parse_dates=["date"])
+        if STREAMFLOW_COL not in ts.columns:
+            problems.append(f"{gid}: no streamflow column")
+        elif (ts[STREAMFLOW_COL].dropna() < 0).any():
+            problems.append(f"{gid}: negative streamflow (must be NaN)")
+        if len(ts) > 1 and pd.infer_freq(ts.index) != "D":
+            problems.append(f"{gid}: date index is not daily")
+    return {"ok": not problems, "problems": problems, "n_gauges": len(ids)}
+
+
+__all__ = ["CARAVAN_END", "CARAVAN_START", "CaravanReport", "FORCING", "GaugeExport", "climate_indices",
+           "export_caravan", "fetch_forcing", "gauge_id_for", "station_area_km2", "validate_caravan"]

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -721,6 +721,44 @@ def cmd_basins(args: argparse.Namespace) -> None:
     print(f"\n  {res['attribution']}")
 
 
+def cmd_caravan(args: argparse.Namespace) -> None:
+    """`aquascope caravan export|validate`: Caravan-format sub-datasets from the Archive."""
+    from aquascope.archive import caravan
+
+    if args.caravan_cmd == "validate":
+        res = caravan.validate_caravan(args.out, args.prefix)
+        print(f"  {res['n_gauges']} gauges, {'OK' if res['ok'] else str(len(res['problems'])) + ' problems'}")
+        for pr in res["problems"][:30]:
+            print(f"    - {pr}")
+        if not res["ok"]:
+            sys.exit(1)
+        return
+
+    def say(msg: str) -> None:
+        if not args.quiet:
+            print(f"  · {msg}", file=sys.stderr)
+
+    try:
+        report = caravan.export_caravan(
+            args.source, args.out, station_ids=args.station or None, max_stations=args.max_stations,
+            min_years=args.min_years, start=args.start, end=args.end, prefix=args.prefix,
+            forcing=not args.no_forcing, forcing_models=None if args.era5 else "best_match",
+            fetch_missing=args.fetch_missing, write_netcdf=args.netcdf, pause=args.pause, on_event=say,
+        )
+    except ValueError as exc:
+        logger.error("%s", exc)
+        sys.exit(2)
+    for g in report.gauges:
+        status = f"{g.n_days:>6} days, {g.n_streamflow:>6} with flow, area {g.area_km2:,.0f} km2 ({g.area_source})" \
+            if g.ok else f"skipped: {g.error}"
+        print(f"  {g.gauge_id:<48} {status}")
+    print(f"\n  {report.n_ok}/{len(report.gauges)} gauges written under {report.out_dir} (prefix {report.prefix})")
+    res = caravan.validate_caravan(args.out, report.prefix) if report.n_ok else {"ok": False, "problems": ["nothing written"]}
+    print(f"  validation: {'OK' if res['ok'] else '; '.join(res['problems'][:5])}")
+    if report.n_ok == 0:
+        sys.exit(1)
+
+
 def cmd_completion(args: argparse.Namespace) -> None:
     """Print the shell activation line for tab-completion."""
     from argcomplete.shell_integration import shellcode
@@ -1472,6 +1510,29 @@ def main() -> None:
     p_bbuild.add_argument("--max-features", type=int, default=None)
     p_bbuild.add_argument("--fgb", action="store_true", help="Also write lev12.fgb from Python (needs memory)")
 
+    # ── caravan ──────────────────────────────────────────────────────
+    p_car = sub.add_parser("caravan", help="Caravan-format sub-datasets (forcing + mm/day streamflow + attributes) from the Archive")
+    car_sub = p_car.add_subparsers(dest="caravan_cmd", required=True)
+    p_cex = car_sub.add_parser("export", help="Export one source's discharge stations in the Caravan layout")
+    p_cex.add_argument("--source", required=True, choices=["usgs", "uk_ea", "hubeau_hydrometrie"])
+    p_cex.add_argument("--out", required=True, help="Output folder (Caravan tree is written inside it)")
+    p_cex.add_argument("--station", action="append", help="Only these station ids (repeatable)")
+    p_cex.add_argument("--max-stations", type=int, default=None, help="Cap (longest archived records first)")
+    p_cex.add_argument("--min-years", type=float, default=10.0, help="Minimum streamflow record length (default 10)")
+    p_cex.add_argument("--start", type=date.fromisoformat, default=None, help="Forcing start (default 1981-01-01)")
+    p_cex.add_argument("--end", type=date.fromisoformat, default=None, help="Forcing end (default last observation)")
+    p_cex.add_argument("--prefix", default=None, help="Sub-dataset prefix (default aquascope_<source>)")
+    p_cex.add_argument("--no-forcing", action="store_true", help="Streamflow and attributes only, no Open-Meteo calls")
+    p_cex.add_argument("--era5", action="store_true",
+                       help="Use plain ERA5 (25 km) instead of Open-Meteo's ERA5-Land + ERA5 blend")
+    p_cex.add_argument("--fetch-missing", action="store_true", help="Fetch stations the archive lacks from the agency")
+    p_cex.add_argument("--netcdf", action="store_true", help="Also write timeseries/netcdf (needs xarray + netCDF4)")
+    p_cex.add_argument("--pause", type=float, default=3.0, help="Seconds between Open-Meteo calls (default 3)")
+    p_cex.add_argument("--quiet", action="store_true")
+    p_cval = car_sub.add_parser("validate", help="Check a folder against the Caravan layout")
+    p_cval.add_argument("out")
+    p_cval.add_argument("--prefix", required=True)
+
     p_mcp = sub.add_parser("mcp", help="Serve find_stations / get_timeseries / analyze_station over MCP (#113)")
     p_mcp.add_argument("--transport", choices=["stdio", "sse", "streamable-http"], default="stdio")
 
@@ -1664,6 +1725,7 @@ def main() -> None:
         "harvest": cmd_harvest,
         "mcp": cmd_mcp,
         "basins": cmd_basins,
+        "caravan": cmd_caravan,
         "ask": cmd_ask,
         "ingest": cmd_ingest,
         "solve": cmd_solve,

--- a/aquascope/collectors/openmeteo.py
+++ b/aquascope/collectors/openmeteo.py
@@ -61,6 +61,7 @@ class OpenMeteoCollector(BaseCollector):
         daily: list[str] | None = None,
         hourly: list[str] | None = None,
         forecast_days: int = 7,
+        models: str | None = None,
     ) -> dict:
         """Call the Open-Meteo API and return the raw JSON response.
 
@@ -76,11 +77,19 @@ class OpenMeteoCollector(BaseCollector):
             Hourly variables (e.g. ``["river_discharge"]``).
         forecast_days : int
             Number of forecast days (only for ``mode="forecast"``).
+        models : str | None
+            Weather-mode reanalysis to read through the ``/archive`` endpoint:
+            ``"best_match"`` (Open-Meteo's blend: ERA5-Land where available, ERA5
+            otherwise; the only choice that serves every daily variable),
+            ``"era5_land"``, ``"era5"``, ... Default (None) is ERA5 via ``/era5``.
         """
         params: dict = {"latitude": latitude, "longitude": longitude, "timezone": "auto"}
 
         if self.mode == "weather":
             url = f"{_ARCHIVE_URL}/era5"
+            if models:
+                url = f"{_ARCHIVE_URL}/archive"
+                params["models"] = models
             if not (start_date and end_date):
                 raise ValueError("start_date and end_date are required for weather mode")
             params["start_date"] = start_date

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -131,6 +131,13 @@ sub-basins for any station or clicked point. Built by
 not weekly. Why BasinATLAS and not HydroBASINS: the HydroSHEDS core licence
 forbids stand-alone redistribution, HydroATLAS is CC BY 4.0.
 
+## Caravan-format export
+
+`aquascope caravan export --source uk_ea --out caravan_gb` turns the archive
+(catalog + discharge bundle + BasinATLAS + Open-Meteo forcing) into a Caravan
+sub-dataset: per-gauge daily forcing and mm/d streamflow, climate indices and
+HydroATLAS-style attributes. See [caravan.md](caravan.md).
+
 ## Terms
 
 The station catalog is factual metadata (where a gauge is, what it measures)

--- a/docs/caravan.md
+++ b/docs/caravan.md
@@ -1,0 +1,85 @@
+# Caravan-format export: large-sample datasets from the Archive
+
+[Caravan](https://doi.org/10.1038/s41597-023-01975-w) (Kratzert et al. 2023)
+is the layout the large-sample and machine-learning hydrology community
+trains on: one CSV per gauge with daily forcing and area-normalised
+streamflow in mm/d, plus three attribute tables per sub-dataset. Extending
+it normally means running Google Earth Engine. The Archive already holds
+every ingredient (station catalog, daily discharge bundles, BasinATLAS
+catchments), so `aquascope caravan export` writes the same layout from it:
+
+```bash
+pip install "aquascope[archive,basins]"
+aquascope caravan export --source uk_ea --out caravan_gb --max-stations 50
+aquascope caravan export --source usgs --out caravan_us --station USGS-01013500 --station USGS-01646500 --fetch-missing
+aquascope caravan validate caravan_gb --prefix aquascope_uk_ea
+```
+
+```
+caravan_gb/
+  attributes/aquascope_uk_ea/attributes_other_aquascope_uk_ea.csv        gauge_id, gauge_name, gauge_lat, gauge_lon, area, country, ...
+  attributes/aquascope_uk_ea/attributes_caravan_aquascope_uk_ea.csv      p_mean, pet_mean_FAO_PM, aridity_FAO_PM, frac_snow, moisture_index_FAO_PM, seasonality_FAO_PM, high/low_prec_freq/dur
+  attributes/aquascope_uk_ea/attributes_hydroatlas_aquascope_uk_ea.csv   catchment attributes under Caravan's HydroATLAS column names
+  attributes/aquascope_uk_ea/attributes_basinatlas_raw_aquascope_uk_ea.csv  the containing sub-basin's full BasinATLAS row
+  timeseries/csv/aquascope_uk_ea/aquascope_uk_ea_<station_id>.csv        date, forcing columns, streamflow (mm/d)
+  licenses/aquascope_uk_ea.md, provenance.json, README.md
+```
+
+Sources today: `usgs`, `uk_ea`, `hubeau_hydrometrie` (the sources whose
+daily discharge the Archive mirrors and whose agencies publish a catchment
+area). Stations come from the archive bundle, longest records first; a
+station needs ten years of daily flow (`--min-years`); `--fetch-missing`
+pulls stations the archive has not reached yet straight from the agency.
+
+## What is the same as Caravan, and what is not
+
+Same: the folder and file layout, `gauge_id = <prefix>_<station_id>`,
+streamflow in mm/d with NaN (never negative numbers) for gaps, daily values
+in local time, values rounded to two decimals, and the climate indices,
+which are a port of `caravan_utils.calculate_climate_indices` (Knoben's
+moisture index and seasonality, the snow fraction, the 5 x p_mean and 1 mm
+frequency and duration indices) over Caravan's reference period 1981 to 2020
+where the forcing covers it. The export is meant to be dropped next to a
+Caravan copy or read by the same loaders.
+
+Different, and written into `provenance.json`, `README.md` and the
+`licenses/` note of every export:
+
+- **Forcing is at the gauge point, not a basin average.** It comes from
+  Open-Meteo's reanalysis blend (ERA5-Land where it has the variable, ERA5
+  otherwise) and only for the daily variables Open-Meteo serves:
+  `total_precipitation_sum`, `potential_evaporation_sum_FAO_PENMAN_MONTEITH`
+  (FAO-56 ET0, there is no ERA5-Land potential evaporation),
+  `temperature_2m_mean/min/max`, and `surface_solar_radiation_downwards_mean`
+  (downward shortwave, so it is not called net radiation). `--era5` switches to
+  plain ERA5. Open-Meteo meters its free tier per minute; a 40-year request is
+  heavy, so the exporter pauses between gauges (`--pause`) and waits out 429s.
+- **HydroATLAS attributes are BasinATLAS's own upstream values** for the
+  level-12 sub-basin containing the gauge (its outlet, not the gauge, closes
+  the catchment), written under Caravan's column names
+  (`ele_mt_sav`, `pre_mm_syr`, ... hold the `_u`/`_p` upstream aggregate where
+  BasinATLAS has one). The raw sub-basin row is kept next to them.
+- **Area** is the agency's where it publishes one (USGS `drainage_area`, UK
+  EA `catchmentArea`, Hub'Eau `surface_bv`), else BasinATLAS `up_area` of the
+  containing sub-basin; `area_source` in `attributes_other` says which.
+- No basin shapefiles.
+
+## From Python
+
+```python
+from aquascope.archive.caravan import export_caravan, validate_caravan
+report = export_caravan("uk_ea", "caravan_gb", max_stations=20)
+print(report.n_ok, validate_caravan("caravan_gb", "aquascope_uk_ea"))
+```
+
+`climate_indices(frame)` and `fetch_forcing(lat, lon, start, end)` are
+importable on their own.
+
+## Towards CAMELS-TW
+
+This is the exporter the CAMELS-TW epic
+([#100](https://github.com/Rekin226/aquascope/issues/100)) needs; what it
+still lacks for Taiwan is a daily discharge collector with a station catalog
+([#211](https://github.com/Rekin226/aquascope/issues/211)). Once that source
+is harvested, `aquascope caravan export --source taiwan_wra_flow_daily` is
+the whole pipeline.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
     - Theory: theory.md
     - Data sources: data_sources.md
     - The Archive (open gauge catalog): archive.md
+    - Caravan export (large-sample datasets): caravan.md
     - The Explorer (click any gauge): explorer.md
     - MCP server (tools for assistants): mcp.md
     - The Analyst (ask, ingest): analyst.md

--- a/tests/test_archive/test_caravan.py
+++ b/tests/test_archive/test_caravan.py
@@ -1,0 +1,194 @@
+"""Caravan-format export from the Archive: indices match Caravan's own code, the layout validates."""
+
+from __future__ import annotations
+
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aquascope.archive import caravan
+
+
+def _forcing_frame(days=365 * 3, seed=1, start="2000-01-01"):
+    idx = pd.date_range(start, periods=days, freq="D", name="date")
+    rng = np.random.default_rng(seed)
+    doy = idx.dayofyear.to_numpy()
+    p = np.where(rng.random(days) < 0.35, rng.gamma(1.5, 6.0, days), 0.0)
+    t = 8 + 12 * np.sin((doy - 100) / 365 * 2 * np.pi) + rng.normal(0, 2, days)
+    pet = np.clip(1.5 + 2.5 * np.sin((doy - 100) / 365 * 2 * np.pi), 0.2, None)
+    return pd.DataFrame({
+        "total_precipitation_sum": p,
+        "potential_evaporation_sum_FAO_PENMAN_MONTEITH": pet,
+        "temperature_2m_mean": t,
+        "temperature_2m_min": t - 4,
+        "temperature_2m_max": t + 4,
+        "surface_solar_radiation_downwards_mean": 150 + 100 * np.sin((doy - 100) / 365 * 2 * np.pi),
+    }, index=idx)
+
+
+def _caravan_reference(df):
+    """Verbatim logic of caravan_utils.calculate_climate_indices (FAO-PM branch) as an independent oracle."""
+    p_mean = df["total_precipitation_sum"].mean()
+    pet_mean = df["potential_evaporation_sum_FAO_PENMAN_MONTEITH"].mean()
+    precipitation, pet = df["total_precipitation_sum"], df["potential_evaporation_sum_FAO_PENMAN_MONTEITH"]
+    mean_monthly_precip = precipitation.groupby(precipitation.index.month).mean()
+    mean_monthly_pet = pet.groupby(pet.index.month).mean()
+    p_gt_et = 1 - mean_monthly_pet.loc[mean_monthly_precip > mean_monthly_pet] / mean_monthly_precip.loc[
+        mean_monthly_precip > mean_monthly_pet]
+    srs = pd.Series(np.zeros((12), dtype=np.float32), index=mean_monthly_pet.index, name="dummy")
+    p_eq_et = srs.loc[mean_monthly_precip == mean_monthly_pet]
+    p_lt_et = mean_monthly_precip.loc[mean_monthly_precip < mean_monthly_pet] / mean_monthly_pet.loc[
+        mean_monthly_precip < mean_monthly_pet] - 1
+    monthly = pd.concat([p_gt_et, p_eq_et, p_lt_et])
+    mean_monthly_temp = df["temperature_2m_mean"].groupby(df.index.month).mean()
+    frac_snow = mean_monthly_precip.loc[mean_monthly_temp < 0].sum() / mean_monthly_precip.sum()
+    high_prec_freq = len(df.loc[df["total_precipitation_sum"] >= 5 * p_mean]) / len(df)
+    low_prec_freq = len(df.loc[df["total_precipitation_sum"] < 1]) / len(df)
+
+    def split_list(a_list):
+        new_list, start = [], 0
+        for index, value in enumerate(a_list):
+            if index < len(a_list) - 1:
+                if a_list[index + 1] > value + 1:
+                    end = index + 1
+                    new_list.append(a_list[start:end])
+                    start = end
+            else:
+                new_list.append(a_list[start:len(a_list)])
+        return new_list
+
+    precip = df["total_precipitation_sum"].values
+    groups = split_list(list(np.where(precip < 1)[0]))
+    low_dur = np.mean([len(g) for g in groups]) if groups else 0.0
+    groups = split_list(list(np.where(precip >= 5 * p_mean)[0]))
+    high_dur = np.mean([len(g) for g in groups]) if groups else 0.0
+    return {"p_mean": p_mean, "pet_mean_FAO_PM": pet_mean, "aridity_FAO_PM": pet_mean / p_mean, "frac_snow": frac_snow,
+            "moisture_index_FAO_PM": monthly.mean(), "seasonality_FAO_PM": monthly.max() - monthly.min(),
+            "high_prec_freq": high_prec_freq, "high_prec_dur": high_dur, "low_prec_freq": low_prec_freq,
+            "low_prec_dur": low_dur}
+
+
+def test_climate_indices_match_caravan_reference():
+    df = _forcing_frame()
+    ours = caravan.climate_indices(df, start=df.index.min(), end=df.index.max())
+    ref = _caravan_reference(df)
+    for k, v in ref.items():
+        assert ours[k] == pytest.approx(v, rel=1e-9, abs=1e-12), k
+    assert 0 <= ours["frac_snow"] <= 1 and ours["high_prec_dur"] >= 1 and ours["low_prec_dur"] >= 1
+    # the Caravan reference period is applied when the frame covers it
+    long = _forcing_frame(days=365 * 45, start="1979-01-01")
+    d = long.loc[caravan.CARAVAN_START:caravan.CARAVAN_END]
+    assert caravan.climate_indices(long)["p_mean"] == pytest.approx(d["total_precipitation_sum"].mean())
+
+
+def test_hydroatlas_catchment_row_prefers_upstream_fields():
+    raw = {"hybas_id": 1, "ele_mt_sav": 100, "ele_mt_uav": 400, "run_mm_syr": 30, "dis_m3_pyr": 12.5,
+           "for_pc_sse": 10, "for_pc_use": None, "up_area": 999.0, "next_down": 0}
+    row = caravan._hydroatlas_catchment_row(raw)
+    assert row == {"ele_mt_sav": 400, "run_mm_syr": 30, "dis_m3_pyr": 12.5, "for_pc_sse": 10}
+
+
+def test_gauge_ids_and_area_helpers():
+    assert caravan.gauge_id_for("aquascope_usgs", "USGS-01646500") == "aquascope_usgs_USGS-01646500"
+    assert caravan.gauge_id_for("x", "a b/c") == "x_a_b_c"
+
+
+def test_export_end_to_end_with_fakes(tmp_path, monkeypatch):
+    """Two archived stations (one too short), forcing/basins/areas faked; files, units and validation checked."""
+    catalog = [
+        {"source": "uk_ea", "station_id": "S1", "name": "Thames at Somewhere", "latitude": 51.4, "longitude": -0.3,
+         "variables": ["discharge"], "country": "United Kingdom", "extra": {}},
+        {"source": "uk_ea", "station_id": "S2", "name": "Short record", "latitude": 52.0, "longitude": -1.0,
+         "variables": ["discharge"], "country": "United Kingdom", "extra": {}},
+        {"source": "uk_ea", "station_id": "S3", "name": "Not archived", "latitude": 53.0, "longitude": -2.0,
+         "variables": ["discharge"], "country": "United Kingdom", "extra": {}},
+    ]
+    idx1 = pd.date_range("1990-01-01", periods=365 * 15, freq="D")
+    idx2 = pd.date_range("2015-01-01", periods=400, freq="D")
+    obs = pd.concat([
+        pd.DataFrame({"station_id": "S1", "date": idx1, "value": 20.0}),
+        pd.DataFrame({"station_id": "S2", "date": idx2, "value": 5.0}),
+    ], ignore_index=True)
+
+    def fake_forcing(lat, lon, start, end, *, models=None):
+        idx = pd.date_range(start, end, freq="D", name="date")
+        return _forcing_frame(days=len(idx), start=str(start)), "best_match"
+
+    monkeypatch.setattr(caravan, "fetch_forcing", fake_forcing)
+    monkeypatch.setattr(caravan, "station_area_km2", lambda source, st, collectors: (1000.0, "uk_ea_catchmentArea")
+                        if st["station_id"] == "S1" else (None, ""))
+    monkeypatch.setattr("aquascope.archive.basins.sub_basin_at",
+                        lambda lat, lon, **kw: {"hybas_id": 2120000010, "next_down": 0, "main_bas": 2120000010,
+                                                "sub_area": 120.0, "up_area": 1200.0, "pfaf_id": 1})
+    monkeypatch.setattr("aquascope.archive.basins.load_attributes",
+                        lambda ids, **kw: pd.DataFrame([{"hybas_id": 2120000010, "sub_area": 120.0, "up_area": 1200.0,
+                                                         "ele_mt_sav": 90, "ele_mt_uav": 210, "pre_mm_syr": 700,
+                                                         "pre_mm_uyr": 750, "for_pc_sse": 12, "for_pc_use": 20,
+                                                         "dis_m3_pyr": 19.0}]))
+    report = caravan.export_caravan("uk_ea", tmp_path, catalog=catalog, observations=obs, min_years=10,
+                                    end=pd.Timestamp("2004-12-30").date())
+    by = {g.station_id: g for g in report.gauges}
+    assert by["S1"].ok and by["S1"].area_km2 == 1000.0 and by["S1"].hybas_id == 2120000010
+    assert not by["S2"].ok and "too short" in by["S2"].error
+    assert "S3" not in by  # not archived and fetch_missing is off: not picked
+    assert report.n_ok == 1
+
+    prefix = "aquascope_uk_ea"
+    ts = pd.read_csv(tmp_path / "timeseries" / "csv" / prefix / "aquascope_uk_ea_S1.csv", index_col="date",
+                     parse_dates=["date"])
+    assert ts.index.min() == pd.Timestamp("1981-01-01") and ts.index.max() == pd.Timestamp("2004-12-30")
+    assert list(ts.columns) == [c for c, *_ in caravan.FORCING] + ["streamflow"]
+    # 20 m3/s over 1000 km2 = 20 * 86.4 / 1000 = 1.728 mm/d, rounded to 2 decimals; NaN before the record starts
+    assert ts.loc["1995-06-01", "streamflow"] == pytest.approx(1.73)
+    assert np.isnan(ts.loc["1985-06-01", "streamflow"])
+
+    other = pd.read_csv(tmp_path / "attributes" / prefix / f"attributes_other_{prefix}.csv", index_col="gauge_id")
+    assert list(other.index) == ["aquascope_uk_ea_S1"]
+    assert other.loc["aquascope_uk_ea_S1", "area"] == 1000.0 and other.loc["aquascope_uk_ea_S1", "gauge_lat"] == 51.4
+    assert other.loc["aquascope_uk_ea_S1", "area_source"] == "uk_ea_catchmentArea"
+    assert other.loc["aquascope_uk_ea_S1", "forcing_model"] == "best_match"
+    hydro = pd.read_csv(tmp_path / "attributes" / prefix / f"attributes_hydroatlas_{prefix}.csv", index_col="gauge_id")
+    assert hydro.loc["aquascope_uk_ea_S1", "ele_mt_sav"] == 210 and hydro.loc["aquascope_uk_ea_S1", "for_pc_sse"] == 20
+    assert "ele_mt_uav" not in hydro.columns and "hybas_id" not in hydro.columns
+    raw = pd.read_csv(tmp_path / "attributes" / prefix / f"attributes_basinatlas_raw_{prefix}.csv",
+                      index_col="gauge_id")
+    assert raw.loc["aquascope_uk_ea_S1", "ele_mt_uav"] == 210
+    cara = pd.read_csv(tmp_path / "attributes" / prefix / f"attributes_caravan_{prefix}.csv", index_col="gauge_id")
+    for c in caravan.CARAVAN_INDEX_REQUIRED:
+        assert c in cara.columns
+    prov = json.loads((tmp_path / "provenance.json").read_text())
+    sub = prov["subdatasets"][prefix]
+    assert sub["n_gauges"] == 1 and sub["forcing"]["models"] == "best_match"
+    assert (tmp_path / "licenses" / f"{prefix}.md").read_text().count("CC BY 4.0") >= 1
+
+    res = caravan.validate_caravan(tmp_path, prefix)
+    assert res["ok"], res["problems"]
+
+    # a broken tree is caught
+    ts.loc["1995-06-01", "streamflow"] = -1
+    ts.to_csv(tmp_path / "timeseries" / "csv" / prefix / "aquascope_uk_ea_S1.csv")
+    res = caravan.validate_caravan(tmp_path, prefix)
+    assert not res["ok"] and any("negative" in p for p in res["problems"])
+
+
+def test_export_uses_basinatlas_area_when_agency_has_none(tmp_path, monkeypatch):
+    catalog = [{"source": "usgs", "station_id": "USGS-1", "name": "X", "latitude": 40.0, "longitude": -100.0,
+                "variables": ["discharge"], "country": "United States", "extra": {}}]
+    idx = pd.date_range("2000-01-01", periods=365 * 12, freq="D")
+    obs = pd.DataFrame({"station_id": "USGS-1", "date": idx, "value": 8.64})
+    monkeypatch.setattr(caravan, "station_area_km2", lambda *a, **k: (None, ""))
+    monkeypatch.setattr("aquascope.archive.basins.sub_basin_at",
+                        lambda lat, lon, **kw: {"hybas_id": 7, "up_area": 100.0})
+    monkeypatch.setattr("aquascope.archive.basins.load_attributes", lambda ids, **kw: pd.DataFrame())
+    report = caravan.export_caravan("usgs", tmp_path, catalog=catalog, observations=obs, forcing=False)
+    g = report.gauges[0]
+    assert g.ok and g.area_source.startswith("basinatlas") and g.area_km2 == 100.0
+    ts = pd.read_csv(tmp_path / "timeseries" / "csv" / "aquascope_usgs" / "aquascope_usgs_USGS-1.csv", index_col="date")
+    assert list(ts.columns) == ["streamflow"]
+    assert ts["streamflow"].dropna().iloc[0] == pytest.approx(7.46)  # 8.64 m3/s * 86.4 / 100 km2 = 7.46496
+    assert not (tmp_path / "attributes" / "aquascope_usgs" / "attributes_caravan_aquascope_usgs.csv").exists()
+
+    with pytest.raises(ValueError):
+        caravan.export_caravan("taiwan_cwa", tmp_path, catalog=catalog, observations=obs)


### PR DESCRIPTION
Step 3 of #100 (CAMELS-TW), the "Caravan export MVP" gate, built on the Archive instead of Earth Engine.

**What changes**

- `aquascope.archive.caravan` + `aquascope caravan export --source usgs|uk_ea|hubeau_hydrometrie --out DIR [--station ID]* [--max-stations N] [--min-years 10] [--fetch-missing] [--no-forcing] [--era5] [--pause 3]` and `aquascope caravan validate DIR --prefix P`.
- Writes Caravan's tree: `attributes/<prefix>/attributes_{other,caravan,hydroatlas}_<prefix>.csv` (+ `attributes_basinatlas_raw_<prefix>.csv`), `timeseries/csv/<prefix>/<gauge_id>.csv` (date, forcing, `streamflow` in mm/d, two decimals, NaN for gaps), `licenses/<prefix>.md`, `provenance.json`, `README.md`.
- Streamflow from the archive discharge bundle (longest records first, `--min-years`), converted with the agency's catchment area (USGS `drainage_area`, UK EA `catchmentArea`, Hub'Eau `surface_bv`), else BasinATLAS `up_area` (flagged in `area_source`).
- Forcing at the gauge point from Open-Meteo's reanalysis blend (`/archive`, `models=best_match`: ERA5-Land where it has the variable, ERA5 otherwise; `era5_land` alone returns no precipitation/ET0/radiation, checked). Columns: `total_precipitation_sum`, `potential_evaporation_sum_FAO_PENMAN_MONTEITH`, `temperature_2m_mean/min/max`, `surface_solar_radiation_downwards_mean` (named for what it is). 429s are waited out (65 s), a pause separates gauges. The Open-Meteo collector gains `models=`.
- Climate indices: a port of `caravan_utils.calculate_climate_indices` (Knoben moisture index and seasonality, frac_snow, high/low precipitation frequency and duration) over Caravan's 1981 to 2020 reference period; the test checks it against a verbatim copy of Caravan's code on synthetic data.
- HydroATLAS attributes: BasinATLAS's upstream (`_u`/`_p`) values of the containing level-12 sub-basin under Caravan's column names; the raw row is kept alongside.
- Docs page `docs/caravan.md` (what is the same as Caravan and what is not), archive.md link, README, CHANGELOG.

**Checked live**: `aquascope caravan export --source usgs --station USGS-01013500` (Fish River near Fort Kent, which is `camels_01013500` in CAMELS-US) gives 16,659 forcing days, 14,603 with flow, area 2,253 km² from USGS, p_mean 2.95 mm/d, frac_snow 0.37, aridity 0.64, and validates; three UK EA gauges likewise (one skipped by an Open-Meteo 429 before the wait/retry was added). Full suite green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB
