### PR TITLE
feat(ai_engine): add NVIDIA Build as an LLM provider (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to AquaScope are documented here.
 
 ## [Unreleased]
 
+### Added
+- **NVIDIA Build provider support** (#331). Added NVIDIA Build (`https://integrate.api.nvidia.com/v1`) to `aquascope.ai_engine.providers` with default model `openai/gpt-oss-120b`, support for `nvidia/llama-3.1-nemotron-70b-instruct`, `NVIDIA_API_KEY` credential scanning in `ENV_SCAN_ORDER`, documentation in `docs/analyst.md`, and unit test coverage in `tests/test_ai_engine/test_providers.py`.
+
 ### Changed
 - `CITATION.cff` lists the v0.13.0 version DOI `10.5281/zenodo.22152064` (concept DOI unchanged).
 - **WQP collector moved to the WQX 3.0 API** (#170). The old WQX 2.2 endpoint missed USGS data after 2024-03-11. `fetch_raw` now calls `/wqx3/Result/search` with `dataProfile=narrow`; a clean break from 2.2 — only WQX 3.0 field names are read (cross-walked from the official schema, e.g. `ResultMeasureValue` to `Result_Measure`, `CharacteristicName` to `Characteristic_Name`, `MonitoringLocationIdentifier` to `Location_Identifier`), with no dual-version support.

--- a/aquascope/ai_engine/analyst.py
+++ b/aquascope/ai_engine/analyst.py
@@ -247,8 +247,9 @@ def resolve_llm(
             provider = "ollama" if base_url or os.environ.get("AQUASCOPE_LLM_BASE_URL") else None
     if provider is None:
         raise RuntimeError(
-            "No LLM configured. Set OPENAI_API_KEY, GROQ_API_KEY or HF_TOKEN, or AQUASCOPE_LLM_API_KEY with "
-            "AQUASCOPE_LLM_BASE_URL/AQUASCOPE_LLM_MODEL, or pass --provider ollama for a local model."
+            "No LLM configured. Set OPENAI_API_KEY, GROQ_API_KEY, NVIDIA_API_KEY or HF_TOKEN, or "
+            "AQUASCOPE_LLM_API_KEY with AQUASCOPE_LLM_BASE_URL/AQUASCOPE_LLM_MODEL, or pass --provider ollama "
+            "for a local model."
         )
     if provider not in PROVIDERS and provider != "custom":
         raise ValueError(f"Unknown provider {provider!r}; choose from {list(PROVIDERS)}")

--- a/aquascope/ai_engine/providers.py
+++ b/aquascope/ai_engine/providers.py
@@ -106,10 +106,22 @@ PROVIDERS: dict[str, Provider] = {
         browser=False,
         note="Needs `ollama serve` on this machine; a page served over HTTPS cannot reach it.",
     ),
+    "nvidia": Provider(
+        id="nvidia",
+        label="NVIDIA Build (free trial credits)",
+        base_url="https://integrate.api.nvidia.com/v1",
+        model="openai/gpt-oss-120b",
+        models=["openai/gpt-oss-120b", "nvidia/llama-3.1-nemotron-70b-instruct", "openai/gpt-oss-20b"],
+        env="NVIDIA_API_KEY",
+        free="1,000 API calls on signup, more on request; not a refilling quota.",
+        signup="https://build.nvidia.com",
+        browser=False,
+        note="NVIDIA Build endpoints do not support browser CORS; use from the CLI or behind a proxy.",
+    ),
 }
 
 #: The order the CLI scans the environment in when no provider was named.
-ENV_SCAN_ORDER = ("openai", "groq", "huggingface", "mistral", "openrouter")
+ENV_SCAN_ORDER = ("openai", "groq", "nvidia", "huggingface", "mistral", "openrouter")
 
 
 def provider_ids(*, browser_only: bool = False) -> list[str]:

--- a/docs/analyst.md
+++ b/docs/analyst.md
@@ -7,7 +7,7 @@ and aquascope does the part that has to be right.
 
 ```bash
 pip install aquascope             # the openai SDK is optional (pip install "aquascope[llm]")
-export GROQ_API_KEY=...            # or OPENAI_API_KEY, HF_TOKEN, MISTRAL_API_KEY, OPENROUTER_API_KEY, or AQUASCOPE_LLM_API_KEY + _BASE_URL + _MODEL
+export GROQ_API_KEY=...            # or OPENAI_API_KEY, NVIDIA_API_KEY, HF_TOKEN, MISTRAL_API_KEY, OPENROUTER_API_KEY, or AQUASCOPE_LLM_API_KEY + _BASE_URL + _MODEL
 aquascope ask "What is the 100-year flood of the Seine at Paris, and how sure can we be?" -o seine.md
 ```
 
@@ -25,7 +25,7 @@ them against real data. The Markdown report has three parts:
    also assembled from the tool results (never from the model's memory).
 
 A footer records the model, provider, date and the tools called. `--provider`
-picks openai / groq / huggingface / ollama (defaults from the environment),
+picks openai / groq / nvidia / huggingface / mistral / openrouter / ollama (defaults from the environment),
 `--model` overrides the default model, `--max-steps` bounds the tool loop.
 Works with any OpenAI-compatible endpoint that supports tool calling.
 
@@ -39,9 +39,21 @@ button): the browser worker calls the provider directly with your key through
 `aquascope.ai_engine.llm_transport.UrllibChatClient`, a dependency-free
 OpenAI-compatible client that is also the fallback when the `openai` package
 is not installed, so `pip install aquascope` alone is enough for `aquascope
-ask`. Providers: `openai`, `groq`, `huggingface`, `mistral`, `openrouter`,
+ask`. Providers: `openai`, `groq`, `nvidia` (CLI only), `huggingface`, `mistral`, `openrouter`,
 `ollama`, or `AQUASCOPE_LLM_BASE_URL` for anything else that speaks the
 protocol.
+
+### Supported Providers
+
+| Provider | ID | Environment Variable | Default Model | Free Tier / Trial | Browser (Explorer) |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **OpenAI** | `openai` | `OPENAI_API_KEY` | `gpt-4o-mini` | Paid | Yes |
+| **Groq** | `groq` | `GROQ_API_KEY` | `openai/gpt-oss-120b` | Free tier (~1,000 req/day) | Yes |
+| **NVIDIA Build** | `nvidia` | `NVIDIA_API_KEY` | `openai/gpt-oss-120b` | 1,000 trial credits on signup | No (CORS restricted; CLI only) |
+| **Hugging Face** | `huggingface` | `HF_TOKEN` | `Qwen/Qwen2.5-72B-Instruct` | Monthly free tier credit | Yes |
+| **Mistral** | `mistral` | `MISTRAL_API_KEY` | `mistral-small-latest` | Paid | Yes |
+| **OpenRouter** | `openrouter` | `OPENROUTER_API_KEY` | `openai/gpt-4o-mini` | `:free` models available | Yes |
+| **Ollama** | `ollama` | Local (`None`) | `qwen2.5:7b` | Free (runs locally) | No (requires local daemon) |
 
 ## `aquascope ingest`: any export in, a clean series and a QA report out
 

--- a/tests/test_ai_engine/test_providers.py
+++ b/tests/test_ai_engine/test_providers.py
@@ -1,0 +1,114 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from aquascope.ai_engine.analyst import resolve_llm
+from aquascope.ai_engine.providers import (
+    ENV_SCAN_ORDER,
+    PROVIDERS,
+    as_json,
+    default_model,
+    env_var,
+    provider_ids,
+    write_json,
+)
+
+
+def test_nvidia_provider_registered():
+    assert "nvidia" in PROVIDERS
+    p = PROVIDERS["nvidia"]
+    assert p.id == "nvidia"
+    assert p.label == "NVIDIA Build (free trial credits)"
+    assert p.base_url == "https://integrate.api.nvidia.com/v1"
+    assert p.model == "openai/gpt-oss-120b"
+    assert "openai/gpt-oss-120b" in p.models
+    assert "nvidia/llama-3.1-nemotron-70b-instruct" in p.models
+    assert p.env == "NVIDIA_API_KEY"
+    assert p.signup == "https://build.nvidia.com"
+    assert p.browser is False
+    assert p.free is not None
+    assert "1,000 API calls" in p.free
+    assert p.note is not None
+    assert "CORS" in p.note
+
+
+def test_env_scan_order_includes_nvidia():
+    assert "nvidia" in ENV_SCAN_ORDER
+    assert ENV_SCAN_ORDER.index("nvidia") > ENV_SCAN_ORDER.index("groq")
+
+
+def test_provider_ids():
+    all_ids = provider_ids(browser_only=False)
+    browser_ids = provider_ids(browser_only=True)
+    assert "nvidia" in all_ids
+    assert "nvidia" not in browser_ids
+    assert "ollama" not in browser_ids
+    assert "groq" in browser_ids
+
+
+def test_default_model_and_env_var():
+    assert default_model("nvidia") == "openai/gpt-oss-120b"
+    assert env_var("nvidia") == "NVIDIA_API_KEY"
+    assert default_model("unknown_provider") is None
+    assert env_var("unknown_provider") is None
+
+
+def test_as_json_roundtrip():
+    raw_browser = as_json(browser_only=True)
+    data_browser = json.loads(raw_browser)
+    ids_browser = [p["id"] for p in data_browser["providers"]]
+    assert "nvidia" not in ids_browser
+    assert "ollama" not in ids_browser
+    assert "groq" in ids_browser
+    assert "custom" in ids_browser
+    for p in data_browser["providers"]:
+        assert "env" not in p
+
+    raw_all = as_json(browser_only=False)
+    data_all = json.loads(raw_all)
+    ids_all = [p["id"] for p in data_all["providers"]]
+    assert "nvidia" in ids_all
+    assert "ollama" in ids_all
+    assert "groq" in ids_all
+
+    nvidia_entry = next(p for p in data_all["providers"] if p["id"] == "nvidia")
+    assert nvidia_entry["base_url"] == "https://integrate.api.nvidia.com/v1"
+    assert nvidia_entry["model"] == "openai/gpt-oss-120b"
+    assert nvidia_entry["browser"] is False
+    assert "env" not in nvidia_entry
+
+
+def test_write_json_custom_path(tmp_path: Path):
+    target = tmp_path / "providers.json"
+    written = write_json(target)
+    assert written == target
+    assert target.is_file()
+    content = json.loads(target.read_text(encoding="utf-8"))
+    assert "providers" in content
+    ids = [p["id"] for p in content["providers"]]
+    assert "nvidia" not in ids
+
+
+def test_resolve_llm_nvidia_explicit():
+    cfg = resolve_llm(provider="nvidia", api_key="nv-test-key")
+    assert cfg["provider"] == "nvidia"
+    assert cfg["api_key"] == "nv-test-key"
+    assert cfg["base_url"] == "https://integrate.api.nvidia.com/v1"
+    assert cfg["model"] == "openai/gpt-oss-120b"
+
+
+def test_resolve_llm_nvidia_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GROQ_API_KEY", raising=False)
+    monkeypatch.delenv("HF_TOKEN", raising=False)
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("OPENROUTER_API_KEY", raising=False)
+    monkeypatch.delenv("AQUASCOPE_LLM_API_KEY", raising=False)
+    monkeypatch.setenv("NVIDIA_API_KEY", "nv-env-key-1234")
+
+    cfg = resolve_llm()
+    assert cfg["provider"] == "nvidia"
+    assert cfg["api_key"] == "nv-env-key-1234"
+    assert cfg["base_url"] == "https://integrate.api.nvidia.com/v1"
+    assert cfg["model"] == "openai/gpt-oss-120b"


### PR DESCRIPTION
## Summary
Resolves #331.

This PR adds **NVIDIA Build** (`https://integrate.api.nvidia.com/v1`) to the provider registry in `aquascope.ai_engine.providers`. NVIDIA Build provides free trial credits (1,000 requests on signup, with more available on request) for hosting open weights such as `openai/gpt-oss-120b`, `nvidia/llama-3.1-nemotron-70b-instruct`, and others through an OpenAI-compatible `/chat/completions` interface.

### Key Changes
1. **Provider Registration (`aquascope/ai_engine/providers.py`)**:
   - Added `"nvidia"` to `PROVIDERS` with `base_url="https://integrate.api.nvidia.com/v1"`, `env="NVIDIA_API_KEY"`, `signup="https://build.nvidia.com"`, and `free="1,000 API calls on signup, more on request; not a refilling quota."`.
   - Set default model to `openai/gpt-oss-120b` (confirmed present in live catalog) along with `nvidia/llama-3.1-nemotron-70b-instruct` and `openai/gpt-oss-20b`.
   - Verified CORS preflight against `integrate.api.nvidia.com`: the endpoint does not return `Access-Control-Allow-Origin` headers, so configured `browser=False` with a descriptive note explaining that it is restricted from direct browser execution and suitable for the CLI or reverse proxies.
   - Added `"nvidia"` to `ENV_SCAN_ORDER` following the free-tier options.
2. **CLI & Analyst Integration (`aquascope/ai_engine/analyst.py`)**:
   - Included `NVIDIA_API_KEY` in the helpful guidance error message when no LLM credentials are found in the environment.
3. **Unit Tests (`tests/test_ai_engine/test_providers.py`)**:
   - Added comprehensive unit tests covering provider registration, attribute fidelity, `ENV_SCAN_ORDER` positioning, `provider_ids(browser_only=...)` filtering, `as_json` serialization roundtrips, `write_json` path handling, and `resolve_llm` resolution both explicitly and via `NVIDIA_API_KEY`.
4. **Documentation & Changelog**:
   - Added a provider reference table and environment variable documentation in `docs/analyst.md`.
   - Added an entry under `## [Unreleased] -> ### Added` in `CHANGELOG.md`.

## Verification
- Ran `pytest tests/test_ai_engine/ -v` (173 passed in 6.05s).
- Verified `python .github/scripts/check_changelog.py origin/main` passed cleanly.
- Formatted and verified with `uv run ruff check` (0 errors) and `git diff --check` (clean).

Closes #331
