### PR TITLE
deploy: the dashboard Space script ships the redirect, not a wheel

### DIFF
--- a/deploy/hf-static-demo/deploy.sh
+++ b/deploy/hf-static-demo/deploy.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Rebuild the wheel and redeploy the in-browser (stlite) demo to the free
-# static Hugging Face Space.
+# Deploy the redirect page to the retired static Hugging Face Space.
+#
+# The dashboard Space stopped being a demo in #235: its analyses are in the
+# Explorer now, and this folder is the "moved" page that says so. No wheel is
+# built or shipped - a Space serving a stale wheel is exactly what this
+# replaces.
 #
 # Prerequisite (one time):  hf auth login
 # Then:                     bash deploy/hf-static-demo/deploy.sh
@@ -10,22 +14,26 @@ SPACE="${1:-Rekin226/aquascope-dashboard}"
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 HERE="$ROOT/deploy/hf-static-demo"
 
-echo "→ Building wheel…"
-(cd "$ROOT" && python -m build --wheel -o dist)
-cp "$ROOT"/dist/aquascope-*-py3-none-any.whl "$HERE/"
-
-# NOTE: upload via the Python API, not `hf upload` — the CLI pre-flights a
+# NOTE: upload via the Python API, not `hf upload` - the CLI pre-flights a
 # repos/create call that 402s on free accounts (it defaults the sdk to
 # gradio), even when the target static Space already exists.
-echo "→ Uploading to $SPACE…"
-python - "$SPACE" "$HERE" <<'EOF'
+echo "→ Uploading the redirect to $SPACE…"
+python - "$SPACE" "$HERE" <<'PY'
 import sys
 from huggingface_hub import HfApi
 
 space, folder = sys.argv[1], sys.argv[2]
-HfApi().upload_folder(repo_id=space, repo_type="space", folder_path=folder,
-                      commit_message="Redeploy stlite demo")
+# delete_patterns clears what the old stlite deploy left behind (the wheel and
+# its stylesheet); upload_folder does not remove remote files on its own, so
+# without this the Space keeps serving aquascope-0.8.1-py3-none-any.whl.
+HfApi().upload_folder(
+    repo_id=space,
+    repo_type="space",
+    folder_path=folder,
+    delete_patterns=["*.whl", "style.css"],
+    commit_message="Redirect to the Explorer (#235)",
+)
 print("done")
-EOF
+PY
 
 echo "✓ Live at: https://huggingface.co/spaces/$SPACE"


### PR DESCRIPTION
## Summary

`deploy/hf-static-demo/` has held the "this Space has moved to the Explorer" page since #235, but the script next to it was still the stlite deploy: it built a wheel, copied it into the folder and uploaded the lot. Running it today would republish the very thing the redirect replaces.

It also looks like it was never run after #235. The live Space still boots stlite `@1.8.1` and serves `aquascope-0.8.1-py3-none-any.whl`, last touched 2026-07-18, so the CHANGELOG and ROADMAP describe a redirect that is not deployed. Surfaced while reviewing #227, where the README conflict resolution linked that Space as a live demo.

## What changed

- No wheel is built or copied. A redirect page needs no wheel, and shipping one is what left 0.8.1 in front of visitors.
- `upload_folder(..., delete_patterns=["*.whl", "style.css"])`. `upload_folder` does not delete remote files that are absent locally, so without this the stale wheel and its stylesheet survive the redirect deploy.
- Comments say why, so the next person does not "fix" it back into a demo deploy.

## Deploying

Unchanged, and still needs the maintainer's credentials:

```bash
hf auth login
bash deploy/hf-static-demo/deploy.sh
```

No library code touched, so `no-changelog`.
