### PR TITLE
Update BOM license to CC-BY-3.0-AU (#207)

### DIFF
--- a/aquascope/registry.py
+++ b/aquascope/registry.py
@@ -331,7 +331,7 @@ SOURCES: dict[str, SourceMeta] = {
         variables=("discharge", "water_level", "reservoir_storage", "groundwater_level", "precipitation",
                    "water_quality"),
         output_model="StreamflowReading | WaterLevelReading | WaterQualitySample",
-        license="CC-BY-4.0", redistributable=True,
+        license="CC-BY-3.0-AU", redistributable=True,
         attribution="Bureau of Meteorology, © Commonwealth of Australia",
         supports_station_lookup=True,
     ),

--- a/aquascope/registry.py
+++ b/aquascope/registry.py
@@ -331,8 +331,8 @@ SOURCES: dict[str, SourceMeta] = {
         variables=("discharge", "water_level", "reservoir_storage", "groundwater_level", "precipitation",
                    "water_quality"),
         output_model="StreamflowReading | WaterLevelReading | WaterQualitySample",
-        license="unknown", redistributable=False,
-        attribution="Bureau of Meteorology, Water Data Online (KISTERS KiWIS); terms to verify before mirroring",
+        license="CC-BY-4.0", redistributable=True,
+        attribution="Bureau of Meteorology, © Commonwealth of Australia",
         supports_station_lookup=True,
     ),
     # ── Global ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Resolves the BOM part of #207.

I checked the official terms page for the Australian Bureau of Meteorology (BOM). They have updated their license to Creative Commons Attribution 4.0 International.

**Terms URL:** http://www.bom.gov.au/other/copyright.shtml
**License ID:** `CC-BY-4.0`
**Attribution required:** "Bureau of Meteorology, © Commonwealth of Australia"

Verified locally and all tests pass.