### PR TITLE
Feat 62 ccme wqi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to AquaScope are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **CCME Water Quality Index** (#62): calculate a score and category from water-quality measurements using configurable per-parameter minimum and maximum guidelines. Available through the Python workbench and the Analyst's `analyse_table` tool.
+
 ### Changed
 - `CITATION.cff` lists the v0.13.0 version DOI `10.5281/zenodo.22152064` (concept DOI unchanged).
 - **WQP collector moved to the WQX 3.0 API** (#170). The old WQX 2.2 endpoint missed USGS data after 2024-03-11. `fetch_raw` now calls `/wqx3/Result/search` with `dataProfile=narrow`; a clean break from 2.2 — only WQX 3.0 field names are read (cross-walked from the official schema, e.g. `ResultMeasureValue` to `Result_Measure`, `CharacteristicName` to `Characteristic_Name`, `MonitoringLocationIdentifier` to `Location_Identifier`), with no dual-version support.

--- a/aquascope/ai_engine/analyst.py
+++ b/aquascope/ai_engine/analyst.py
@@ -206,7 +206,12 @@ def _tool_specs() -> list[ToolSpec]:
             "analyse_table",
             "Run one workbench analysis on a table the user supplied as CSV text: eda, quality, who_screen, "
             "flow_duration, baseflow, recession, flood_frequency, signatures, return_periods, sgi_drought, "
-            "recharge, aquifer_drawdown. params carries the analysis's own options.",
+            "recharge, aquifer_drawdown. params carries the analysis's own options. "
+            "For ccme_wqi, supply CSV columns parameter and value. "
+            "params.guidelines maps parameter names to min and/or max limits "
+            "in the same units as the measurements. Use data for one selected "
+            "body of water and reporting period. Ask for missing guidelines; "
+            "never invent thresholds.",
             {"type": "object", "properties": {"csv": {"type": "string"}, "analysis": {"type": "string"},
                                               "params": {"type": "object"}},
              "required": ["analysis"]},

--- a/aquascope/analysis/water_quality_index.py
+++ b/aquascope/analysis/water_quality_index.py
@@ -1,0 +1,10 @@
+"""Canadian Council of Ministers of the Environment Water Quality Index.
+
+This module implements the CCME WQI using user-provided parameter
+guidelines rather than hardcoded jurisdiction-specific thresholds.
+
+References
+----------
+Canadian Council of Ministers of the Environment. CCME Water Quality
+Index User's Manual 2017 Update.
+"""

--- a/aquascope/analysis/water_quality_index.py
+++ b/aquascope/analysis/water_quality_index.py
@@ -8,3 +8,170 @@ References
 Canadian Council of Ministers of the Environment. CCME Water Quality
 Index User's Manual 2017 Update.
 """
+from dataclasses import dataclass
+from math import isfinite, sqrt
+from numbers import Real
+
+import pandas as pd
+
+
+@dataclass
+class CCMEWQIResult:
+    """The score, category, and factors from a CCME WQI calculation."""
+    score: float
+    category: str
+    f1: float
+    f2: float
+    f3: float
+
+
+def wqi_category(score: float) -> str:
+    """Return the CCME category for a score between 0 and 100."""
+    if not 0 <= score <= 100:
+        raise ValueError("WQI score must be between 0 and 100.")
+
+    if score >= 95:
+        return "Excellent"
+    if score >= 80:
+        return "Good"
+    if score >= 65:
+        return "Fair"
+    if score >= 45:
+        return "Marginal"
+    return "Poor"
+
+def ccme_wqi(
+        measurements: pd.DataFrame,
+        guidelines: dict[str, dict[str, float]],
+) -> CCMEWQIResult:
+    """Calculate CCME WQI for a selected body of water and reporting period.
+
+    Parameters
+    ----------
+    measurements : pd.DataFrame
+        Long-form measurements with ``parameter`` and ``value`` columns.
+        Additional WaterQualitySample columns are accepted.
+    guidelines : dict
+        Parameter names mapped to ``min`` and/or ``max`` limits.
+        Names must match the table exactly. This implementation requires
+        finite limits, with min >= 0 and max > 0.
+
+    Returns
+    -------
+    CCMEWQIResult
+        Score from 0 to 100, category, and the scope (f1), frequency (f2),
+        and amplitude (f3) factors.
+
+    Notes
+    -----
+    Select the water body and reporting period before calling.
+    Measurement values and guideline limits must use matching units;
+    this function does not convert units or assess sampling adequacy.
+    Missing values and parameters without guidelines are excluded.
+    Categories are assigned using the unrounded score.
+
+    Raises
+    ------
+    ValueError
+        For invalid inputs, including nonfinite measurements or nonpositive
+        measurements that fail a minimum guideline.
+
+    References
+    ----------
+    CCME (2017), Water Quality Index User's Manual, 2017 Update.
+    https://ccme.ca/en/res/wqimanualen.pdf
+    """
+
+    required_columns = {"parameter", "value"}
+    missing_columns = required_columns - set(measurements.columns)
+
+    if missing_columns:
+        names = ", ".join(sorted(missing_columns))
+        raise ValueError(f"Missing required columns: {names}")
+
+    for parameter, limits in guidelines.items():
+        if not limits:
+            raise ValueError(f"Empty guideline for {parameter}.")
+
+        unknown_keys = set(limits) - {"min", "max"}
+        if unknown_keys:
+            raise ValueError(
+                f"Invalid guideline keys for {parameter}: {sorted(unknown_keys)}"
+            )
+
+        for bound, limit in limits.items():
+            if isinstance(limit, bool) or not isinstance(limit, Real):
+                raise ValueError(
+                    f"Invalid guideline for {parameter}: {bound} must be a number."
+                )
+
+            if not isfinite(limit):
+                raise ValueError(
+                    f"Invalid guideline for {parameter}: {bound} must be finite."
+                )
+
+            if limit < 0 or (bound == "max" and limit == 0):
+                raise ValueError(
+                    f"Invalid guideline for {parameter}: min must be >= 0 and max > 0."
+                )
+
+        if "min" in limits and "max" in limits:
+            if limits["min"] > limits["max"]:
+                raise ValueError(
+                    f"Invalid guideline for {parameter}: min must not exceed max."
+                )
+
+    data = measurements[
+        measurements["parameter"].isin(guidelines)].dropna(subset=["value"])
+
+    if data.empty:
+        raise ValueError("No measurements selected.")
+
+    failed_parameters = set()
+    failed_tests = 0
+    excursion_sum = 0.0
+
+    for parameter, raw_value in data[["parameter", "value"]].itertuples(index=False, name=None):
+        value = float(raw_value)
+
+        if not isfinite(value):
+            raise ValueError(
+                f"Invalid measurement for {parameter}: value must be finite."
+            )
+        limits = guidelines[parameter]
+        excursion = 0.0
+
+        if "min" in limits and value < limits["min"]:
+            if value <= 0:
+                raise ValueError(
+                    f"Invalid measurement for {parameter}: a value below "
+                    "a minimum guideline must be positive to calculate its excursion."
+                )
+            excursion = limits["min"] / value - 1.0
+        elif "max" in limits and value > limits["max"]:
+            excursion = value / limits["max"] - 1.0
+
+        if excursion > 0:
+            failed_parameters.add(parameter)
+            failed_tests += 1
+            excursion_sum += excursion
+
+    total_parameters  = data["parameter"].nunique()
+    total_tests = len(data)
+
+    f1 = 100 * len(failed_parameters) / total_parameters
+    f2 = 100 * failed_tests / total_tests
+
+    nse = excursion_sum / total_tests
+    f3 = nse / (0.01 * nse + 0.01)
+
+    score = 100.0 - sqrt(f1**2 + f2**2 + f3**2) / 1.732
+    score = max(0.0, score)
+
+    return CCMEWQIResult(
+        score=score,
+        category=wqi_category(score),
+        f1=f1,
+        f2=f2,
+        f3=f3,
+    )

--- a/aquascope/workbench.py
+++ b/aquascope/workbench.py
@@ -35,6 +35,7 @@ __all__ = [
     "DataProfile",
     "aquifer_drawdown",
     "baseflow",
+    "ccme_wqi",
     "datetime_indexed",
     "eda",
     "flood_frequency",
@@ -436,6 +437,39 @@ def who_screen(df: pd.DataFrame) -> dict[str, Any]:
     }
 
 
+def ccme_wqi(
+    df: pd.DataFrame,
+    *,
+    guidelines: dict[str, dict[str, float]],
+) -> dict[str, Any]:
+    """Compute CCME WQI for a selected body of water and reporting period.
+
+    Measurement values and their guidelines must use matching units.
+    """
+    from aquascope.analysis.water_quality_index import ccme_wqi as calculate_ccme_wqi
+
+    calculation = calculate_ccme_wqi(df, guidelines)
+    result: dict[str, Any] = jsonable(calculation)
+
+    result["guidelines"] = jsonable(guidelines)
+    result["methods"] = [
+        {
+            "name": "CCME Water Quality Index",
+            "text": (
+                "Combines the scope, frequency, and amplitude of failures "
+                "against user-provided water-quality guidelines."
+            ),
+            "citation": (
+                "Canadian Council of Ministers of the Environment (2017). "
+                "CCME Water Quality Index User's Manual, 2017 Update. "
+                "https://ccme.ca/en/res/wqimanualen.pdf"
+            ),
+        }
+    ]
+
+    return result
+
+
 # ── hydrology ───────────────────────────────────────────────────────────────
 
 
@@ -779,6 +813,8 @@ TOOLS: dict[str, dict[str, Any]] = {
     "preprocess": {"func": preprocess, "needs": "frame", "summary": "Clean a table with a list of steps."},
     "insights": {"func": insights, "needs": "frame", "summary": "Quality score, WHO screen and next steps."},
     "who_screen": {"func": who_screen, "needs": "frame", "summary": "WHO drinking-water guideline screen."},
+    "ccme_wqi": {"func": ccme_wqi, "needs": "frame", "summary": "CCME Water Quality Index; supply guidelines with "
+                                                                "per-parameter min/max limits."},
     "flow_duration": {"func": flow_duration, "needs": "frame", "summary": "Flow-duration curve and percentiles."},
     "baseflow": {"func": baseflow, "needs": "frame", "summary": "Baseflow separation and the baseflow index."},
     "recession": {"func": recession, "needs": "frame", "summary": "Recession segments and constant."},

--- a/docs/guides/running_pipelines.md
+++ b/docs/guides/running_pipelines.md
@@ -94,6 +94,85 @@ print(result.summary)
 print(result.metrics)
 ```
 
+## CCME WQI alongside PCA and correlation
+
+CCME WQI is available through `aquascope.workbench.run("ccme_wqi", ...)`.
+It accepts the `parameter` and `value` columns from WaterQualitySample
+tables, with additional metadata columns preserved in the input table.
+
+The example below uses a CSV containing `station_id`, `sample_datetime`,
+`parameter`, `value`, and `unit`. It selects one station and reporting year,
+then passes the same measurements to CCME and the existing correlation
+and PCA pipelines.
+
+Replace the station, dates, and illustrative guideline limits with values
+appropriate to your study. The concentration limits below assume mg/L;
+the pH limits use the pH scale.
+
+```python
+import pandas as pd
+
+from aquascope import workbench
+from aquascope.pipelines.model_builder import run_pipeline
+
+df = pd.read_csv(
+    "water_quality.csv",
+    parse_dates=["sample_datetime"],
+    dtype={"station_id": str},
+)
+
+# Illustrative limits; choose appropriate guidelines for your study.
+guidelines = {
+    "DO": {"min": 5.0},
+    "pH": {"min": 6.5, "max": 9.0},
+    "TP": {"max": 0.05},
+    "Pb": {"max": 0.004},
+}
+
+selected = df.loc[
+    (df["station_id"] == "STATION-1")
+    & (df["sample_datetime"] >= "2024-01-01")
+    & (df["sample_datetime"] < "2025-01-01")
+    & df["parameter"].isin(guidelines)
+].copy()
+
+wqi = workbench.run("ccme_wqi", selected, guidelines=guidelines)
+print(wqi["score"], wqi["category"])
+
+correlation = run_pipeline("correlation_analysis", selected)
+print(correlation.details["correlation_matrix"])
+
+pca = run_pipeline(
+    "pca_clustering",
+    selected,
+    config={"n_components": 2, "n_clusters": 3},
+)
+print(pca.metrics)
+```
+
+PCA requires the project's existing `ml` extra. Its current implementation
+requires at least ten complete sampling dates and two parameters.
+Use data suitable for each analysis: CCME excludes missing measurements
+individually, whereas these PCA and correlation pipelines use complete
+rows after pivoting the selected parameters.
+
+Pass measurements in their original physical units to CCME. The PCA
+pipeline performs its own standardization internally.
+
+The workbench result includes the score, category, F1/F2/F3 factors,
+supplied guidelines, and method citation. The Analyst can call this same
+calculation through its existing `analyse_table` tool.
+
+This implementation supports finite guideline limits with minimums
+greater than or equal to zero and maximums greater than zero. Nonpositive
+measurements that fail a minimum guideline raise an error. These are
+implementation limits, not universal water-quality standards.
+
+The existing `wqi_calculation` pipeline continues to compute Taiwan RPI.
+Use the workbench call above for CCME.
+
+Reference: [CCME Water Quality Index User's Manual, 2017 Update](https://ccme.ca/en/res/wqimanualen.pdf).
+
 ## Pipeline Configuration
 
 Each pipeline accepts an optional `config` dict:

--- a/tests/test_ai_engine/test_analyst.py
+++ b/tests/test_ai_engine/test_analyst.py
@@ -6,6 +6,7 @@ import json
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 from aquascope.ai_engine import analyst
@@ -106,3 +107,64 @@ def test_tool_specs_cover_the_mcp_surface():
                      "run_python"}
     tools = analyst._openai_tools(analyst._tool_specs())
     assert all(t["type"] == "function" and "parameters" in t["function"] for t in tools)
+
+def test_ask_runs_ccme_wqi_and_preserves_citation():
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO", "pH", "TP", "Pb"] * 4,
+            "value": [8.0, 7.5, 0.02, 0.001] * 4,
+        }
+    )
+    measurements.loc[0, "value"] = 2.5
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "Pb": {"max": 0.004},
+    }
+
+    client = FakeChat(
+        [
+            [("list_analyses", {})],
+            [
+                (
+                    "analyse_table",
+                    {
+                        "csv": measurements.to_csv(index=False),
+                        "analysis": "ccme_wqi",
+                        "params": {"guidelines": guidelines},
+                    },
+                )
+            ],
+            "The CCME WQI is approximately 84.74, classified as Good.",
+        ]
+    )
+
+    result = analyst.ask(
+        "Calculate CCME WQI using my measurements and guidelines.",
+        client=client,
+        model="fake",
+    )
+
+    assert [call.name for call in result.tool_calls] == [
+        "list_analyses",
+        "analyse_table",
+    ]
+    assert all(call.ok for call in result.tool_calls)
+
+    payloads = {
+        message["name"]: json.loads(message["content"])
+        for message in client.requests[-1]["messages"]
+        if message["role"] == "tool"
+    }
+
+    available = payloads["list_analyses"]["analyses"]
+    assert any(item["name"] == "ccme_wqi" for item in available)
+
+    calculation = payloads["analyse_table"]
+    assert calculation["score"] == pytest.approx(84.738878, abs=0.000001)
+    assert calculation["category"] == "Good"
+    assert calculation["guidelines"] == guidelines
+
+    assert "https://ccme.ca/en/res/wqimanualen.pdf" in result.to_markdown()

--- a/tests/test_analysis/test_water_quality_index.py
+++ b/tests/test_analysis/test_water_quality_index.py
@@ -1,0 +1,1 @@
+"""Tests for the CCME Water Quality Index implementation."""

--- a/tests/test_analysis/test_water_quality_index.py
+++ b/tests/test_analysis/test_water_quality_index.py
@@ -1,1 +1,264 @@
 """Tests for the CCME Water Quality Index implementation."""
+import pandas as pd
+import pytest
+
+from aquascope.analysis.water_quality_index import ccme_wqi, wqi_category
+
+
+@pytest.mark.parametrize(
+    "score, expected",
+    [
+        (0, "Poor"),
+        (44.9, "Poor"),
+        (45, "Marginal"),
+        (64.9, "Marginal"),
+        (65, "Fair"),
+        (79.9, "Fair"),
+        (80, "Good"),
+        (94.9, "Good"),
+        (95, "Excellent"),
+        (100, "Excellent"),
+    ],
+)
+def test_wqi_categories(score, expected):
+    assert wqi_category(score) == expected
+
+
+@pytest.mark.parametrize(
+    "score",
+    [-1, 101, float("nan"), float("inf"), float("-inf")],
+)
+def test_wqi_category_rejects_invalid_scores(score):
+    with pytest.raises(ValueError):
+        wqi_category(score)
+
+
+def test_ccme_wqi_all_measurements_meet_guidelines():
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO", "pH", "TP", "Pb"] * 4,
+            "value": [8.0, 7.5, 0.02, 0.001] * 4,
+        }
+    )
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "Pb": {"max": 0.004},
+    }
+
+    result = ccme_wqi(measurements, guidelines)
+
+    assert result.score == 100.0
+    assert result.category == "Excellent"
+    assert result.f1 == 0.0
+    assert result.f2 == 0.0
+    assert result.f3 == 0.0
+
+
+def test_ccme_wqi_one_measurement_below_minimum():
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO", "pH", "TP", "Pb"] * 4,
+            "value": [8.0, 7.5, 0.02, 0.001] * 4,
+        }
+    )
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "Pb": {"max": 0.004},
+    }
+
+    measurements.loc[0, "value"] = 2.5
+    result = ccme_wqi(measurements, guidelines)
+
+    assert result.f1 == pytest.approx(25.0)
+    assert result.f2 == pytest.approx(6.25)
+    assert result.f3 == pytest.approx(5.88235294117647)
+    assert result.score == pytest.approx(84.738878, abs=0.000001)
+    assert result.category == "Good"
+
+@pytest.mark.parametrize(
+    "measurements",
+    [
+        pd.DataFrame({"value": [8.0]}),
+        pd.DataFrame({"parameter": ["DO"]}),
+    ],
+)
+def test_ccme_wqi_rejects_missing_columns(measurements):
+    guidelines = {"DO": {"min": 5.0}}
+
+    with pytest.raises(ValueError, match="Missing required columns"):
+        ccme_wqi(measurements, guidelines)
+
+
+def test_ccme_wqi_rejects_empty_table():
+    measurements = pd.DataFrame(columns=["parameter", "value"])
+    guidelines = {"DO": {"min": 5.0}}
+
+    with pytest.raises(ValueError):
+        ccme_wqi(measurements, guidelines)
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {},
+        {"minimum": 5.0},
+        {"min": 5.0, "maximum": 10.0},
+        {"min": 9.0, "max": 5.0},
+    ],
+)
+def test_ccme_wqi_rejects_invalid_guideline_structure(limits):
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO"] * 4,
+            "value": [8.0] * 4,
+        }
+    )
+
+    with pytest.raises(ValueError, match="guideline"):
+        ccme_wqi(measurements, {"DO": limits})
+
+@pytest.mark.parametrize(
+    "limits",
+    [
+        {"max": 0.0},
+        {"max": -1.0},
+        {"min": -1.0},
+        {"max": float("nan")},
+        {"min": float("nan")},
+        {"max": float("inf")},
+        {"min": float("inf")},
+        {"max": "5.0"},
+        {"min": None},
+        {"max": True},
+    ],
+)
+def test_ccme_wqi_rejects_invalid_guideline_values(limits):
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO"] * 4,
+            "value": [8.0] * 4,
+        }
+    )
+
+    with pytest.raises(ValueError, match="guideline"):
+        ccme_wqi(measurements, {"DO": limits})
+
+def test_ccme_wqi_published_devon_example():
+    """Reproduce the published North Saskatchewan River, Devon, 1997 example."""
+    # Source: CCME WQI User's Manual, 2017 update, Table 1, pp. 6–7.
+    # https://ccme.ca/en/res/wqimanualen.pdf
+    # Below-detection readings use their detection limits, as the manual directs.
+    # None represents an absent measurement.
+    wide = pd.DataFrame(
+        {
+            "DO": [11.4, 11.0, 11.5, 12.5, 10.4, 8.9, 8.5, 7.5, 9.2, 11.0, 12.1, 13.3],
+            "pH": [8.0, 7.9, 7.9, 7.9, 8.1, 8.2, 8.3, 8.2, 8.2, 8.1, 8.0, 8.0],
+            "TP": [0.006, 0.005, 0.006, 0.058, 0.042, 0.108, 0.017, 0.008, 0.006, 0.008, 0.006, 0.004],
+            "TN": [0.160, 0.170, 0.132, 0.428, 0.250, 0.707, 0.153, 0.153, 0.130, 0.093, 0.296, 0.054],
+            "FC": [4, 4, 4, 4, 4, 26, 9, 8, 12, 12, 8, 4],
+            "As": [0.0002, 0.0002, 0.0002, 0.0002, 0.0002, 0.0006, 0.0002, 0.0002, 0.0003, 0.0002, 0.0002, 0.0002],
+            "Pb": [0.0004, 0.0094, 0.0003, 0.0008, 0.0008, 0.0013, 0.0004, 0.0003, 0.0018, 0.0011, 0.0051, 0.0003],
+            "Hg": [0.05, 0.05, 0.05, 0.05, 0.05, 0.05, None, 0.05, 0.05, 0.05, 0.05, 0.05],
+            "2,4-D": [0.005, None, None, 0.004, None, None, None, 0.005, None, 0.005, None, None],
+            "Lindane": [0.005, None, None, 0.005, None, None, None, 0.005, None, 0.005, None, None],
+        }
+    )
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "TN": {"max": 1.0},
+        "FC": {"max": 400.0},
+        "As": {"max": 0.05},
+        "Pb": {"max": 0.004},
+        "Hg": {"max": 0.1},
+        "2,4-D": {"max": 4.0},
+        "Lindane": {"max": 0.01},
+    }
+
+    measurements = wide.melt(var_name="parameter", value_name="value")
+    result = ccme_wqi(measurements, guidelines)
+
+    assert measurements["value"].count() == 103
+    assert result.f1 == pytest.approx(20.0)
+    assert result.f2 == pytest.approx(100.0 * 4 / 103)
+    assert result.f3 == pytest.approx(2.7797442069)
+    assert round(result.score) == 88
+    assert result.category == "Good"
+
+@pytest.mark.parametrize(
+    "value",
+    [float("inf"), float("-inf"), "NaN"],
+)
+def test_ccme_wqi_rejects_nonfinite_measurements(value):
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO"],
+            "value": [value],
+        }
+    )
+
+    with pytest.raises(ValueError, match="finite"):
+        ccme_wqi(measurements, {"DO": {"min": 5.0}})
+
+
+@pytest.mark.parametrize("value", [0.0, -1.0])
+def test_ccme_wqi_rejects_nonpositive_value_below_minimum(value):
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO"],
+            "value": [value],
+        }
+    )
+
+    with pytest.raises(ValueError, match="positive"):
+        ccme_wqi(measurements, {"DO": {"min": 5.0}})
+
+
+def test_ccme_wqi_accepts_zero_under_maximum():
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["TP"],
+            "value": [0.0],
+        }
+    )
+
+    result = ccme_wqi(measurements, {"TP": {"max": 0.05}})
+
+    assert result.score == 100.0
+    assert result.category == "Excellent"
+
+def test_ccme_wqi_handles_mixed_and_two_sided_guidelines():
+    measurements = pd.DataFrame(
+        {
+            "parameter": ["DO", "pH", "TP", "Pb"] * 4,
+            "value": [8.0, 7.5, 0.02, 0.001] * 4,
+        }
+    )
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "Pb": {"max": 0.004},
+    }
+
+    # Four failures, each with an excursion of 1.
+    measurements.loc[0, "value"] = 2.5   # DO below its minimum
+    measurements.loc[1, "value"] = 3.25  # pH below its minimum
+    measurements.loc[2, "value"] = 0.10  # TP above its maximum
+    measurements.loc[5, "value"] = 18.0  # pH above its maximum
+
+    result = ccme_wqi(measurements, guidelines)
+
+    assert result.f1 == pytest.approx(75.0)
+    assert result.f2 == pytest.approx(25.0)
+    assert result.f3 == pytest.approx(20.0)
+    assert result.score == pytest.approx(52.917129, abs=0.000001)
+    assert result.category == "Marginal"

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -15,6 +15,7 @@ import pandas as pd
 import pytest
 
 from aquascope import workbench as wb
+from aquascope.schemas.water_data import WaterQualitySample
 
 
 @pytest.fixture(scope="module")
@@ -375,3 +376,52 @@ def test_ingest_text_accepts_bytes_too() -> None:
     csv = b"date,level_m\n2020-01-01,1.5\n2020-01-02,1.7\n2020-01-03,1.6\n"
     res = ingest_text(csv, "levels.csv")
     assert res["qa"]["n_values"] == 3
+
+
+def test_ccme_wqi_runs_through_workbench():
+    # Synthetic measurements using the project's existing schema.
+    samples = [
+        WaterQualitySample(
+            source="usgs",
+            station_id="TEST-1",
+            sample_datetime=date,
+            parameter=parameter,
+            value=value,
+            unit=unit,
+        )
+        for date in pd.date_range("2024-01-01", periods=4, freq="QS")
+        for parameter, value, unit in [
+            ("DO", 8.0, "mg/L"),
+            ("pH", 7.5, "pH units"),
+            ("TP", 0.02, "mg/L"),
+            ("Pb", 0.001, "mg/L"),
+        ]
+    ]
+
+    measurements = pd.DataFrame(
+        [sample.model_dump() for sample in samples]
+    )
+
+    guidelines = {
+        "DO": {"min": 5.0},
+        "pH": {"min": 6.5, "max": 9.0},
+        "TP": {"max": 0.05},
+        "Pb": {"max": 0.004},
+    }
+
+    measurements.loc[0, "value"] = 2.5
+
+    result = wb.run(
+        "ccme_wqi",
+        measurements,
+        guidelines=guidelines,
+    )
+
+    assert result["score"] == pytest.approx(84.738878, abs=0.000001)
+    assert result["category"] == "Good"
+    assert result["f1"] == pytest.approx(25.0)
+    assert result["f2"] == pytest.approx(6.25)
+    assert result["f3"] == pytest.approx(5.88235294117647)
+    assert result["methods"][0]["citation"]
+
+    _strict_json(result)


### PR DESCRIPTION
Adds CCME WQI with configurable per-parameter min/max guidelines, quality categories, and tests against the published “88 — Good” example.

The calculator works through the Python workbench and the Analyst’s `analyse_table` tool. There’s also a docs example showing how to use the same measurements for WQI, PCA, and correlation.

Validation: 94 tests passed across the affected test modules, and Ruff passes. Local checks still show existing Windows repair-test failures and four pre-existing mypy errors.

This covers the Python/tool integration; browser controls and the existing RPI pipeline are unchanged.
