### PR TITLE
release: 0.14.0, Solve: from a location and a problem to a verified study

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to AquaScope are documented here.
 ## [Unreleased]
 
 ### Added
+
+### Changed
+
+### Fixed
+
+## [0.14.0] - 2026-09-04
+
+### Added
 - **HydroGym Phase 1 at scale: the 60-task suite of 2026-09-03** (#175). `aquascope gym tasks` samples stations still listed as open (an open catalog end runs to today, as the reconnaissance reads it), which brings the French hydrometry gauges and most Environment Agency stations into the suite; a site whose reconnaissance fails, or a task whose key the tree cannot compute, is skipped and reported. `aquascope gym bench` gains `--resume` and `--spread`, prints the spend so far, counts timeouts in their own column and prices a timed-out row at zero. The ask agent's refusal is read by `read_refusal` (explicit refusals only; the stem "declin" no longer counts, since on the groundwater playbook it is the finding) and `rescore_ask` re-reads stored rows when the lists change. `assess_site` lists the station each variable's span came from even beyond the nearest 25, so a playbook that selects a branch on the context can always resolve its station (this crashed the tree at dense UK sites). Results, 15 sites and 60 tasks with 6 sites held out, 4.57 USD at list prices: the team matched every key with Claude Sonnet 5 (6,575 tokens a task) and all but one with Claude Haiku 4.5, the keyless tree and team matched every key at no cost, and the old Ask loop matched 68 percent with 16 percent false declines at 30,810 tokens a task. Leaderboard, discussion and a Zenodo deposit package under `aquascope/gym/results/2026-09-03/` and `docs/hydrogym.md`.
 - **SPEI next to SPI** (#309). `standardized_precipitation_evapotranspiration_index` in `aquascope.climate.indices` (log-logistic fit on the climatic water balance, Vicente-Serrano et al. 2010, sharing the SPI core) with a monthly Thornthwaite PET helper from temperature, so it runs on the ERA5 temperature `anywhere()` returns; a `spei` workbench analysis and the drought challenge path.
 - **Four more playbooks** (#307): `drought_status` (SPI and SPEI at a gauge or the ERA5 cell at 1, 3 and 12 months with their divergence, the SGI and its lag behind SPI at a well, the low-flow context at a river; declines flash-drought questions, which need a sub-monthly index), `supply_reliability` (run-of-river screening of a stated demand against the flow-duration curve with Q95 kept in the river, at a gauge or from regionalized signatures; declines reservoir schemes), `irrigation_feasibility` (the crop's seasonal demand from FAO-56 single Kc on ERA5 ET0, then the supply screening where a gauge is within reach; the Kc tables await the 2025 revision, #310), and `water_quality` (below). Solve's keyword rules and intake hints cover them; `explorer/playbooks.json` carries all seven.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,8 +15,8 @@ authors:
     given-names: Abdoul Rachid
     orcid: "https://orcid.org/0000-0002-4616-4153"
     affiliation: "National Central University, Taiwan"
-version: 0.13.0
-date-released: "2026-08-29"
+version: 0.14.0
+date-released: "2026-09-04"
 doi: 10.5281/zenodo.21903143
 license: MIT
 repository-code: https://github.com/Rekin226/aquascope
@@ -68,8 +68,8 @@ preferred-citation:
     - family-names: Ouédraogo
       given-names: Abdoul Rachid
       orcid: "https://orcid.org/0000-0002-4616-4153"
-  version: 0.13.0
-  date-released: "2026-08-29"
+  version: 0.14.0
+  date-released: "2026-09-04"
   doi: 10.5281/zenodo.21903143
   license: MIT
   repository-code: https://github.com/Rekin226/aquascope

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ If you use AquaScope in your research, please cite:
   author  = {Ouédraogo, Abdoul Rachid},
   year    = {2026},
   url     = {https://github.com/Rekin226/aquascope},
-  version = {0.13.0},
+  version = {0.14.0},
   doi     = {10.5281/zenodo.21903143},
   license = {MIT}
 }
@@ -446,7 +446,7 @@ If you use AquaScope in your research, please cite:
 Machine-readable metadata lives in [CITATION.cff](CITATION.cff); GitHub's "Cite this
 repository" button renders it in APA and BibTeX. Every tagged release is archived on
 Zenodo; `10.5281/zenodo.21903143` is the concept DOI that always resolves to the latest
-version (v0.12.0 is [10.5281/zenodo.21995649](https://doi.org/10.5281/zenodo.21995649)).
+version (v0.13.0 is [10.5281/zenodo.22152064](https://doi.org/10.5281/zenodo.22152064)).
 
 ## 📄 License
 

--- a/aquascope/__init__.py
+++ b/aquascope/__init__.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 __author__ = "AquaScope Contributors"
 __license__ = "MIT"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,7 +92,7 @@ pip install "aquascope[all]"       # everything: ML, viz, spatial, dashboard
   author  = {AquaScope Contributors},
   year    = {2026},
   url     = {https://github.com/Rekin226/aquascope},
-  version = {0.13.0},
+  version = {0.14.0},
   doi     = {10.5281/zenodo.21903143},
   license = {MIT}
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aquascope"
-version = "0.13.0"
+version = "0.14.0"
 description = "Open-source water data aggregation toolkit with AI-powered research methodology recommendations"
 readme = "README.md"
 license = {text = "MIT"}


### PR DESCRIPTION
The 0.14.0 release: version bump in both files, the CHANGELOG rolled from Unreleased into `[0.14.0] - 2026-09-04` with a fresh empty Unreleased above it, `CITATION.cff` (both `version` and `date-released` pairs), and the BibTeX version in `README.md` and `docs/index.md`. The README sentence naming the previous version's Zenodo DOI had been left at v0.12.0 by the last release; it now names v0.13.0's.

Same six files as the 0.12.0 and 0.13.0 release PRs. After merge: the GitHub Release `v0.14.0` with `--target main`, PyPI publishes on the release event, then the new Zenodo version DOI goes into `CITATION.cff` identifiers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)