### PR TITLE
Update GRDC license details (#207)

### DIFF
--- a/aquascope/registry.py
+++ b/aquascope/registry.py
@@ -343,8 +343,8 @@ SOURCES: dict[str, SourceMeta] = {
         homepage="https://grdc.bafg.de/",
         variables=("discharge",),
         output_model="StreamflowReading",
-        license="GRDC-terms", redistributable=False,
-        attribution="Global Runoff Data Centre, 56068 Koblenz, Germany (redistribution not permitted)",
+        license="GRDC Policy Guidelines", redistributable=False,
+        attribution="The Global Runoff Data Centre, 56068 Koblenz, Germany",
     ),
     "openmeteo": _s(
         key="openmeteo", label="Open-Meteo", region="Global",


### PR DESCRIPTION
Resolves the GRDC part of #207.

As suspected in the issue description, redistribution is strictly not permitted. Annex 2, Point 1 of their Policy Guidelines states that data must not be transferred to third parties or the general public.

**Terms URL:** https://www.bafg.de/GRDC/EN/01_GRDC/13_dtplcy/datapolicy_node.html (Specifically inside the Policy Guidelines PDF)
**License ID:** GRDC Policy Guidelines
**Attribution required:** "The Global Runoff Data Centre, 56068 Koblenz, Germany" (as per Annex 2, Point 5).

Verified locally and all tests pass.