### PR TITLE
Lazy sklearn ensembles in aquascope.models (bare-install GR4J and gym); v0.12.0 DOI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to AquaScope are documented here.
 ### Added
 
 ### Changed
+- `CITATION.cff` lists the v0.12.0 version DOI `10.5281/zenodo.21995649` (concept DOI unchanged).
 
 ### Fixed
+- `aquascope.models` no longer imports the scikit-learn ensembles at package import time (PEP 562 lazy attributes), so `from aquascope.models.rainfall_runoff import GR4J`, `aquascope.gym` and `pip install "aquascope[gym]"` work on a bare install; the ensembles still import on first use with the `ml` extra.
 
 ## [0.12.0] - 2026-08-18
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,6 +37,9 @@ identifiers:
     value: 10.5281/zenodo.21903143
     description: Concept DOI, resolves to the latest archived version
   - type: doi
+    value: 10.5281/zenodo.21995649
+    description: Version DOI for v0.12.0
+  - type: doi
     value: 10.5281/zenodo.21989509
     description: Version DOI for v0.11.0
   - type: url

--- a/aquascope/models/__init__.py
+++ b/aquascope/models/__init__.py
@@ -11,13 +11,6 @@ from aquascope.models.bayesian import (
     effective_sample_size,
     gelman_rubin,
 )
-from aquascope.models.ensemble import (
-    AdaptiveEnsemble,
-    EnsembleResult,
-    StackingEnsemble,
-    WeightedEnsemble,
-    ensemble_cross_validate,
-)
 from aquascope.models.transfer import (
     DonorSelector,
     DonorSite,
@@ -28,6 +21,19 @@ from aquascope.models.transfer import (
 )
 
 MODEL_MAP: dict[str, type[BaseHydroModel]] = {}
+
+# The ensembles need scikit-learn (the ``ml`` extra); import them on first use so that
+# ``aquascope.models.rainfall_runoff`` (GR4J) and friends work on a bare install.
+_ENSEMBLE_NAMES = ("AdaptiveEnsemble", "EnsembleResult", "StackingEnsemble", "WeightedEnsemble",
+                   "ensemble_cross_validate")
+
+
+def __getattr__(name: str):  # PEP 562: lazy attributes
+    if name in _ENSEMBLE_NAMES:
+        from aquascope.models import ensemble
+
+        return getattr(ensemble, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _lazy_load() -> None:


### PR DESCRIPTION
Found while smoke-testing the 0.12.0 wheel in a clean venv: \`aquascope gym run --synthetic\` (and any \`from aquascope.models.rainfall_runoff import GR4J\` without the \`ml\` extra) died with \`ModuleNotFoundError: sklearn\`, because \`aquascope/models/__init__.py\` imported the ensembles eagerly. That predates 0.12.0 but 0.12.0's release notes say \`pip install "aquascope[gym]"\`, so it matters now.

- \`aquascope.models\`: the five ensemble names (\`AdaptiveEnsemble\`, \`EnsembleResult\`, \`StackingEnsemble\`, \`WeightedEnsemble\`, \`ensemble_cross_validate\`) become PEP 562 lazy attributes; \`from aquascope.models import AdaptiveEnsemble\` still works with scikit-learn installed, the model tests pass unchanged (90).
- Verified on a bare venv from a local wheel: GR4J, \`aquascope.gym\` and \`aquascope gym run --synthetic\` work without scikit-learn.
- \`CITATION.cff\`: v0.12.0 version DOI \`10.5281/zenodo.21995649\` (Zenodo archived the release). CHANGELOG entries under Unreleased.

Suggest a 0.12.1 patch right after this merges so \`pip install "aquascope[gym]"\` does what the release notes say.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01812ELXE4YS6m9MCjDvkNBB