### PR TITLE
feat(agri): add Kc coefficients for sorghum, groundnut and sugar beet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+- Crop coefficients for **sorghum**, **groundnut** and **sugar beet** in `aquascope.agri.crop_water`: single-crop `KC_TABLE`, basal `KCB_TABLE` and `DEFAULT_STAGE_LENGTHS` entries, taken from FAO-56 Tables 12 and 17.
 
 ### Changed
 - `CITATION.cff` lists the v0.12.0 version DOI `10.5281/zenodo.21995649` (concept DOI unchanged).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ MCP client) `find_stations`, `get_timeseries`, `analyze_station` and `flood_freq
 
 - 🌊 **Pull water data** from USGS, FAO AQUASTAT, FAO WaPOR, GEMStat, EU WFD, Copernicus ERA5, France Hub'Eau, Taiwan MOENV/WRA/Civil IoT/DataGov, Japan MLIT, Korea WAMIS, India WRIS, GRDC, CAMELS-CL, OpenMeteo, UN SDG 6, US Water Quality Portal — **one unified Python API**.
 - 📈 **Run hydrological analyses** — Bulletin 17C flood frequency (GEV / LP3 / Gumbel / non-stationary GEV / EMA), baseflow separation, rating curves, 22 hydrological signatures.
-- 🌾 **Plan agricultural water** — FAO-56 Penman-Monteith ET₀, crop water requirements for 20 crops, irrigation scheduling, soil water balance with auto-irrigation.
+- 🌾 **Plan agricultural water** — FAO-56 Penman-Monteith ET₀, crop water requirements for 23 crops, irrigation scheduling, soil water balance with auto-irrigation.
 - 🤖 **Ask the AI engine** — describe your goal in plain English and get a recommended methodology, scored against your dataset profile and auto-executed. LLM enhancement via OpenAI, Groq (free), HuggingFace (free), or local Ollama.
 - 📊 **Visualise + report** — 16 plot types, Q-Q / P-P diagnostics, Markdown / HTML reports with embedded figures, threshold alerts (WHO / EPA / EU WFD).
 - 🗺️ **Spatial hydrology** — DEM processing, D8 flow direction, watershed delineation, Strahler ordering.

--- a/aquascope/agri/crop_water.py
+++ b/aquascope/agri/crop_water.py
@@ -50,6 +50,9 @@ KC_TABLE: dict[str, dict[str, float]] = {
     "banana": {"initial": 0.50, "mid": 1.10, "late": 1.00},
     "coffee": {"initial": 0.90, "mid": 0.95, "late": 0.95},
     "tea": {"initial": 0.95, "mid": 1.00, "late": 1.00},
+    "sorghum": {"initial": 0.30, "mid": 1.05, "late": 0.55},
+    "groundnut": {"initial": 0.40, "mid": 1.15, "late": 0.60},
+    "sugar_beet": {"initial": 0.35, "mid": 1.20, "late": 0.70},
 }
 
 # ---------------------------------------------------------------------------
@@ -78,6 +81,9 @@ KCB_TABLE: dict[str, dict[str, float]] = {
     "banana": {"initial": 0.15, "mid": 1.05, "late": 0.90},
     "coffee": {"initial": 0.85, "mid": 0.90, "late": 0.90},
     "tea": {"initial": 0.90, "mid": 0.95, "late": 0.95},
+    "sorghum": {"initial": 0.15, "mid": 0.95, "late": 0.35},
+    "groundnut": {"initial": 0.15, "mid": 1.10, "late": 0.50},
+    "sugar_beet": {"initial": 0.15, "mid": 1.15, "late": 0.50},
 }
 
 # ---------------------------------------------------------------------------
@@ -105,6 +111,9 @@ DEFAULT_STAGE_LENGTHS: dict[str, dict[str, int]] = {
     "banana": {"initial": 120, "development": 60, "mid": 180, "late": 5},
     "coffee": {"initial": 60, "development": 90, "mid": 120, "late": 60},
     "tea": {"initial": 60, "development": 90, "mid": 120, "late": 60},
+    "sorghum": {"initial": 20, "development": 35, "mid": 40, "late": 30},
+    "groundnut": {"initial": 25, "development": 35, "mid": 45, "late": 25},
+    "sugar_beet": {"initial": 30, "development": 45, "mid": 90, "late": 15},
 }
 
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -31,7 +31,7 @@ See [docs/data_sources.md](data_sources.md) for the full list with endpoints and
 
 - **FAO-56 Penman-Monteith ET₀** — reference evapotranspiration with all intermediate steps
 - **Hargreaves ET₀** — temperature-only alternative
-- **Crop water requirements** — 20 crops with FAO-56 Kc coefficients and growth stages; single (Kc) and dual (Kcb + Ke) coefficient modes
+- **Crop water requirements** — 23 crops with FAO-56 Kc coefficients and growth stages; single (Kc) and dual (Kcb + Ke) coefficient modes
 - **Irrigation scheduling** — effective rainfall, net/gross demand, efficiency
 - **Soil water balance** — daily tracking, depletion, auto-irrigation triggers
 - **WaPOR productivity workflows** — biomass water productivity and AETI-to-RET performance metrics

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ pip install "aquascope[all]"       # everything: ML, viz, spatial, dashboard
 
 - 🌊 **Pull water data** from USGS, FAO AQUASTAT, FAO WaPOR, GEMStat, EU WFD, Copernicus ERA5, Taiwan MOENV / WRA, Japan MLIT, Korea WAMIS, OpenMeteo, and UN SDG 6, with one unified Python API.
 - 📈 **Run hydrological analyses**: Bulletin 17C flood frequency (GEV / LP3 / Gumbel / non-stationary GEV / EMA), baseflow separation, rating curves, and 22 hydrological signatures.
-- 🌾 **Plan agricultural water**: FAO-56 Penman–Monteith ET₀, crop water requirements for 20 crops, irrigation scheduling, and soil water balance with auto-irrigation.
+- 🌾 **Plan agricultural water**: FAO-56 Penman–Monteith ET₀, crop water requirements for 23 crops, irrigation scheduling, and soil water balance with auto-irrigation.
 - 🤖 **Ask the AI engine**: describe your goal in plain English, get a recommended methodology scored against your dataset, and auto-execute it.
 - 📊 **Visualise and report**: 16 plot types, Q-Q / P-P diagnostics, Markdown / HTML reports with embedded figures, threshold alerts (WHO / EPA / EU WFD).
 - 🗺️ **Spatial hydrology**: DEM processing, D8 flow direction, watershed delineation, Strahler ordering.

--- a/tests/test_agri/test_agri.py
+++ b/tests/test_agri/test_agri.py
@@ -605,3 +605,48 @@ class TestWaPORCollector:
         """Normalising an empty list returns an empty list."""
         collector = WaPORCollector()
         assert collector.normalise([]) == []
+
+
+class TestNewFao56Crops:
+    """Sorghum, groundnut and sugar beet, added from FAO-56 Tables 12 and 17."""
+
+    NEW_CROPS = ["sorghum", "groundnut", "sugar_beet"]
+
+    @pytest.mark.parametrize("crop", NEW_CROPS)
+    def test_get_kc_returns_dict(self, crop):
+        """get_kc returns the full Kc dict for each new crop."""
+        kc = get_kc(crop)
+        assert set(kc) == {"initial", "mid", "late"}
+        assert all(isinstance(v, float) for v in kc.values())
+
+    @pytest.mark.parametrize("crop", NEW_CROPS)
+    def test_present_in_every_table(self, crop):
+        """Each new crop is in KC_TABLE, KCB_TABLE and DEFAULT_STAGE_LENGTHS."""
+        assert crop in KC_TABLE
+        assert crop in KCB_TABLE
+        assert crop in DEFAULT_STAGE_LENGTHS
+
+    @pytest.mark.parametrize("crop", NEW_CROPS)
+    def test_crop_water_requirement_runs(self, crop):
+        """A full season computes and every day gets a stage."""
+        n_days = sum(DEFAULT_STAGE_LENGTHS[crop].values())
+        eto = _make_daily_series(n_days, 5.0)
+        df = crop_water_requirement(eto, crop, date(2024, 1, 1))
+        assert len(df) == n_days
+        assert set(df["stage"].unique()) == {"initial", "development", "mid", "late"}
+        assert (df["etc"] > 0).all()
+
+    @pytest.mark.parametrize("crop", NEW_CROPS)
+    def test_dual_method_runs(self, crop):
+        """The dual Kcb approach works, which needs KCB_TABLE to have the crop."""
+        n_days = sum(DEFAULT_STAGE_LENGTHS[crop].values())
+        eto = _make_daily_series(n_days, 5.0)
+        df = crop_water_requirement(eto, crop, date(2024, 1, 1), method="dual")
+        assert len(df) == n_days
+        assert get_kcb(crop, "mid") <= get_kc(crop, "mid")
+
+    def test_fao56_mid_season_values(self):
+        """Kc mid-season values match FAO-56 Table 12."""
+        assert get_kc("sorghum", "mid") == 1.05
+        assert get_kc("groundnut", "mid") == 1.15
+        assert get_kc("sugar_beet", "mid") == 1.20


### PR DESCRIPTION
Adds the three FAO-56 crops requested in the issue, using exactly the values it specifies.

### Acceptance criteria

- [x] `get_kc("sorghum")`, `get_kc("groundnut")`, `get_kc("sugar_beet")` each return a Kc dict
- [x] `crop_water_requirement(eto_series, crop=..., planting_date=...)` works for all three
- [x] All three added to `KC_TABLE` **and** `DEFAULT_STAGE_LENGTHS`
- [x] More than 3 new unit tests — 13, parametrized across the three crops
- [x] `docs/features.md` crop count updated to 23

`pytest tests/test_agri/` → **99 passed**.

### One addition beyond the issue: KCB_TABLE

The issue names two dicts, but the module has a third — `KCB_TABLE`, the FAO-56 Table 17 basal coefficients used by `method="dual"`. It currently holds exactly the same 20 crops as `KC_TABLE`, so adding a crop to only two of the three dicts would have left `get_kcb("sorghum")` raising and `crop_water_requirement(..., method="dual")` broken for the new crops while the single-Kc path worked.

I added them there too, from FAO-56 Table 17:

| Crop | Kcb ini | Kcb mid | Kcb end |
|---|---|---|---|
| sorghum | 0.15 | 0.95 | 0.35 |
| groundnut | 0.15 | 1.10 | 0.50 |
| sugar_beet | 0.15 | 1.15 | 0.50 |

These sit consistently below the corresponding Kc values, matching the pattern of the existing entries. One of the tests asserts `Kcb_mid <= Kc_mid` for each crop so the relationship stays true. Say the word if you'd rather this be a separate PR.

### Docs

Beyond `docs/features.md`, the same "20 crops" figure appears in `docs/index.md` and `README.md`. I updated those too rather than leave three counts disagreeing.

### Note

Confirmed sunflower and soybean are already present and left them untouched, per the scope correction in the issue.

Closes #5