### PR TITLE
Similar gauged basins: donor selection for ungauged sites (CLI, MCP, analyst, Explorer)

### DIFF
--- a/.github/workflows/harvest.yml
+++ b/.github/workflows/harvest.yml
@@ -53,8 +53,8 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install aquascope with the archive extra
-        run: python -m pip install -q ".[archive]"
+      - name: Install aquascope with the archive and basins extras
+        run: python -m pip install -q ".[archive,basins]"
 
       - name: Sync the existing observations (incremental runs)
         if: env.HF_TOKEN != ''
@@ -69,6 +69,29 @@ jobs:
           aquascope harvest stations $ARGS
           echo "exit=$?" >> "$GITHUB_OUTPUT"
           set -e
+
+      - name: Assign every station to its BasinATLAS sub-basin (basins/station_catchments.parquet)
+        # Reads the published lev12.fgb (955 MB) and lev12_attributes.parquet from the Hub, spatially joins the
+        # fresh catalog, and writes the table the similar-basins search runs on. Skipped when basins are not
+        # published yet; a failure here must not stop the observation harvest.
+        continue-on-error: true
+        run: |
+          python - <<'EOF'
+          import os, sys, logging
+          logging.basicConfig(level=logging.INFO, format="%(message)s")
+          from huggingface_hub import hf_hub_download
+          repo = os.environ["HF_DATASET"]
+          try:
+              fgb = hf_hub_download(repo, "basins/lev12.fgb", repo_type="dataset")
+              attrs = hf_hub_download(repo, "basins/lev12_attributes.parquet", repo_type="dataset")
+          except Exception as exc:
+              print(f"basins not published yet, skipping ({exc})"); sys.exit(0)
+          from aquascope.archive.similar import assign_station_catchments
+          from aquascope.archive.catalog import load_stations
+          catalog = load_stations(path="archive/stations.parquet")
+          table = assign_station_catchments(catalog, fgb, attrs, "archive/basins/station_catchments.parquet")
+          print(f"{len(table):,} of {len(catalog):,} stations assigned")
+          EOF
 
       - name: Harvest daily observations (budgeted; the archive fills up over weeks)
         id: obs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+- **Similar gauged basins** (`aquascope.archive.similar`, `aquascope basins similar LAT LON | --station SOURCE/ID`, MCP `similar_basins`, Explorer): the weekly harvest joins every catalog station to its BasinATLAS sub-basin and publishes `basins/station_catchments.parquet`; on it, any point or station gets the gauged basins whose catchments resemble it most (weighted distance in standardised BasinATLAS attribute space, great-circle distance, or both), with per-feature deltas and the citation (Bloeschl et al. 2013, Oudin et al. 2008). The donor-selection half of prediction in ungauged basins (#53); the analyst is told to use it before analysing donors. `load_stations(path=...)` reads a local `stations.parquet`.
 - **Caravan-format export from the Archive** (`aquascope caravan export|validate`, `aquascope.archive.caravan`): per-gauge daily forcing (Open-Meteo's ERA5-Land + ERA5 blend at the gauge point) and area-normalised streamflow in mm/d from the discharge bundles, Caravan's climate indices (a port of `caravan_utils.calculate_climate_indices`, FAO-PM variants), HydroATLAS-style attributes from BasinATLAS, `attributes_other` with area and provenance, licences and a `provenance.json`; USGS, UK EA and Hub'Eau, areas from the agency (`drainage_area`, `catchmentArea`, `surface_bv`) else BasinATLAS. The Open-Meteo collector accepts `models=` for the `/archive` endpoint. (#100)
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ AquaScope ships a 24-command CLI (`agri`, `basins` and `caravan` carry subcomman
 aquascope stations --bbox -0.5,51.3,0.3,51.7 --variable discharge --format geojson
 aquascope harvest stations --out archive          # the open gauge catalog (GeoParquet)
 aquascope basins at 48.85 2.35                    # the catchment of any point: area, climate, land cover, soils, dams (BasinATLAS)
+aquascope basins similar 25.04 121.56             # gauged basins whose catchments look most like this point's (ungauged-site donors)
 aquascope caravan export --source uk_ea --out caravan_gb   # a Caravan-format large-sample dataset from the archive
 aquascope mcp                                     # serve the same tools to Claude / Cursor over MCP
 aquascope ask "100-year flood of the Seine at Paris?"   # the analyst: tools + a cited Markdown report

--- a/aquascope/ai_engine/analyst.py
+++ b/aquascope/ai_engine/analyst.py
@@ -54,6 +54,7 @@ Rules:
 - Find stations with find_stations before analysing; prefer stations with long records for flood questions.
 - Use analyze_station / flood_frequency for numbers; use anywhere(lat, lon) when the user names a place with no gauge.
 - Use describe_catchment(lat, lon) for the catchment itself: area, elevation, climate, land cover, soils, dams.
+- For an ungauged place, use similar_basins to find donor gauges, then analyze_station on the best donors.
 - Never invent values, station ids, or citations. If a tool returns an error or an empty record, say so.
 - Report units. Quote return levels with their confidence intervals when available.
 - Say which record (station, source, period, number of years) each number comes from.
@@ -135,6 +136,16 @@ def _tool_specs() -> list[ToolSpec]:
             {"type": "object", "properties": {"lat": num, "lon": num, "upstream": {"type": "boolean"}},
              "required": ["lat", "lon"]},
             t.describe_catchment,
+        ),
+        ToolSpec(
+            "similar_basins",
+            "Gauged basins whose catchments most resemble a point's (lat, lon) or a station's (source, station_id): "
+            "donor selection for ungauged sites. method: similarity | proximity | combined.",
+            {"type": "object", "properties": {"lat": num, "lon": num, "source": {"type": "string"},
+                                              "station_id": {"type": "string"}, "k": {"type": "integer"},
+                                              "method": {"type": "string"},
+                                              "sources": {"type": "array", "items": {"type": "string"}}}},
+            t.similar_basins,
         ),
         ToolSpec(
             "describe_methods", "What each analysis computes and the reference to cite.",
@@ -256,6 +267,11 @@ def _harvest_provenance(name: str, args: dict[str, Any], result: Any, res: AskRe
                 "label": label, "period": period, "license": result.get("license"),
                 "attribution": result.get("attribution"),
             })
+    if name == "similar_basins" and result.get("stations"):
+        label = "similar-basins search"
+        if not any(d.get("label") == label for d in res.data_used):
+            res.data_used.append({"label": label, "period": None, "license": result.get("license"),
+                                  "attribution": result.get("attribution")})
     if name == "describe_catchment" and result.get("sub_basin"):
         label = f"catchment at {result.get('latitude')}, {result.get('longitude')}"
         if not any(d.get("label") == label for d in res.data_used):

--- a/aquascope/archive/basins.py
+++ b/aquascope/archive/basins.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import time
 from collections import defaultdict, deque
 from dataclasses import asdict, dataclass
@@ -562,7 +563,7 @@ def catchment_attributes(ids: list[int], attrs: pd.DataFrame, outlet: int | None
     for key, (s_field, u_field, unit, how, label) in ATTRIBUTE_GUIDE.items():
         val = None
         source = None
-        has_u = u_field and u_field in df.columns and outlet in df.index and len(df) > 1
+        has_u = u_field and u_field in df.columns and outlet in df.index
         if has_u and pd.notna(df.at[outlet, u_field]) and float(df.at[outlet, u_field]) > NODATA:
             val, source, field = float(df.at[outlet, u_field]), "basinatlas_upstream", u_field
         elif s_field in df.columns:
@@ -587,6 +588,33 @@ def catchment_attributes(ids: list[int], attrs: pd.DataFrame, outlet: int | None
         if source == "area_weighted_mean" and not complete:
             entry["note"] = "aggregated over the sub-basins returned; the upstream set may be capped"
         out[key] = entry
+    return out
+
+
+def row_catchment_attributes(row: dict[str, Any] | pd.Series) -> dict[str, float]:
+    """Flat ``{guide key: value}`` for one BasinATLAS row, taking the upstream field where it exists.
+
+    The catchment closed at the row's sub-basin outlet, in real units (storage
+    multipliers undone, ``NODATA`` dropped). Used to tabulate every gauged
+    station's catchment for similarity search.
+    """
+    if isinstance(row, pd.Series):
+        row = row.to_dict()
+    out: dict[str, float] = {}
+    for key, (s_field, u_field, _unit, _how, _label) in ATTRIBUTE_GUIDE.items():
+        val = None
+        for f in (u_field, s_field):
+            if f and f in row and row[f] is not None:
+                try:
+                    v = float(row[f])
+                except (TypeError, ValueError):
+                    continue
+                if not math.isnan(v) and v > NODATA:
+                    val, field = v, f
+                    break
+        if val is None:
+            continue
+        out[key] = round(scale_value(field, val)[0], 4)
     return out
 
 

--- a/aquascope/archive/catalog.py
+++ b/aquascope/archive/catalog.py
@@ -60,22 +60,30 @@ def _download(url: str, dest: Path, refresh: bool) -> Path:
     return dest
 
 
-def load_stations(*, repo_id: str = DEFAULT_REPO_ID, refresh: bool = False) -> list[dict[str, Any]]:
+def load_stations(
+    *, repo_id: str = DEFAULT_REPO_ID, refresh: bool = False, path: str | Path | None = None
+) -> list[dict[str, Any]]:
     """Return every station in the published catalog as a list of dicts.
 
     Keys: ``source, station_id, name, latitude, longitude, variables (list),
     period_start, period_end, url, river, country, agency, license,
-    redistributable, extra (dict)``.
+    redistributable, extra (dict)``. ``path`` reads a local ``stations.parquet``
+    (a fresh harvest) instead of the Hub.
     """
-    if _OVERRIDE is not None:
+    if _OVERRIDE is not None and path is None:
         return _OVERRIDE
     try:
         import pyarrow.parquet as pq  # noqa: F401
     except ImportError:
         pq = None
+    if path is not None and pq is None:
+        raise ImportError("reading a local stations.parquet needs pyarrow (pip install 'aquascope[archive]')")
     if pq is not None:
-        local = cache_dir() / f"{repo_id.replace('/', '__')}.parquet"
-        dest = _download(catalog_url(repo_id, "stations.parquet"), local, refresh)
+        if path is not None:
+            dest = Path(path)
+        else:
+            local = cache_dir() / f"{repo_id.replace('/', '__')}.parquet"
+            dest = _download(catalog_url(repo_id, "stations.parquet"), local, refresh)
         table = pq.read_table(dest, columns=[c for c in [
             "source", "station_id", "name", "latitude", "longitude", "variables", "period_start", "period_end",
             "url", "river", "country", "agency", "license", "redistributable", "extra",

--- a/aquascope/archive/similar.py
+++ b/aquascope/archive/similar.py
@@ -1,0 +1,349 @@
+"""Nearest similar gauged basins: prediction in ungauged basins, the practical half (#53).
+
+Given any point on land (or any station), find the gauged catchments in the
+Archive that look most like its catchment: same size class, climate, relief,
+land cover, soils, human pressure. That is the "physical similarity" donor
+selection of regionalisation (Bloeschl et al. 2013, Runoff Prediction in
+Ungauged Basins; Oudin et al. 2008 for why spatial proximity is a strong
+baseline), and it is what a consultant does by hand before transferring
+anything to an ungauged site.
+
+Two tables make it instant:
+
+``basins/station_catchments.parquet``
+    one row per catalog station: ``source, station_id, hybas_id, up_area`` and
+    the catchment attributes of :data:`aquascope.archive.basins.ATTRIBUTE_GUIDE`
+    (BasinATLAS upstream values for the level-12 sub-basin containing the
+    gauge, real units). Built weekly by the harvest workflow with
+    :func:`assign_station_catchments` (a spatial join of the catalog against
+    the BasinATLAS FlatGeobuf), published next to the catalog.
+
+The search standardises a chosen feature set over the table (z-scores),
+measures Euclidean distance in that space (``method="similarity"``), or
+great-circle distance (``"proximity"``), or both combined (``"combined"``:
+similarity distance plus proximity in units of 500 km), and returns the
+``k`` closest stations that measure discharge, with the per-feature deltas
+so the reader can see why they were chosen.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from aquascope.archive.basins import ATTRIBUTION, LICENSE, row_catchment_attributes
+from aquascope.registry import SOURCES
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_REPO_ID = "Rekin226/aquascope-gauges"
+TABLE_NAME = "station_catchments.parquet"
+
+# feature key -> (attribute key in the guide / table column, transform, weight)
+FEATURES: dict[str, tuple[str, str | None, float]] = {
+    "log_area": ("up_area", "log10", 1.5),
+    "elevation": ("elevation_m", None, 1.0),
+    "slope": ("slope_deg", "log1p", 1.0),
+    "precipitation": ("precipitation_mm_yr", None, 1.5),
+    "aridity": ("aridity_index", "log1p", 1.5),
+    "temperature": ("temperature_c", None, 1.0),
+    "snow": ("snow_cover_pct", None, 1.0),
+    "forest": ("forest_pct", None, 0.7),
+    "cropland": ("cropland_pct", None, 0.7),
+    "urban": ("urban_pct", "log1p", 0.7),
+    "clay": ("clay_pct", None, 0.5),
+    "sand": ("sand_pct", None, 0.5),
+    "population_density": ("population_density", "log1p", 0.5),
+    "regulation": ("degree_of_regulation_pct", "log1p", 0.7),
+}
+PROXIMITY_SCALE_KM = 500.0
+
+
+def table_url(repo_id: str = DEFAULT_REPO_ID) -> str:
+    return f"https://huggingface.co/datasets/{repo_id}/resolve/main/basins/{TABLE_NAME}"
+
+
+# ── build (harvest workflow) ────────────────────────────────────────────────
+
+
+def assign_station_catchments(
+    catalog: list[dict[str, Any]],
+    fgb_path: str | Path,
+    attributes_path: str | Path,
+    out_path: str | Path,
+    *,
+    batch: int = 20_000,
+) -> pd.DataFrame:
+    """Spatial-join every catalog station to its level-12 sub-basin and tabulate the catchment attributes.
+
+    Needs geopandas + pyogrio (``basins`` extra) and the local ``lev12.fgb`` and
+    ``lev12_attributes.parquet``. Stations in the sea or off coverage get no row.
+    """
+    import geopandas as gpd
+    import pyogrio
+    from shapely.geometry import Point
+
+    from aquascope.archive.basins import TOPOLOGY_COLUMNS, load_attributes
+
+    t0 = time.perf_counter()
+    pts = gpd.GeoDataFrame(
+        {"source": [r["source"] for r in catalog], "station_id": [r["station_id"] for r in catalog]},
+        geometry=[Point(float(r["longitude"]), float(r["latitude"])) for r in catalog], crs="EPSG:4326",
+    )
+    # Tile the world so the million polygons never sit in memory at once: read the sub-basins
+    # intersecting each 20 x 20 degree tile that holds stations, join those points, move on.
+    joined_parts = []
+    xs, ys = pts.geometry.x.to_numpy(), pts.geometry.y.to_numpy()
+    tile = 20.0
+    tiles = sorted({(math.floor(x / tile) * tile, math.floor(y / tile) * tile) for x, y in zip(xs, ys)})
+    for tx, ty in tiles:
+        in_tile = pts[(xs >= tx) & (xs < tx + tile) & (ys >= ty) & (ys < ty + tile)]
+        if in_tile.empty:
+            continue
+        polys = pyogrio.read_dataframe(str(fgb_path), bbox=(tx - 0.01, ty - 0.01, tx + tile + 0.01, ty + tile + 0.01))
+        if polys.empty:
+            continue
+        polys.columns = [c.lower() if c.upper() in TOPOLOGY_COLUMNS else c for c in polys.columns]
+        keep = [c for c in ("hybas_id", "up_area", "sub_area", "next_down") if c in polys.columns]
+        polys = polys[keep + [polys.geometry.name]]
+        part = gpd.sjoin(in_tile, polys, how="inner", predicate="within")
+        joined_parts.append(part[~part.index.duplicated(keep="first")])
+        logger.info("  tile %+.0f,%+.0f: %d stations, %d sub-basins, %d matched",
+                    tx, ty, len(in_tile), len(polys), len(part))
+    joined = pd.concat(joined_parts) if joined_parts else pts.iloc[0:0].assign(hybas_id=[], up_area=[], sub_area=[])
+    joined = joined[~joined.index.duplicated(keep="first")]
+    logger.info("station join: %d of %d stations fall in a sub-basin (%.0fs)", len(joined), len(pts),
+                time.perf_counter() - t0)
+
+    ids = sorted({int(x) for x in joined["hybas_id"].dropna().unique()})
+    rows: list[dict[str, Any]] = []
+    attrs_by_id: dict[int, dict[str, Any]] = {}
+    for i in range(0, len(ids), batch):
+        chunk = ids[i:i + batch]
+        df = load_attributes(chunk, path=attributes_path)
+        for rec in df.to_dict("records"):
+            attrs_by_id[int(rec["hybas_id"])] = rec
+    for rec in joined.drop(columns=[joined.geometry.name]).to_dict("records"):
+        hid = int(rec["hybas_id"])
+        base = {"source": rec["source"], "station_id": rec["station_id"], "hybas_id": hid,
+                "up_area": float(rec.get("up_area") or 0.0), "sub_area": float(rec.get("sub_area") or 0.0)}
+        base.update(row_catchment_attributes(attrs_by_id.get(hid, {})))
+        rows.append(base)
+    out = pd.DataFrame(rows)
+    out_path = Path(out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out.to_parquet(out_path, index=False)
+    logger.info("station catchments: %d rows, %d columns -> %s (%.0fs)", len(out), out.shape[1], out_path,
+                time.perf_counter() - t0)
+    return out
+
+
+# ── read side ───────────────────────────────────────────────────────────────
+
+
+def load_station_catchments(*, repo_id: str = DEFAULT_REPO_ID, refresh: bool = False,
+                            path: str | Path | None = None) -> pd.DataFrame:
+    """The station -> catchment table (downloaded once a day into the cache)."""
+    if path is None:
+        from aquascope.archive.catalog import _download, cache_dir
+
+        path = _download(table_url(repo_id), cache_dir() / f"{repo_id.replace('/', '__')}__{TABLE_NAME}", refresh)
+    return pd.read_parquet(path)
+
+
+def _transform(values: pd.Series | np.ndarray | float, how: str | None):
+    v = np.asarray(values, dtype=float)
+    if how == "log10":
+        return np.log10(np.clip(v, 1e-3, None))
+    if how == "log1p":
+        return np.log1p(np.clip(v, 0, None))
+    return v
+
+
+def _haversine_km(lat1: float, lon1: float, lat2: np.ndarray, lon2: np.ndarray) -> np.ndarray:
+    r = 6371.0088
+    p1, p2 = math.radians(lat1), np.radians(lat2)
+    dphi = np.radians(lat2 - lat1)
+    dl = np.radians(lon2 - lon1)
+    a = np.sin(dphi / 2) ** 2 + math.cos(p1) * np.cos(p2) * np.sin(dl / 2) ** 2
+    return 2 * r * np.arcsin(np.sqrt(a))
+
+
+def similar_basins(
+    target: dict[str, Any],
+    *,
+    k: int = 10,
+    method: str = "similarity",
+    require_discharge: bool = True,
+    sources: list[str] | None = None,
+    features: list[str] | None = None,
+    exclude: tuple[str, str] | None = None,
+    table: pd.DataFrame | None = None,
+    catalog: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Rank gauged stations by how much their catchment resembles ``target``.
+
+    ``target`` carries the catchment attributes under the guide keys (as
+    :func:`row_catchment_attributes` / ``describe_catchment()["attributes"]``
+    give them) plus ``latitude`` / ``longitude`` (needed for proximity).
+    ``method``: ``similarity`` (attribute space), ``proximity`` (distance on the
+    ground) or ``combined``. ``exclude`` drops one ``(source, station_id)`` (the
+    target station itself). Returns the ranking with per-feature deltas.
+    """
+    from aquascope.archive.catalog import load_stations
+
+    if method not in ("similarity", "proximity", "combined"):
+        raise ValueError("method must be similarity, proximity or combined")
+    tab = table if table is not None else load_station_catchments()
+    cat = catalog if catalog is not None else load_stations()
+    meta = {(r["source"], r["station_id"]): r for r in cat}
+    keys = [(s, i) for s, i in zip(tab["source"], tab["station_id"])]
+    if require_discharge:
+        mask = np.array(["discharge" in ((meta.get(kk) or {}).get("variables") or []) for kk in keys])
+    else:
+        mask = np.ones(len(tab), dtype=bool)
+    if sources:
+        mask &= tab["source"].isin(sources).to_numpy()
+    if exclude:
+        mask &= ~((tab["source"] == exclude[0]) & (tab["station_id"] == exclude[1])).to_numpy()
+    cand = tab[mask].reset_index(drop=True)
+    if cand.empty:
+        return {"n_candidates": 0, "stations": [], "method": method}
+
+    tval = _target_values(target)
+    feats = [f for f in (features or list(FEATURES)) if f in FEATURES]
+    used = [f for f in feats if FEATURES[f][0] in cand.columns and tval.get(f) is not None]
+    dist_attr = np.zeros(len(cand))
+    contributions: dict[str, np.ndarray] = {}
+    if method in ("similarity", "combined") and used:
+        parts = []
+        for f in used:
+            col, how, w = FEATURES[f]
+            x = _transform(cand[col].to_numpy(dtype=float), how)
+            mu, sd = np.nanmean(x), np.nanstd(x)
+            sd = sd if sd and not math.isnan(sd) else 1.0
+            z = (x - mu) / sd
+            zt = (_transform(tval[f], how) - mu) / sd
+            d = np.where(np.isnan(z), 3.0, np.abs(z - zt)) * w  # missing values are penalised, not ignored
+            contributions[f] = d
+            parts.append(d ** 2)
+        dist_attr = np.sqrt(np.sum(parts, axis=0) / max(sum(FEATURES[f][2] ** 2 for f in used), 1e-9))
+    dist_km = None
+    if method in ("proximity", "combined"):
+        lat0, lon0 = float(target.get("latitude")), float(target.get("longitude"))
+        lats = np.array([float((meta.get(kk) or {}).get("latitude", np.nan)) for kk in
+                         zip(cand["source"], cand["station_id"])])
+        lons = np.array([float((meta.get(kk) or {}).get("longitude", np.nan)) for kk in
+                         zip(cand["source"], cand["station_id"])])
+        dist_km = _haversine_km(lat0, lon0, lats, lons)
+    if method == "similarity":
+        score = dist_attr
+    elif method == "proximity":
+        score = np.nan_to_num(dist_km, nan=1e9)
+    else:
+        score = np.sqrt(dist_attr ** 2 + (np.nan_to_num(dist_km, nan=1e9) / PROXIMITY_SCALE_KM) ** 2)
+    order = np.argsort(score)[: max(1, int(k))]
+    out = []
+    for i in order:
+        row = cand.iloc[i]
+        st = meta.get((row["source"], row["station_id"]), {})
+        deltas = {}
+        for f in used:
+            col = FEATURES[f][0]
+            v = row.get(col)
+            if v is not None and not (isinstance(v, float) and math.isnan(v)):
+                deltas[f] = {"station": round(float(v), 3), "target": round(float(tval[f]), 3)}
+        out.append({
+            "source": row["source"], "station_id": row["station_id"], "name": st.get("name"),
+            "latitude": st.get("latitude"), "longitude": st.get("longitude"),
+            "agency": SOURCES[row["source"]].agency if row["source"] in SOURCES else None,
+            "period_start": st.get("period_start"), "period_end": st.get("period_end"),
+            "score": round(float(score[i]), 4),
+            "similarity_distance": round(float(dist_attr[i]), 4) if used else None,
+            "distance_km": round(float(dist_km[i]), 1) if dist_km is not None and not math.isnan(dist_km[i]) else None,
+            "hybas_id": int(row["hybas_id"]), "up_area_km2": round(float(row["up_area"]), 1),
+            "features": deltas,
+        })
+    return {
+        "method": method, "features_used": used, "n_candidates": int(len(cand)), "k": len(out),
+        "target": {f: tval[f] for f in used}, "stations": out,
+        "license": LICENSE, "attribution": ATTRIBUTION,
+        "methods": [{
+            "name": "Similar gauged basins (physical similarity / spatial proximity)",
+            "text": "Gauged stations ranked by weighted Euclidean distance in standardised BasinATLAS catchment "
+                    "attribute space (area, relief, climate, land cover, soils, human pressure), by great-circle "
+                    "distance, or both; the donor-selection step of regionalisation.",
+            "citation": "Bloeschl, G., Sivapalan, M., Wagener, T., Viglione, A., Savenije, H. (eds.) (2013). Runoff "
+                        "Prediction in Ungauged Basins. Cambridge University Press; Oudin, L. et al. (2008). Spatial "
+                        "proximity, physical similarity, regression and ungaged catchments. Water Resour. Res. 44, "
+                        "W03413. Attributes: " + ATTRIBUTION,
+        }],
+    }
+
+
+def _target_values(target: dict[str, Any]) -> dict[str, float | None]:
+    """Feature values from a target dict (flat guide keys, or describe_catchment's nested attributes)."""
+    attrs = target.get("attributes") if isinstance(target.get("attributes"), dict) else target
+    out: dict[str, float | None] = {}
+    for f, (col, _how, _w) in FEATURES.items():
+        v = attrs.get(col)
+        if isinstance(v, dict):
+            v = v.get("value")
+        if v is None and col == "up_area":
+            v = (attrs.get("upstream_area_km2") if isinstance(attrs.get("upstream_area_km2"), (int, float)) else None)
+            if v is None and isinstance(target.get("sub_basin"), dict):
+                v = target["sub_basin"].get("up_area")
+        try:
+            out[f] = None if v is None else float(v)
+        except (TypeError, ValueError):
+            out[f] = None
+    return out
+
+
+def similar_for_point(
+    lat: float, lon: float, *, k: int = 10, method: str = "combined", **kw: Any
+) -> dict[str, Any]:
+    """Describe the catchment of a point (BasinATLAS) and rank the gauged basins most like it."""
+    from aquascope.archive.basins import describe_catchment
+
+    desc = describe_catchment(lat, lon, upstream=False)
+    if desc.get("error"):
+        return {"latitude": lat, "longitude": lon, "error": desc["error"]}
+    target = {"latitude": lat, "longitude": lon, "attributes": desc.get("attributes", {}),
+              "sub_basin": desc.get("sub_basin")}
+    res = similar_basins(target, k=k, method=method, **kw)
+    res.update({"latitude": lat, "longitude": lon, "sub_basin": desc.get("sub_basin"),
+                "run_at": datetime.now(timezone.utc).isoformat(timespec="seconds")})
+    return res
+
+
+def similar_for_station(
+    source: str, station_id: str, *, k: int = 10, method: str = "combined", **kw: Any
+) -> dict[str, Any]:
+    """Rank the gauged basins most like a station's own catchment (the station itself excluded)."""
+    from aquascope.archive.catalog import load_stations
+
+    tab = kw.pop("table", None)
+    tab = tab if tab is not None else load_station_catchments()
+    row = tab[(tab["source"] == source) & (tab["station_id"] == station_id)]
+    if row.empty:
+        return {"source": source, "station_id": station_id,
+                "error": "station has no catchment row (not on land in BasinATLAS, or not in the catalog)"}
+    cat = kw.pop("catalog", None)
+    cat = cat if cat is not None else load_stations()
+    st = next((r for r in cat if r["source"] == source and r["station_id"] == station_id), {})
+    target = {**row.iloc[0].to_dict(), "latitude": st.get("latitude"), "longitude": st.get("longitude")}
+    res = similar_basins(target, k=k, method=method, exclude=(source, station_id), table=tab, catalog=cat, **kw)
+    res.update({"source": source, "station_id": station_id})
+    return res
+
+
+__all__ = ["FEATURES", "TABLE_NAME", "assign_station_catchments", "load_station_catchments", "similar_basins",
+           "similar_for_point", "similar_for_station", "table_url"]

--- a/aquascope/cli.py
+++ b/aquascope/cli.py
@@ -693,6 +693,35 @@ def cmd_basins(args: argparse.Namespace) -> None:
             print(f"  {name:<32} {size / 1e6:8.1f} MB")
         print(f"\n  {report.n_basins:,} sub-basins in {report.seconds:.0f}s -> {args.out}/basins")
         return
+    if args.basins_cmd == "assign":
+        from aquascope.archive.catalog import load_stations
+        from aquascope.archive.similar import assign_station_catchments
+
+        catalog = load_stations()
+        table = assign_station_catchments(catalog, args.fgb, args.attributes, args.out)
+        print(f"  {len(table):,} of {len(catalog):,} stations assigned to a sub-basin -> {args.out}")
+        return
+    if args.basins_cmd == "similar":
+        from aquascope.archive.similar import similar_for_point, similar_for_station
+
+        if args.station:
+            src, _, sid = args.station.partition("/")
+            res = similar_for_station(src, sid, k=args.k, method=args.method, sources=args.source or None)
+        else:
+            res = similar_for_point(args.lat, args.lon, k=args.k, method=args.method, sources=args.source or None)
+        if args.json:
+            print(json.dumps(res, indent=2, ensure_ascii=False, default=str))
+            return
+        if res.get("error"):
+            print(f"  {res['error']}")
+            sys.exit(1)
+        print(f"  {res['k']} of {res['n_candidates']} gauged basins, method {res['method']}, "
+              f"features {', '.join(res['features_used'])}")
+        for i, st in enumerate(res["stations"], 1):
+            dist = f"{st['distance_km']:,.0f} km" if st.get("distance_km") is not None else ""
+            print(f"  {i:>2}. {st['source']:<20} {st['station_id']:<40} {(st.get('name') or '')[:38]:<38} "
+                  f"area {st['up_area_km2']:>9,.0f} km2  score {st['score']:.3f} {dist}")
+        return
     if args.basins_cmd == "upstream":
         topo = basins.Topology(basins.load_topology())
         ids = topo.upstream_ids(int(args.hybas_id), limit=args.limit)
@@ -1501,6 +1530,18 @@ def main() -> None:
     p_bat.add_argument("lon", type=float)
     p_bat.add_argument("--local", action="store_true", help="Only the level-12 sub-basin containing the point")
     p_bat.add_argument("--json", action="store_true")
+    p_bsim = basins_sub.add_parser("similar", help="Gauged basins whose catchments most resemble a point's or a station's")
+    p_bsim.add_argument("lat", type=float, nargs="?", default=None)
+    p_bsim.add_argument("lon", type=float, nargs="?", default=None)
+    p_bsim.add_argument("--station", default=None, metavar="SOURCE/ID", help="Use a station's own catchment as the target")
+    p_bsim.add_argument("--k", type=int, default=10)
+    p_bsim.add_argument("--method", choices=["similarity", "proximity", "combined"], default="combined")
+    p_bsim.add_argument("--source", action="append", help="Restrict donors to these sources (repeatable)")
+    p_bsim.add_argument("--json", action="store_true")
+    p_bassign = basins_sub.add_parser("assign", help="Build basins/station_catchments.parquet (harvest workflow step)")
+    p_bassign.add_argument("--fgb", required=True, help="Local lev12.fgb")
+    p_bassign.add_argument("--attributes", required=True, help="Local lev12_attributes.parquet")
+    p_bassign.add_argument("--out", default="archive/basins/station_catchments.parquet")
     p_bup = basins_sub.add_parser("upstream", help="List the level-12 sub-basins upstream of a HYBAS_ID")
     p_bup.add_argument("hybas_id", type=int)
     p_bup.add_argument("--limit", type=int, default=200_000)

--- a/aquascope/mcp_server.py
+++ b/aquascope/mcp_server.py
@@ -266,6 +266,36 @@ def describe_catchment(lat: float, lon: float, upstream: bool = True) -> dict[st
         return {"error": f"catchment lookup failed: {type(exc).__name__}: {exc}"}
 
 
+def similar_basins(
+    lat: float | None = None,
+    lon: float | None = None,
+    source: str | None = None,
+    station_id: str | None = None,
+    k: int = 10,
+    method: str = "combined",
+    sources: list[str] | None = None,
+) -> dict[str, Any]:
+    """The gauged basins in the Archive whose catchments most resemble a point's (or a station's) catchment:
+    donor selection for prediction in ungauged basins. Give lat/lon for a point, or source + station_id for a
+    station (itself excluded). method: 'similarity' (standardised BasinATLAS attribute space: area, relief,
+    climate, land cover, soils, human pressure), 'proximity' (distance on the ground) or 'combined'. Returns
+    up to k stations with ids you can pass to analyze_station, the per-feature deltas, and the citation.
+    """
+    from aquascope.archive.similar import similar_for_point, similar_for_station
+
+    k = max(1, min(int(k or 10), 50))
+    try:
+        if source and station_id:
+            return similar_for_station(source, station_id, k=k, method=method, sources=sources)
+        if lat is None or lon is None:
+            return {"error": "give lat and lon, or source and station_id"}
+        return similar_for_point(float(lat), float(lon), k=k, method=method, sources=sources)
+    except ImportError as exc:
+        return {"error": f"{exc}"}
+    except Exception as exc:  # noqa: BLE001 - the model gets to see it
+        return {"error": f"similar basins lookup failed: {type(exc).__name__}: {exc}"}
+
+
 def _default_years_note() -> str:
     today = date.today()
     return f"Records are requested back to {(today - timedelta(days=int(40 * 365.25))).isoformat()} by default."
@@ -284,6 +314,7 @@ def build_server():
     server.tool()(flood_frequency)
     server.tool()(describe_methods)
     server.tool()(describe_catchment)
+    server.tool()(similar_basins)
     server.tool()(archive_health)
 
     @server.resource("aquascope://sources")

--- a/docs/archive.md
+++ b/docs/archive.md
@@ -125,7 +125,30 @@ topo = basins.Topology(basins.load_topology())     # upstream_ids / downstream_i
 
 The MCP tool `describe_catchment(lat, lon)` and the analyst expose the same
 function, and the Explorer shows the card and highlights the upstream
-sub-basins for any station or clicked point. Built by
+sub-basins for any station or clicked point.
+
+### Similar gauged basins (prediction in ungauged basins, the practical half)
+
+The weekly harvest also spatially joins every catalog station to its
+sub-basin and publishes `basins/station_catchments.parquet` (station, sub-basin,
+upstream area and the catchment attributes above). On that table,
+
+```bash
+aquascope basins similar 25.04 121.56 --k 8            # gauges whose catchments most resemble this point's
+aquascope basins similar --station usgs/USGS-01646500  # ... or a station's own catchment (itself excluded)
+aquascope basins similar 48.85 2.35 --method proximity --source hubeau_hydrometrie
+```
+
+ranks the gauged stations by weighted Euclidean distance in standardised
+BasinATLAS attribute space (log area, elevation, slope, precipitation,
+aridity, temperature, snow, forest, cropland, urban, clay, sand, population
+density, regulation), by great-circle distance, or both (`combined`, the
+default), and prints the per-feature deltas. That is the donor-selection
+step of regionalisation (Bloeschl et al. 2013; Oudin et al. 2008); the MCP
+tool `similar_basins` and the analyst use it ("find gauges like this
+ungauged site, then analyse the best donors"), and the Explorer lists them
+under the catchment card. `aquascope.archive.similar` is the module; #53
+tracks the regression / leave-one-out half. Built by
 `.github/workflows/basins.yml` (`aquascope basins build` plus `ogr2ogr` and
 `tippecanoe`); it downloads BasinATLAS from figshare, so it runs on demand,
 not weekly. Why BasinATLAS and not HydroBASINS: the HydroSHEDS core licence

--- a/docs/explorer.md
+++ b/docs/explorer.md
@@ -52,6 +52,12 @@ forest / cropland / urban / glacier / lake / karst extent, soil texture,
 population density, regulation by dams, human footprint. Citation in the
 methods panel.
 
+Under the catchment card, **Similar gauged basins** lists the gauges whose
+catchments look most like the point's or the station's (standardised
+BasinATLAS attributes combined with distance, from
+`basins/station_catchments.parquet`), the donor list one needs at an
+ungauged site; click one to open it.
+
 Why not HydroBASINS itself: the HydroSHEDS core licence forbids distributing
 the data "as a stand-alone product" and requires an end-user licence, so it
 cannot be hosted on the free-tier archive; HydroATLAS is CC BY 4.0, which is

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -44,6 +44,7 @@ If `aquascope` is not on the client's PATH, use the interpreter explicitly:
 | `flood_frequency(source, station_id, years, bootstrap_ci)` | just the return-period table and its methods | yes |
 | `describe_methods()` | what each analysis computes and the reference to cite | no |
 | `describe_catchment(lat, lon, upstream=True)` | the BasinATLAS (HydroATLAS, CC BY 4.0) catchment of a point: sub-basin, upstream area, elevation, climate, land cover, soils, population, dams; `upstream=False` for the local sub-basin | no (Archive `basins/` files) |
+| `similar_basins(lat, lon | source, station_id, k, method, sources)` | the gauged basins whose catchments most resemble a point's or a station's (BasinATLAS attribute space and/or distance): donor selection for ungauged sites | no (Archive `basins/station_catchments.parquet`) |
 | `archive_health()` | per-source status of the last catalog harvest | no |
 
 Resources: `aquascope://sources` and `aquascope://methods` (JSON).

--- a/explorer/app.js
+++ b/explorer/app.js
@@ -402,6 +402,7 @@ function renderPoint(res) {
   $("pt-sec-methods").hidden = ms.length === 0;
   if (!$("pt-catchment").hidden) addMethodOnce("pt-methods", "pt-sec-methods", NLDI_METHOD);
   if (!$("pt-basin").hidden) addMethodOnce("pt-methods", "pt-sec-methods", BASIN_METHOD);
+  if (!$("pt-similar").hidden) addMethodOnce("pt-methods", "pt-sec-methods", SIMILAR_METHOD);
 }
 
 // ── catchments (USGS NLDI, public domain) ───────────────────────────────────
@@ -451,7 +452,7 @@ function clearCatchment() {
   catchmentReq++;
   basinReq++;
   if (state.mapOk && map.getSource("catchment")) map.getSource("catchment").setData(EMPTY_FC);
-  for (const id of ["st-catchment", "pt-catchment", "st-basin", "pt-basin"]) { const el = $(id); if (el) { el.textContent = ""; el.hidden = true; } }
+  for (const id of ["st-catchment", "pt-catchment", "st-basin", "pt-basin", "st-similar", "pt-similar"]) { const el = $(id); if (el) { el.textContent = ""; el.hidden = true; } }
   highlightBasins([]);
 }
 
@@ -678,8 +679,102 @@ async function requestBasin(lat, lon, target) {
       (kv ? `<div class="kv">${kv}</div>` : `<div class="muted">attributes unavailable</div>`) +
       `<div class="basin-foot muted">HydroATLAS v1.0, CC BY 4.0 (Linke et al. 2019). Upstream sub-basins highlighted on the map at zoom 4+.</div>`;
     addMethodOnce(target === "st" ? "methods" : "pt-methods", target === "st" ? "sec-methods" : "pt-sec-methods", BASIN_METHOD);
+    if (attrs) requestSimilar({ lat, lon, upArea, attrs, target, my });
   } catch (err) {
     console.info("basin lookup unavailable:", err && err.message);
+  }
+}
+
+// ── similar gauged basins (PUB-lite) ────────────────────────────────────────
+// The harvest publishes basins/station_catchments.parquet: every catalog
+// station with the BasinATLAS attributes of its catchment. Standardise the
+// feature set over that table, measure the weighted distance to the target's
+// catchment (plus distance on the ground: "combined"), list the closest gauges
+// that measure discharge. Same features and weights as aquascope.archive.similar.
+
+const SIMILAR_METHOD = {
+  name: "Similar gauged basins (physical similarity / spatial proximity)",
+  text: "Gauged stations ranked by weighted Euclidean distance in standardised BasinATLAS catchment attribute space (area, relief, climate, land cover, soils, human pressure) combined with great-circle distance (in units of 500 km); the donor-selection step of regionalisation.",
+  citation: "Blöschl, G., Sivapalan, M., Wagener, T., Viglione, A., Savenije, H. (eds.) (2013). Runoff Prediction in Ungauged Basins. Cambridge University Press; Oudin, L. et al. (2008). Spatial proximity, physical similarity, regression and ungaged catchments. Water Resour. Res. 44, W03413.",
+};
+// [table column, basin-card key, transform, weight]
+const SIMILAR_FEATURES = [
+  ["up_area", "__area", "log10", 1.5], ["elevation_m", "elev", null, 1.0], ["slope_deg", "slope", "log1p", 1.0],
+  ["precipitation_mm_yr", "pre", null, 1.5], ["aridity_index", "ari", "log1p", 1.5], ["temperature_c", "tmp", null, 1.0],
+  ["snow_cover_pct", "snw", null, 1.0], ["forest_pct", "for", null, 0.7], ["cropland_pct", "crp", null, 0.7],
+  ["urban_pct", "urb", "log1p", 0.7], ["clay_pct", "cly", null, 0.5], ["sand_pct", "snd", null, 0.5],
+  ["population_density", "ppd", "log1p", 0.5], ["degree_of_regulation_pct", "dor", "log1p", 0.7],
+];
+let similarTable = null;  // { rows: [...], stats: {col: {mu, sd}} }
+const tf = (v, how) => (how === "log10" ? Math.log10(Math.max(v, 1e-3)) : how === "log1p" ? Math.log1p(Math.max(v, 0)) : v);
+
+async function ensureSimilarTable() {
+  if (similarTable) return similarTable;
+  const { conn } = await duck();
+  const res = await conn.query(`SELECT * FROM read_parquet('${basinsUrl("station_catchments.parquet")}')`);
+  const rows = res.toArray().map((r) => r.toJSON());
+  const stats = {};
+  for (const [col, , how] of SIMILAR_FEATURES) {
+    const xs = rows.map((r) => (r[col] === null || r[col] === undefined ? NaN : tf(Number(r[col]), how))).filter((x) => Number.isFinite(x));
+    const mu = xs.reduce((a, b) => a + b, 0) / Math.max(xs.length, 1);
+    const sd = Math.sqrt(xs.reduce((a, b) => a + (b - mu) ** 2, 0) / Math.max(xs.length, 1)) || 1;
+    stats[col] = { mu, sd };
+  }
+  similarTable = { rows, stats };
+  return similarTable;
+}
+
+async function requestSimilar({ lat, lon, upArea, attrs, target, my }) {
+  const el = $(`${target}-similar`);
+  if (!el) return;
+  try {
+    const { rows, stats } = await ensureSimilarTable();
+    if (my !== basinReq) return;
+    const tvals = {};
+    for (const [col, key] of SIMILAR_FEATURES) {
+      const v = key === "__area" ? upArea : (attrs[key] && attrs[key].value);
+      if (v !== undefined && v !== null && Number.isFinite(Number(v))) tvals[col] = Number(v);
+    }
+    const used = SIMILAR_FEATURES.filter(([col]) => tvals[col] !== undefined);
+    if (!used.length) return;
+    const wsum = used.reduce((a, [, , , w]) => a + w * w, 0);
+    const selfKey = target === "st" && state.selected ? `${state.selected.source}/${state.selected.station_id}` : null;
+    const scored = [];
+    for (const r of rows) {
+      const key = `${r.source}/${r.station_id}`;
+      if (key === selfKey) continue;
+      const st = state.byKey.get(key);
+      if (!st || !(st.variables || []).includes("discharge")) continue;
+      let acc = 0;
+      for (const [col, , how, w] of used) {
+        const { mu, sd } = stats[col];
+        const zt = (tf(tvals[col], how) - mu) / sd;
+        const v = r[col];
+        const z = v === null || v === undefined ? NaN : (tf(Number(v), how) - mu) / sd;
+        const d = Number.isFinite(z) ? Math.abs(z - zt) : 3.0;
+        acc += (d * w) ** 2;
+      }
+      const dAttr = Math.sqrt(acc / wsum);
+      const dKm = haversineKm(lat, lon, st.lat, st.lon);
+      scored.push({ st, dAttr, dKm, score: Math.sqrt(dAttr ** 2 + (dKm / 500) ** 2), area: Number(r.up_area) });
+    }
+    scored.sort((a, b) => a.score - b.score);
+    const top = scored.slice(0, 8);
+    if (!top.length) return;
+    el.innerHTML = `<h3>Similar gauged basins <span class="muted">catchment attributes + distance</span></h3><ul class="nearest similar"></ul>` +
+      `<div class="basin-foot muted">Donor candidates for an ungauged site: ${scored.length.toLocaleString()} gauged catchments compared on ${used.length} standardised BasinATLAS attributes and distance. Click one to open it.</div>`;
+    const ul = el.querySelector("ul");
+    for (const s of top) {
+      const li = document.createElement("li");
+      li.dataset.key = `${s.st.source}/${s.st.station_id}`;
+      li.innerHTML = `<i style="background:${(SOURCE_STYLE[s.st.source] || {}).color || FALLBACK_COLOR}"></i>${escapeHtml(s.st.name || s.st.station_id)} <span class="muted">${escapeHtml((SOURCE_STYLE[s.st.source] || {}).label || s.st.source)} · ${fmt(s.area, 0)} km²</span><span class="dist">${s.dKm < 10 ? s.dKm.toFixed(1) : Math.round(s.dKm).toLocaleString()} km · Δ${s.dAttr.toFixed(2)}</span>`;
+      li.addEventListener("click", () => selectStation(li.dataset.key, { fly: true }));
+      ul.appendChild(li);
+    }
+    el.hidden = false;
+    addMethodOnce(target === "st" ? "methods" : "pt-methods", target === "st" ? "sec-methods" : "pt-sec-methods", SIMILAR_METHOD);
+  } catch (err) {
+    console.info("similar basins unavailable:", err && err.message);
   }
 }
 
@@ -811,6 +906,7 @@ function renderMethods(res) {
   $("sec-methods").hidden = ms.length === 0 && !res.attribution;
   if (!$("st-catchment").hidden) addMethodOnce("methods", "sec-methods", NLDI_METHOD);
   if (!$("st-basin").hidden) addMethodOnce("methods", "sec-methods", BASIN_METHOD);
+  if (!$("st-similar").hidden) addMethodOnce("methods", "sec-methods", SIMILAR_METHOD);
 }
 
 function renderFfaTable(ffa, unit) {

--- a/explorer/index.html
+++ b/explorer/index.html
@@ -88,6 +88,7 @@
             <li><strong>Taiwan CWA</strong>: daily rainfall, last 10 years.</li>
             <li>Click anywhere that is not a gauge: ERA5 rainfall, temperature, FAO-56 ET0, aridity, and GloFAS modelled discharge for that spot, plus the nearest gauges.</li>
             <li><strong>Catchments</strong>: for USGS gauges and any point in the US, the upstream drainage basin is drawn on the map (USGS NLDI over NHDPlus V2, public domain), with its area. Everywhere on land, the BasinATLAS sub-basin (HydroATLAS, CC BY 4.0) gives the upstream area, climate, land cover, soils and population of the catchment, and the upstream sub-basins light up on the map (toggle "Basins" in the legend).</li>
+            <li><strong>Similar gauged basins</strong>: for any point or station, the gauges whose catchments look most like it (attributes + distance), the donor list for an ungauged site.</li>
             <li><strong>Ask ✨</strong> (top right): a plain-language question, answered from real gauges with a Data and Methods section. Bring your own key (Groq and Hugging Face have free tiers).</li>
             <li>First analysis loads Python in your browser (about 15 MB, once). After that it is quick.</li>
           </ul>
@@ -101,6 +102,7 @@
           <div class="st-meta"><span id="pt-coords"></span> · ERA5 climate + GloFAS modelled discharge, last 10 years</div>
           <div id="pt-catchment" class="catchment" hidden></div>
           <div id="pt-basin" class="basin" hidden></div>
+          <section id="pt-similar" hidden></section>
           <div class="st-actions">
             <button id="btn-share-pt" class="btn" title="Copy a link to this point">Copy link</button>
           </div>
@@ -136,6 +138,7 @@
           </div>
           <div id="st-catchment" class="catchment" hidden></div>
           <div id="st-basin" class="basin" hidden></div>
+          <section id="st-similar" hidden></section>
           <div class="st-actions">
             <a id="st-agency" href="#" target="_blank" rel="noopener" class="btn">Agency page ↗</a>
             <button id="btn-share" class="btn" title="Copy a link to this station">Copy link</button>

--- a/explorer/style.css
+++ b/explorer/style.css
@@ -56,6 +56,8 @@ main { display: flex; flex: 1; min-height: 0; }
 .basin .kv b { font-weight: 600; white-space: nowrap; }
 .basin .basin-foot { margin-top: .3rem; font-size: .72rem; }
 .chip.basins-toggle i { border-radius: 2px; }
+.nearest.similar li { cursor: pointer; }
+.nearest.similar .dist { white-space: nowrap; }
 .btn { font: inherit; font-size: .8rem; padding: .35rem .65rem; border-radius: 8px; border: 1px solid var(--line); background: #fff; color: var(--ink); cursor: pointer; text-decoration: none; }
 .btn:hover:not(:disabled) { background: #f4f7fb; }
 .btn:disabled { opacity: .5; cursor: default; }

--- a/tests/test_ai_engine/test_analyst.py
+++ b/tests/test_ai_engine/test_analyst.py
@@ -99,6 +99,6 @@ def test_resolve_llm_env_and_errors(monkeypatch):
 def test_tool_specs_cover_the_mcp_surface():
     names = {s.name for s in analyst._tool_specs()}
     assert names == {"list_sources", "find_stations", "analyze_station", "flood_frequency", "get_timeseries",
-                     "anywhere", "describe_catchment", "describe_methods"}
+                     "anywhere", "describe_catchment", "similar_basins", "describe_methods"}
     tools = analyst._openai_tools(analyst._tool_specs())
     assert all(t["type"] == "function" and "parameters" in t["function"] for t in tools)

--- a/tests/test_archive/test_similar.py
+++ b/tests/test_archive/test_similar.py
@@ -1,0 +1,151 @@
+"""Nearest similar gauged basins over the station -> catchment table (#53, the practical half)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from aquascope.archive import similar
+from aquascope.archive.basins import row_catchment_attributes
+
+
+def _table():
+    rows = []
+    rng = np.random.default_rng(0)
+    for i in range(60):
+        rows.append({
+            "source": "usgs" if i % 2 else "uk_ea", "station_id": f"S{i}", "hybas_id": 100 + i,
+            "up_area": float(10 ** rng.uniform(1.5, 4.5)), "sub_area": 100.0,
+            "elevation_m": float(rng.uniform(20, 2500)), "slope_deg": float(rng.uniform(0.5, 25)),
+            "precipitation_mm_yr": float(rng.uniform(300, 2500)), "aridity_index": float(rng.uniform(0.2, 3)),
+            "temperature_c": float(rng.uniform(-2, 24)), "snow_cover_pct": float(rng.uniform(0, 60)),
+            "forest_pct": float(rng.uniform(0, 90)), "cropland_pct": float(rng.uniform(0, 80)),
+            "urban_pct": float(rng.uniform(0, 30)), "clay_pct": float(rng.uniform(10, 40)),
+            "sand_pct": float(rng.uniform(20, 70)), "population_density": float(rng.uniform(0, 500)),
+            "degree_of_regulation_pct": float(rng.uniform(0, 100)),
+        })
+    # a near-twin of the target and a far-away twin
+    twin = dict(rows[0], station_id="TWIN", hybas_id=999, up_area=1000.0, elevation_m=300.0, slope_deg=3.0,
+                precipitation_mm_yr=900.0, aridity_index=0.9, temperature_c=10.0, snow_cover_pct=5.0,
+                forest_pct=30.0, cropland_pct=40.0, urban_pct=3.0, clay_pct=22.0, sand_pct=40.0,
+                population_density=80.0, degree_of_regulation_pct=5.0)
+    rows.append(twin)
+    return pd.DataFrame(rows)
+
+
+def _catalog(table):
+    rng = np.random.default_rng(1)
+    cat = []
+    for r in table.to_dict("records"):
+        lat, lon = float(rng.uniform(35, 60)), float(rng.uniform(-120, 10))
+        if r["station_id"] == "TWIN":
+            lat, lon = 51.5, -0.1
+        cat.append({"source": r["source"], "station_id": r["station_id"], "name": f"Station {r['station_id']}",
+                    "latitude": lat, "longitude": lon,
+                    "variables": ["discharge"] if r["station_id"] != "S1" else ["water_level"],
+                    "period_start": "1980-01-01", "period_end": None})
+    return cat
+
+
+TARGET = {"latitude": 51.4, "longitude": -0.3, "up_area": 1050.0, "elevation_m": 310.0, "slope_deg": 3.2,
+          "precipitation_mm_yr": 880.0, "aridity_index": 0.95, "temperature_c": 10.3, "snow_cover_pct": 4.0,
+          "forest_pct": 28.0, "cropland_pct": 42.0, "urban_pct": 4.0, "clay_pct": 21.0, "sand_pct": 41.0,
+          "population_density": 90.0, "degree_of_regulation_pct": 4.0}
+
+
+def test_similarity_ranks_the_twin_first_and_explains_it():
+    tab = _table()
+    cat = _catalog(tab)
+    res = similar.similar_basins(TARGET, k=5, method="similarity", table=tab, catalog=cat)
+    assert res["stations"][0]["station_id"] == "TWIN"
+    assert res["k"] == 5 and res["n_candidates"] == 60  # S1 has no discharge and is excluded
+    top = res["stations"][0]
+    assert top["features"]["precipitation"] == {"station": 900.0, "target": 880.0}
+    assert top["similarity_distance"] < res["stations"][1]["similarity_distance"]
+    assert set(res["features_used"]) == set(similar.FEATURES)
+    assert res["methods"][0]["citation"].startswith("Bloeschl")
+
+
+def test_proximity_and_combined_use_the_ground_distance():
+    tab = _table()
+    cat = _catalog(tab)
+    prox = similar.similar_basins(TARGET, k=3, method="proximity", table=tab, catalog=cat)
+    assert prox["stations"][0]["station_id"] == "TWIN" and prox["stations"][0]["distance_km"] < 20
+    comb = similar.similar_basins(TARGET, k=3, method="combined", table=tab, catalog=cat)
+    assert comb["stations"][0]["station_id"] == "TWIN" and comb["stations"][0]["distance_km"] is not None
+    with pytest.raises(ValueError):
+        similar.similar_basins(TARGET, method="magic", table=tab, catalog=cat)
+
+
+def test_filters_sources_exclusion_and_missing_values():
+    tab = _table()
+    cat = _catalog(tab)
+    only_usgs = similar.similar_basins(TARGET, k=4, sources=["usgs"], table=tab, catalog=cat)
+    assert all(s["source"] == "usgs" for s in only_usgs["stations"])
+    excl = similar.similar_basins(TARGET, k=3, exclude=("uk_ea", "TWIN"), table=tab, catalog=cat)
+    assert all(s["station_id"] != "TWIN" for s in excl["stations"])
+    # a station with a missing attribute is penalised, not dropped or crashed on
+    tab2 = tab.copy()
+    tab2.loc[tab2["station_id"] == "TWIN", "forest_pct"] = np.nan
+    res = similar.similar_basins(TARGET, k=2, table=tab2, catalog=cat)
+    assert res["stations"][0]["station_id"] == "TWIN" and "forest" not in res["stations"][0]["features"]
+    # a target missing a feature just uses the rest
+    t2 = {k: v for k, v in TARGET.items() if k != "snow_cover_pct"}
+    res = similar.similar_basins(t2, k=1, table=tab, catalog=cat)
+    assert "snow" not in res["features_used"] and res["stations"][0]["station_id"] == "TWIN"
+    # nothing left after filters
+    assert similar.similar_basins(TARGET, sources=["nope"], table=tab, catalog=cat)["stations"] == []
+
+
+def test_target_from_describe_catchment_shape():
+    desc_like = {"latitude": 51.4, "longitude": -0.3, "sub_basin": {"hybas_id": 1, "up_area": 1050.0},
+                 "attributes": {"upstream_area_km2": 1050.0, "elevation_m": {"value": 310.0, "unit": "m"},
+                                "precipitation_mm_yr": {"value": 880.0}, "aridity_index": {"value": 0.95}}}
+    vals = similar._target_values(desc_like)
+    assert vals["log_area"] == 1050.0 and vals["elevation"] == 310.0 and vals["snow"] is None
+
+
+def test_similar_for_station_excludes_itself(monkeypatch):
+    tab = _table()
+    cat = _catalog(tab)
+    res = similar.similar_for_station("uk_ea", "TWIN", k=3, method="similarity", table=tab, catalog=cat)
+    assert res["source"] == "uk_ea" and all(s["station_id"] != "TWIN" for s in res["stations"])
+    assert "error" in similar.similar_for_station("usgs", "nope", table=tab, catalog=cat)
+
+
+def test_row_catchment_attributes_takes_upstream_fields():
+    row = {"ele_mt_sav": 100, "ele_mt_uav": 400, "pre_mm_syr": 700, "pre_mm_uyr": 750, "run_mm_syr": 20,
+           "slp_dg_uav": 35, "pop_ct_usu": 12.5, "dor_pc_pva": 120, "soc_th_uav": -9999, "soc_th_sav": 30}
+    out = row_catchment_attributes(row)
+    assert out["elevation_m"] == 400 and out["precipitation_mm_yr"] == 750 and out["runoff_mm_yr"] == 20
+    assert out["slope_deg"] == 3.5 and out["population"] == 12500 and out["degree_of_regulation_pct"] == 12.0
+    assert out["soil_organic_carbon_t_ha"] == 30  # NODATA upstream falls back to the local value
+
+
+def test_assign_station_catchments_on_a_synthetic_layer(tmp_path):
+    pytest.importorskip("pyogrio")
+    gpd = pytest.importorskip("geopandas")
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    from shapely.geometry import box
+
+    layer = gpd.GeoDataFrame(
+        {"HYBAS_ID": [1, 2], "UP_AREA": [50.0, 900.0], "SUB_AREA": [50.0, 100.0], "NEXT_DOWN": [2, 0]},
+        geometry=[box(0, 0, 1, 1), box(1, 0, 2, 1)], crs="EPSG:4326",
+    )
+    fgb = tmp_path / "lev12.fgb"
+    layer.to_file(fgb, driver="FlatGeobuf")
+    attrs = pd.DataFrame([{"hybas_id": 1, "ele_mt_uav": 500, "pre_mm_uyr": 1000, "for_pc_use": 40},
+                          {"hybas_id": 2, "ele_mt_uav": 200, "pre_mm_uyr": 800, "for_pc_use": 10}])
+    ap = tmp_path / "attrs.parquet"
+    pq.write_table(pa.Table.from_pandas(attrs, preserve_index=False), ap)
+    catalog = [{"source": "usgs", "station_id": "A", "latitude": 0.5, "longitude": 0.5},
+               {"source": "usgs", "station_id": "B", "latitude": 0.5, "longitude": 1.5},
+               {"source": "usgs", "station_id": "SEA", "latitude": 5.0, "longitude": 5.0}]
+    out = similar.assign_station_catchments(catalog, fgb, ap, tmp_path / "station_catchments.parquet")
+    assert sorted(out["station_id"]) == ["A", "B"]
+    a = out[out["station_id"] == "A"].iloc[0]
+    assert a["hybas_id"] == 1 and a["up_area"] == 50.0 and a["elevation_m"] == 500 and a["forest_pct"] == 40
+    back = pd.read_parquet(tmp_path / "station_catchments.parquet")
+    assert len(back) == 2 and "precipitation_mm_yr" in back.columns

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -110,7 +110,7 @@ def test_server_registers_tools_and_calls_through_sdk():
     tools = asyncio.run(server.list_tools())
     names = {t.name for t in tools}
     assert names >= {"list_sources", "find_stations", "get_timeseries", "analyze_station", "flood_frequency",
-                     "describe_methods", "describe_catchment", "archive_health"}
+                     "describe_methods", "describe_catchment", "similar_basins", "archive_health"}
     with patch("aquascope.archive.catalog.load_stations", return_value=CATALOG):
         res = asyncio.run(server.call_tool("find_stations", {"query": "potomac"}))
     payload = getattr(res, "structured_content", None) or getattr(res, "structuredContent", None)
@@ -140,3 +140,15 @@ def test_describe_catchment_tool_wraps_basins(monkeypatch):
 
     monkeypatch.setattr("aquascope.archive.basins.describe_catchment", boom)
     assert "no basins yet" in m.describe_catchment(0, 0)["error"]
+
+
+def test_similar_basins_tool_dispatches(monkeypatch):
+    calls = []
+    monkeypatch.setattr("aquascope.archive.similar.similar_for_point",
+                        lambda lat, lon, **kw: calls.append(("point", lat, lon, kw)) or {"stations": [], "k": 0})
+    monkeypatch.setattr("aquascope.archive.similar.similar_for_station",
+                        lambda s, i, **kw: calls.append(("station", s, i, kw)) or {"stations": [], "k": 0})
+    assert m.similar_basins(lat=1.0, lon=2.0, k=99)["k"] == 0 and calls[-1][0] == "point" and calls[-1][3]["k"] == 50
+    assert m.similar_basins(source="usgs", station_id="USGS-1", method="similarity")["k"] == 0
+    assert calls[-1][:3] == ("station", "usgs", "USGS-1")
+    assert "give lat and lon" in m.similar_basins()["error"]


### PR DESCRIPTION
The practical half of #53 (prediction in ungauged basins), built on BasinATLAS (#213) and the catalog.

**What changes**

- `harvest.yml` gains a step that spatially joins every catalog station to its level-12 sub-basin (tiled 20° reads of the published `lev12.fgb`, so the million polygons never sit in memory at once) and publishes `basins/station_catchments.parquet`: station, sub-basin, upstream area and the catchment's BasinATLAS attributes (upstream fields, real units). `continue-on-error`, and it skips itself while `basins/` is not published.
- `aquascope.archive.similar.similar_basins()`: gauged discharge stations ranked by weighted Euclidean distance in standardised attribute space (log area, elevation, slope, precipitation, aridity, temperature, snow, forest, cropland, urban, clay, sand, population density, regulation), by great-circle distance, or both (`combined`, default: attribute distance plus km/500); missing values are penalised rather than ignored; per-feature deltas and the citation (Bloeschl et al. 2013, Oudin et al. 2008) come back with the ranking. `similar_for_point` (via `describe_catchment`) and `similar_for_station` (itself excluded).
- `aquascope basins similar LAT LON | --station SOURCE/ID [--k] [--method] [--source]`, `aquascope basins assign` (the workflow step), MCP tool `similar_basins`, analyst spec plus a system-prompt line ("for an ungauged place, find donors, then analyse the best ones"), Explorer: a "Similar gauged basins" list under the catchment card for any point or station (same features and weights, computed in the tab from the parquet through DuckDB-WASM), click to open.
- `basins.row_catchment_attributes()` and `load_stations(path=...)`; docs (archive, mcp, explorer), README, CHANGELOG.

**Checked**: 7 new tests (ranking finds a planted twin, proximity/combined use the ground distance, filters and exclusion, missing values, describe_catchment-shaped targets, row attributes, and the spatial join on a synthetic FlatGeobuf); full suite green; the Explorer list verified in headless Chromium against a synthetic table served locally. The real table appears after the next harvest run (I will dispatch one once this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB
