### PR TITLE
Groq default model after the 2026-08-16 retirement; twelve months on the Explorer climate chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to AquaScope are documented here.
 
 ### Fixed
 - `aquascope.models` no longer imports the scikit-learn ensembles at package import time (PEP 562 lazy attributes), so `from aquascope.models.rainfall_runoff import GR4J`, `aquascope.gym` and `pip install "aquascope[gym]"` work on a bare install; the ensembles still import on first use with the `ml` extra.
+- Groq retired `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` on 2026-08-16, so `aquascope ask --provider groq`, the Explorer's Ask panel and the dashboard recommender failed with a model-not-found error on the default. The Groq defaults are now `openai/gpt-oss-120b` (analyst, Explorer) and `openai/gpt-oss-120b` / `openai/gpt-oss-20b` (recommender picker); an explicit `--model` still wins.
+- Explorer: the "Monthly climate" chart on the click-anywhere card drew eight bars instead of twelve. Plotly merges categorical x values with the same label, and the one-letter month labels repeated (M, J, A), so May, June, July and August were folded into March, January and April. Months are now labelled Jan..Dec.
 
 ## [0.12.0] - 2026-08-18
 

--- a/aquascope/ai_engine/analyst.py
+++ b/aquascope/ai_engine/analyst.py
@@ -35,8 +35,10 @@ MAX_TOOL_RESULT_CHARS = 14_000
 
 PROVIDERS: dict[str, dict[str, str | None]] = {
     "openai": {"base_url": None, "model": "gpt-4o-mini", "env": "OPENAI_API_KEY"},
+    # Groq retired llama-3.3-70b-versatile on 2026-08-16 (console.groq.com/docs/deprecations);
+    # gpt-oss-120b is the production tool-calling model on the free tier.
     "groq": {
-        "base_url": "https://api.groq.com/openai/v1", "model": "llama-3.3-70b-versatile", "env": "GROQ_API_KEY",
+        "base_url": "https://api.groq.com/openai/v1", "model": "openai/gpt-oss-120b", "env": "GROQ_API_KEY",
     },
     "huggingface": {
         "base_url": "https://router.huggingface.co/v1", "model": "Qwen/Qwen2.5-72B-Instruct", "env": "HF_TOKEN",

--- a/aquascope/ai_engine/recommender.py
+++ b/aquascope/ai_engine/recommender.py
@@ -226,10 +226,11 @@ PROVIDER_MODELS: dict[str, list[str]] = {
         "google/gemma-3-12b-it",
         "microsoft/phi-4",
     ],
+    # Groq retired llama-3.1-8b-instant and llama-3.3-70b-versatile on 2026-08-16
+    # (console.groq.com/docs/deprecations); these are the production chat models now.
     "groq": [
-        "llama-3.1-8b-instant",
-        "llama-3.3-70b-versatile",
-        "llama3-8b-8192",
+        "openai/gpt-oss-120b",
+        "openai/gpt-oss-20b",
     ],
     "ollama": ["mistral", "llama3.2", "qwen2.5:7b"],
 }

--- a/explorer/app.js
+++ b/explorer/app.js
@@ -372,7 +372,9 @@ function renderPoint(res) {
       ["aridity", `${fmt(c.aridity_index, 2)}`, c.aridity_class || "P / ET0"],
       ["temperature", `${fmt(c.temperature_mean_c, 1)} °C`, `wettest day ${fmt(c.wettest_day_mm, 0)} mm`],
     ].map(([l, v, s]) => `<div class="kpi"><div class="l">${l}</div><div class="v">${v}</div><div class="s">${s}</div></div>`).join("");
-    const months = ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
+    // Distinct labels: Plotly merges categorical x values with the same name, so
+    // one-letter months collapsed May/Jun/Jul/Aug into Mar/Jan/Apr and drew 8 bars.
+    const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
     Plotly.react("plot-climate", [
       { x: months, y: c.monthly_precipitation_mm, type: "bar", name: "rain (mm)", marker: { color: "#1565c0" } },
       { x: months, y: c.monthly_et0_mm, type: "scatter", mode: "lines+markers", name: "ET0 (mm)", line: { color: "#ef6c00" } },
@@ -1130,7 +1132,7 @@ function renderFfaPlot(ffa, unit, color) {
 // ends with Data and Methods sections assembled from tool results.
 
 const ASK_PROVIDERS = {
-  groq: { base_url: "https://api.groq.com/openai/v1", model: "llama-3.3-70b-versatile" },
+  groq: { base_url: "https://api.groq.com/openai/v1", model: "openai/gpt-oss-120b" },
   huggingface: { base_url: "https://router.huggingface.co/v1", model: "Qwen/Qwen2.5-72B-Instruct" },
   openai: { base_url: "https://api.openai.com/v1", model: "gpt-4o-mini" },
   mistral: { base_url: "https://api.mistral.ai/v1", model: "mistral-small-latest" },


### PR DESCRIPTION
Two small fixes found while walking through the live Explorer on 2026-08-19.

**Groq default model.** Groq retired `llama-3.3-70b-versatile` and `llama-3.1-8b-instant` on 2026-08-16 (their deprecations page lists 08/16/26 with `openai/gpt-oss-120b` as the replacement), so `aquascope ask --provider groq`, the Explorer's Ask panel and the dashboard recommender picker all failed on their default. Defaults move to `openai/gpt-oss-120b` in `analyst.PROVIDERS` and `explorer/app.js` `ASK_PROVIDERS`, and the recommender's Groq list becomes `openai/gpt-oss-120b` / `openai/gpt-oss-20b` (the two production chat models on Groq today, both tool-calling). An explicit `--model` still wins.

**Explorer monthly climate chart.** The click-anywhere card drew 8 bars instead of 12: the x values were one-letter month labels, and Plotly merges categorical x values with the same name, so May/Jun/Jul/Aug were folded into Mar/Jan/Apr (verified from the live trace: `x = ["J","F","M","A","M","J","J","A","S","O","N","D"]`). Labels are now `Jan..Dec`.

Checks: `ruff check` clean on the two Python files, `pytest tests/test_ai_engine` 80 passed, `node --check explorer/app.js` ok. CHANGELOG `[Unreleased]` → Fixed.

Part of the 2026-08-19 direction pass (one-platform vision doc); the larger items are filed as separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018W2hPYUZ3ZsjnMY4fRk9xc
