### PR TITLE
CITATION.cff: the v0.15.1 Zenodo version DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -37,6 +37,9 @@ identifiers:
     value: 10.5281/zenodo.21903143
     description: Concept DOI, resolves to the latest archived version
   - type: doi
+    value: 10.5281/zenodo.22637405
+    description: Version DOI for v0.15.1
+  - type: doi
     value: 10.5281/zenodo.22291813
     description: Version DOI for v0.14.0
   - type: doi


### PR DESCRIPTION
Adds 10.5281/zenodo.22637405 (the Zenodo archive of v0.15.1) to the identifiers, newest first. The concept DOI in the badge and the BibTeX stays as it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XvrSt2fsLStp1gmiEFPsUJ