### PR TITLE
add Scotland SEPA hydrometric collector

### DIFF
--- a/aquascope/collectors/__init__.py
+++ b/aquascope/collectors/__init__.py
@@ -21,6 +21,7 @@ from aquascope.collectors.korea_wamis import KoreaWAMISCollector
 from aquascope.collectors.noaa_nwps import NOAANWPSCollector
 from aquascope.collectors.openmeteo import OpenMeteoCollector
 from aquascope.collectors.pegelonline import PegelonlineCollector
+from aquascope.collectors.scotland_sepa import ScotlandSepaCollector
 from aquascope.collectors.sdg6 import SDG6Collector
 from aquascope.collectors.south_africa_dws import SouthAfricaDWSCollector
 from aquascope.collectors.taiwan_civil_iot import TaiwanCivilIoTCollector
@@ -61,6 +62,7 @@ __all__ = [
     "OpenMeteoCollector",
     "PegelonlineCollector",
     "SDG6Collector",
+    "ScotlandSepaCollector",
     "SouthAfricaDWSCollector",
     "TaiwanCivilIoTCollector",
     "TaiwanDataGovCollector",

--- a/aquascope/collectors/scotland_sepa.py
+++ b/aquascope/collectors/scotland_sepa.py
@@ -1,0 +1,437 @@
+"""
+Collector for Scotland's SEPA hydrometric time-series API.
+
+SEPA publishes river flow and river-level observations through a Kisters
+KiWIS service.
+
+The collector works in two steps:
+
+1. ``getTimeseriesList`` resolves the relevant time-series ID for a station.
+2. ``getTimeseriesValues`` fetches observations for that time series.
+
+SEPA parameter codes:
+- ``Q`` = river flow / discharge
+- ``SG`` = river level
+
+API documentation:
+https://timeseriesdoc.sepa.org.uk/
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from aquascope.collectors.base import BaseCollector
+from aquascope.schemas.water_data import (
+    DataSource,
+    GeoLocation,
+    StreamflowReading,
+    WaterLevelReading,
+)
+
+logger = logging.getLogger(__name__)
+
+
+SEPA_BASE_URL = "https://timeseries.sepa.org.uk/KiWIS/KiWIS"
+
+# SEPA uses these station parameter codes in KiWIS.
+FLOW_PARAMETER = "Q"
+LEVEL_PARAMETER = "SG"
+
+VALID_PARAMETERS = {FLOW_PARAMETER, LEVEL_PARAMETER}
+
+# Prefer units reported by the API, but keep these as safe fallbacks.
+PARAMETER_UNITS: dict[str, str] = {
+    FLOW_PARAMETER: "m3/s",
+    LEVEL_PARAMETER: "m",
+}
+
+
+class ScotlandSepaCollector(BaseCollector):
+    """Collect river flow and river-level observations from SEPA."""
+
+    name: str = "scotland_sepa"
+
+    # ------------------------------------------------------------------ #
+    # fetch_raw
+    # ------------------------------------------------------------------ #
+    def fetch_raw(
+        self,
+        station_id: str | None = None,
+        parameter: str = FLOW_PARAMETER,
+        start_date: str | None = None,
+        end_date: str | None = None,
+        days: int | None = None,
+        **kwargs: Any,
+    ) -> list[dict]:
+        """Fetch raw hydrometric observations for a SEPA station.
+
+        Parameters
+        ----------
+        station_id : str
+            SEPA station number.
+        parameter : str
+            SEPA station parameter. ``Q`` represents river flow and ``SG``
+            represents river level.
+        start_date : str | None
+            Start date in ``YYYY-MM-DD`` format.
+        end_date : str | None
+            End date in ``YYYY-MM-DD`` format.
+        days : int | None
+            Convenience alternative to ``start_date`` for requesting the
+            last N days. Defaults to 30 days when no date range is supplied.
+
+        Returns
+        -------
+        list[dict]
+            Raw observation rows merged with station and time-series metadata.
+        """
+        if not station_id:
+            raise ValueError(
+                "ScotlandSepaCollector.fetch_raw requires a station_id."
+            )
+
+        if parameter not in VALID_PARAMETERS:
+            raise ValueError(
+                "SEPA parameter must be 'Q' (flow) or 'SG' (river level)."
+            )
+
+        # Supply a useful default date window when one is not provided.
+        if start_date is None:
+            window_days = days if days is not None else 30
+            end = datetime.now(timezone.utc)
+            start = end - timedelta(days=window_days)
+
+            start_date = start.strftime("%Y-%m-%d")
+
+            if end_date is None:
+                end_date = end.strftime("%Y-%m-%d")
+
+        ts_meta = self._resolve_timeseries(station_id, parameter)
+
+        if ts_meta is None:
+            logger.warning(
+                "No SEPA timeseries found for station_no=%s, parameter=%s",
+                station_id,
+                parameter,
+            )
+            return []
+
+        metadata, values = self._fetch_timeseries_values(
+            ts_meta["ts_id"],
+            start_date,
+            end_date,
+        )
+
+        rows: list[dict] = []
+
+        for timestamp, value, quality_code in values:
+            rows.append(
+                {
+                    "station_no": ts_meta.get("station_no", station_id),
+                    "station_name": ts_meta.get("station_name"),
+                    "parameter": parameter,
+                    "unit": metadata.get("unit") or ts_meta.get("unit"),
+                    "latitude": (
+                        metadata.get("latitude")
+                        if metadata.get("latitude") is not None
+                        else ts_meta.get("latitude")
+                    ),
+                    "longitude": (
+                        metadata.get("longitude")
+                        if metadata.get("longitude") is not None
+                        else ts_meta.get("longitude")
+                    ),
+                    "timestamp": timestamp,
+                    "value": value,
+                    "quality_code": quality_code,
+                }
+            )
+
+        return rows
+
+    # ------------------------------------------------------------------ #
+    # KiWIS helpers
+    # ------------------------------------------------------------------ #
+    def _resolve_timeseries(
+        self,
+        station_id: str,
+        parameter: str,
+    ) -> dict | None:
+        """Resolve a SEPA station and parameter to its 15-minute time series.
+
+        SEPA stations can publish several series for the same parameter,
+        including annual maxima, peaks over threshold, gaugings, daily means,
+        and regular 15-minute observations.
+
+        AquaScope uses the 15-minute observation series so normal collection
+        does not accidentally select an aggregated or event-based product.
+        """
+        params = {
+            "service": "kisters",
+            "type": "queryServices",
+            "datasource": 0,
+            "request": "getTimeseriesList",
+            "station_no": station_id,
+            "stationparameter_no": parameter,
+            "ts_name": "15minute",
+            "returnfields": (
+                "station_no,station_name,station_latitude,"
+                "station_longitude,stationparameter_name,"
+                "ts_name,ts_id,ts_path"
+            ),
+            "format": "json",
+        }
+
+        try:
+            data = self.client.get_json(SEPA_BASE_URL, params=params)
+        except Exception:
+            logger.warning(
+                "SEPA getTimeseriesList request failed for station %s",
+                station_id,
+                exc_info=True,
+            )
+            return None
+
+        row = self._first_data_row(data)
+
+        if row is None:
+            return None
+
+        ts_id = row.get("ts_id")
+
+        if not ts_id:
+            return None
+
+        return {
+            "ts_id": ts_id,
+            "station_no": row.get("station_no", station_id),
+            "station_name": row.get("station_name"),
+            "latitude": self._float_or_none(
+                row.get("station_latitude")
+            ),
+            "longitude": self._float_or_none(
+                row.get("station_longitude")
+            ),
+            "unit": PARAMETER_UNITS.get(parameter),
+        }
+
+    def _fetch_timeseries_values(
+        self,
+        ts_id: str,
+        start_date: str,
+        end_date: str | None,
+    ) -> tuple[dict, list[tuple[str, str, str | None]]]:
+        """Fetch observations and metadata for a SEPA time-series ID."""
+        params: dict[str, Any] = {
+            "service": "kisters",
+            "type": "queryServices",
+            "datasource": 0,
+            "request": "getTimeseriesValues",
+            "ts_id": ts_id,
+            "from": start_date,
+            "returnfields": "Timestamp,Value,Quality Code",
+            "metadata": "true",
+            "format": "json",
+        }
+
+        if end_date:
+            params["to"] = end_date
+
+        try:
+            data = self.client.get_json(SEPA_BASE_URL, params=params)
+        except Exception:
+            logger.warning(
+                "SEPA getTimeseriesValues request failed for ts_id %s",
+                ts_id,
+                exc_info=True,
+            )
+            return {}, []
+
+        series = self._first_series(data)
+
+        if series is None:
+            return {}, []
+
+        metadata = {
+            "latitude": self._float_or_none(
+                series.get("station_latitude")
+            ),
+            "longitude": self._float_or_none(
+                series.get("station_longitude")
+            ),
+            "unit": series.get("ts_unitsymbol"),
+        }
+
+        columns = [
+            column.strip()
+            for column in series.get("columns", "").split(",")
+        ]
+
+        observations: list[tuple[str, str, str | None]] = []
+
+        for record in series.get("data", []):
+            row = dict(zip(columns, record))
+
+            timestamp = row.get("Timestamp")
+            value = row.get("Value")
+
+            if timestamp is None or value is None:
+                continue
+
+            observations.append(
+                (
+                    timestamp,
+                    value,
+                    row.get("Quality Code"),
+                )
+            )
+
+        return metadata, observations
+
+    @staticmethod
+    def _first_data_row(data: Any) -> dict | None:
+        """Return the first row from a KiWIS list-style response."""
+        if not isinstance(data, list) or not data:
+            return None
+
+        if data[0] == "No matches.":
+            return None
+
+        header, *rows = data
+
+        if not rows or not isinstance(header, list):
+            return None
+
+        return dict(zip(header, rows[0]))
+
+    @staticmethod
+    def _first_series(data: Any) -> dict | None:
+        """Return the first series from a KiWIS values response."""
+        if isinstance(data, dict):
+            return data
+
+        if isinstance(data, list) and data and isinstance(data[0], dict):
+            return data[0]
+
+        return None
+
+    @staticmethod
+    def _float_or_none(value: Any) -> float | None:
+        """Convert an API metadata value to a float when possible."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------ #
+    # normalise
+    # ------------------------------------------------------------------ #
+    def normalise(
+        self,
+        raw: list[dict],
+    ) -> list[StreamflowReading | WaterLevelReading]:
+        """Convert raw SEPA observations into AquaScope records."""
+        if not raw:
+            return []
+
+        records: list[StreamflowReading | WaterLevelReading] = []
+        skipped = 0
+
+        for row in raw:
+            try:
+                value = row.get("value")
+
+                if value is None or str(value).strip() in {
+                    "",
+                    "NaN",
+                    "--",
+                }:
+                    continue
+
+                value = float(value)
+
+                timestamp = row.get("timestamp")
+
+                if not timestamp:
+                    continue
+
+                reading_datetime = datetime.fromisoformat(
+                    str(timestamp)
+                ).replace(tzinfo=None)
+
+                location = None
+                latitude = row.get("latitude")
+                longitude = row.get("longitude")
+
+                if latitude is not None and longitude is not None:
+                    location = GeoLocation(
+                        latitude=float(latitude),
+                        longitude=float(longitude),
+                    )
+
+                parameter = row.get("parameter", "")
+
+                unit = (
+                    row.get("unit")
+                    or PARAMETER_UNITS.get(parameter, "")
+                )
+
+                quality_code = row.get("quality_code")
+
+                remark = (
+                    f"Quality Code: {quality_code}"
+                    if quality_code is not None
+                    else None
+                )
+
+                if parameter == FLOW_PARAMETER:
+                    records.append(
+                        StreamflowReading(
+                            source=DataSource.SCOTLAND_SEPA,
+                            station_id=str(
+                                row.get("station_no", "unknown")
+                            ),
+                            station_name=row.get("station_name"),
+                            location=location,
+                            reading_datetime=reading_datetime,
+                            discharge_cms=value,
+                            source_type="in_situ",
+                            unit=unit or "m3/s",
+                            remark=remark,
+                        )
+                    )
+
+                elif parameter == LEVEL_PARAMETER:
+                    records.append(
+                        WaterLevelReading(
+                            source=DataSource.SCOTLAND_SEPA,
+                            station_id=str(
+                                row.get("station_no", "unknown")
+                            ),
+                            station_name=row.get("station_name"),
+                            location=location,
+                            reading_datetime=reading_datetime,
+                            water_level=value,
+                            unit=unit or "m",
+                            remark=remark,
+                        )
+                    )
+
+            except (TypeError, ValueError, KeyError) as exc:
+                skipped += 1
+                logger.debug(
+                    "Skipping SEPA row: %s",
+                    exc,
+                )
+
+        if skipped:
+            logger.warning(
+                "SEPA normalise: skipped %d of %d row(s) that failed to parse.",
+                skipped,
+                len(raw),
+            )
+
+        return records

--- a/aquascope/schemas/water_data.py
+++ b/aquascope/schemas/water_data.py
@@ -40,6 +40,7 @@ class DataSource(str, Enum):
     INDIA_WRIS = "india_wris"
     HUBEAU = "france_hubeau"
     UK_EA = "uk_ea"
+    SCOTLAND_SEPA = "scotland_sepa"
     GRDC = "grdc"
     CAMELS_CL = "camels_cl"
     CAMELS_BR = "camels_br"

--- a/docs/data_sources.md
+++ b/docs/data_sources.md
@@ -1,6 +1,6 @@
 # Data Sources
 
-AquaScope ships **36 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
+AquaScope ships **37 collectors** that normalise water data into typed Pydantic records. One API call per source, one schema across the toolkit.
 
 Most sources emit point observations and share the unified `water_data` schema (`WaterQualitySample`, `WaterLevelReading`, `ReservoirStatus`). Three aggregate/gridded sources use purpose-built record types that match their data shape: **FAO AQUASTAT** returns country-level `AquastatRecord`, **UN SDG 6** returns `SDG6Indicator`, and **FAO WaPOR** returns gridded `WaPORObservation`.
 
@@ -45,6 +45,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | [ANA Hidroweb](https://www.snirh.gov.br/hidroweb/) | `brazil_ana` | Brazil | Telemetric streamflow, stage, rainfall | REST | ✅ |
 | [Ireland OPW](https://waterlevel.ie) | `ireland_opw` | Ireland | River / lake water level (15-min resolution) | GeoJSON / CSV | ✅ |
 | [Environment Agency (England)](https://environment.data.gov.uk) | `uk_ea` | England (UK) | River and groundwater levels, river flow, rainfall data | REST | ✅ |
+| [SEPA Hydrometric Data](https://timeseries.sepa.org.uk/) | `scotland_sepa` | Scotland (UK) | River flow and river level (15-min observations) | KISTERS WISKI (KiWIS) | ✅ |
 | [BOM Water Data Online](http://www.bom.gov.au/waterdata/) | `bom` | Australia | Streamflow, water level, storage, groundwater level | KISTERS WISKI (KiWIS) | ✅ |
 | [South Africa DWS](https://www.dws.gov.za/Hydrology/) | `south_africa_dws` | South Africa | Verified river discharge, water level | HTML / text | ✅ |
 | [Colorado DWR/CDSS](https://dwr.state.co.us/Rest/GET/Help) | `colorado_cdss` | Colorado, USA | State telemetry streamflow observations | REST | ✅ |
@@ -76,6 +77,7 @@ To request a new source, open an [issue](https://github.com/Rekin226/aquascope/i
 | Greece Hydroscope | No | Open access via hydroscope.gr |
 | Greece OpenHi.net | No | Open access via system.openhi.net (CC BY-SA 4.0) |
 | Environment Agency (England) | No | Open access |
+| SEPA Hydrometric Data (Scotland) | No | Open access |
 | BOM Water Data Online | No | Open access |
 | Colorado DWR/CDSS | No | Open access |
 

--- a/tests/test_collectors/test_scotland_sepa.py
+++ b/tests/test_collectors/test_scotland_sepa.py
@@ -1,0 +1,388 @@
+"""Tests for the Scotland SEPA hydrometric time-series collector.
+
+Station reference data:
+
+- 133171 "Newton Stewart" -- station number, coordinates, flow series,
+  and river-level series confirmed against the live SEPA KiWIS API.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from aquascope.collectors.scotland_sepa import (
+    FLOW_PARAMETER,
+    LEVEL_PARAMETER,
+    PARAMETER_UNITS,
+    ScotlandSepaCollector,
+)
+from aquascope.schemas.water_data import (
+    DataSource,
+    StreamflowReading,
+    WaterLevelReading,
+)
+
+TS_LIST_FLOW_RESPONSE = [
+    [
+        "station_no",
+        "station_name",
+        "station_latitude",
+        "station_longitude",
+        "stationparameter_name",
+        "ts_name",
+        "ts_id",
+        "ts_path",
+    ],
+    [
+        "133171",
+        "Newton Stewart",
+        "54.95726338",
+        "-4.480525846",
+        "Flow",
+        "15minute",
+        "67947010",
+        "1/133171/Q/15m.Cmd",
+    ],
+]
+
+TS_LIST_LEVEL_RESPONSE = [
+    [
+        "station_no",
+        "station_name",
+        "station_latitude",
+        "station_longitude",
+        "stationparameter_name",
+        "ts_name",
+        "ts_id",
+        "ts_path",
+    ],
+    [
+        "133171",
+        "Newton Stewart",
+        "54.95726338",
+        "-4.480525846",
+        "Level",
+        "15minute",
+        "67948010",
+        "1/133171/SG/15m.Cmd",
+    ],
+]
+
+TS_LIST_NO_MATCH = ["No matches."]
+
+# getTimeseriesValues with metadata=true returns station coordinates and
+# the API's unit alongside the observation data.
+TS_VALUES_FLOW_RESPONSE = [
+    {
+        "ts_id": "67947010",
+        "station_latitude": "54.95726338",
+        "station_longitude": "-4.480525846",
+        "ts_unitsymbol": "m³/s",
+        "columns": "Timestamp,Value,Quality Code",
+        "data": [
+            ["2026-09-10T00:00:00.000Z", "8.315", "254"],
+            ["2026-09-10T00:15:00.000Z", "8.262", "254"],
+            ["2026-09-10T00:30:00.000Z", "", "255"],
+        ],
+    }
+]
+
+TS_VALUES_LEVEL_RESPONSE = [
+    {
+        "ts_id": "67948010",
+        "station_latitude": "54.95726338",
+        "station_longitude": "-4.480525846",
+        "ts_unitsymbol": "m",
+        "columns": "Timestamp,Value,Quality Code",
+        "data": [
+            ["2026-09-10T00:00:00.000Z", "0.708", "254"],
+        ],
+    }
+]
+
+SAMPLE_FLOW_RAW = {
+    "station_no": "133171",
+    "station_name": "Newton Stewart",
+    "parameter": "Q",
+    "unit": "m³/s",
+    "latitude": 54.95726338,
+    "longitude": -4.480525846,
+    "timestamp": "2026-09-10T00:00:00.000Z",
+    "value": "8.315",
+    "quality_code": "254",
+}
+
+SAMPLE_LEVEL_RAW = {
+    "station_no": "133171",
+    "station_name": "Newton Stewart",
+    "parameter": "SG",
+    "unit": "m",
+    "latitude": 54.95726338,
+    "longitude": -4.480525846,
+    "timestamp": "2026-09-10T00:00:00.000Z",
+    "value": "0.708",
+    "quality_code": "254",
+}
+
+
+class TestScotlandSepaInit:
+    def test_collector_name(self):
+        assert ScotlandSepaCollector().name == "scotland_sepa"
+
+
+class TestScotlandSepaFetchRaw:
+    def setup_method(self):
+        self.mock_client = MagicMock()
+        self.collector = ScotlandSepaCollector(client=self.mock_client)
+
+    def test_fetch_raw_requires_station_id(self):
+        try:
+            self.collector.fetch_raw(station_id="")
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            assert "station_id" in str(exc)
+
+    def test_fetch_raw_rejects_unknown_parameter(self):
+        try:
+            self.collector.fetch_raw(
+                station_id="133171",
+                parameter="UNKNOWN",
+            )
+            assert False, "Should have raised ValueError"
+        except ValueError as exc:
+            assert "'Q'" in str(exc)
+            assert "'SG'" in str(exc)
+
+    def test_fetch_raw_returns_merged_flow_rows(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        rows = self.collector.fetch_raw(
+            station_id="133171",
+            parameter=FLOW_PARAMETER,
+            days=1,
+        )
+
+        # Missing values are deliberately retained here because normalise()
+        # owns filtering and validation of individual observations.
+        assert len(rows) == 3
+        assert rows[0]["station_no"] == "133171"
+        assert rows[0]["station_name"] == "Newton Stewart"
+        assert rows[0]["parameter"] == FLOW_PARAMETER
+        assert rows[0]["unit"] == "m³/s"
+        assert rows[0]["latitude"] == 54.95726338
+        assert rows[0]["longitude"] == -4.480525846
+        assert rows[0]["value"] == "8.315"
+
+    def test_fetch_raw_calls_timeseries_list_then_values(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        self.collector.fetch_raw(
+            station_id="133171",
+            parameter=FLOW_PARAMETER,
+        )
+
+        calls = self.mock_client.get_json.call_args_list
+        assert calls[0][1]["params"]["request"] == "getTimeseriesList"
+        assert calls[1][1]["params"]["request"] == "getTimeseriesValues"
+
+    def test_fetch_raw_requests_15_minute_series(self):
+        # A station can expose annual maxima, daily means, gaugings, and other
+        # products for the same parameter. Explicitly requesting "15minute"
+        # prevents AquaScope from accidentally selecting an aggregate series.
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        self.collector.fetch_raw(
+            station_id="133171",
+            parameter=FLOW_PARAMETER,
+        )
+
+        params = self.mock_client.get_json.call_args_list[0][1]["params"]
+
+        assert params["station_no"] == "133171"
+        assert params["stationparameter_no"] == FLOW_PARAMETER
+        assert params["ts_name"] == "15minute"
+
+    def test_fetch_raw_requests_timeseries_list_fields(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        self.collector.fetch_raw(station_id="133171")
+
+        params = self.mock_client.get_json.call_args_list[0][1]["params"]
+
+        # Unlike BOM's KiWIS deployment, SEPA supports returnfields on
+        # getTimeseriesList, so request only the metadata AquaScope needs.
+        assert "returnfields" in params
+        assert "ts_id" in params["returnfields"]
+        assert "station_name" in params["returnfields"]
+
+    def test_fetch_raw_requests_metadata_on_values_call(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        self.collector.fetch_raw(station_id="133171")
+
+        params = self.mock_client.get_json.call_args_list[1][1]["params"]
+        assert params["metadata"] == "true"
+        assert params["returnfields"] == "Timestamp,Value,Quality Code"
+
+    def test_fetch_raw_no_matches_returns_empty(self):
+        self.mock_client.get_json.side_effect = [TS_LIST_NO_MATCH]
+
+        rows = self.collector.fetch_raw(
+            station_id="999999",
+            parameter=FLOW_PARAMETER,
+        )
+
+        assert rows == []
+
+    def test_fetch_raw_handles_request_failure(self):
+        self.mock_client.get_json.side_effect = ConnectionError("boom")
+
+        rows = self.collector.fetch_raw(
+            station_id="133171",
+            parameter=FLOW_PARAMETER,
+        )
+
+        assert rows == []
+
+    def test_fetch_raw_passes_explicit_dates(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_FLOW_RESPONSE,
+            TS_VALUES_FLOW_RESPONSE,
+        ]
+
+        self.collector.fetch_raw(
+            station_id="133171",
+            parameter=FLOW_PARAMETER,
+            start_date="2026-09-01",
+            end_date="2026-09-10",
+        )
+
+        params = self.mock_client.get_json.call_args_list[1][1]["params"]
+        assert params["from"] == "2026-09-01"
+        assert params["to"] == "2026-09-10"
+
+    def test_fetch_raw_level_resolves_correct_timeseries(self):
+        self.mock_client.get_json.side_effect = [
+            TS_LIST_LEVEL_RESPONSE,
+            TS_VALUES_LEVEL_RESPONSE,
+        ]
+
+        rows = self.collector.fetch_raw(
+            station_id="133171",
+            parameter=LEVEL_PARAMETER,
+        )
+
+        assert len(rows) == 1
+        assert rows[0]["parameter"] == LEVEL_PARAMETER
+        assert rows[0]["unit"] == "m"
+        assert rows[0]["value"] == "0.708"
+
+
+class TestScotlandSepaNormalise:
+    def setup_method(self):
+        self.collector = ScotlandSepaCollector()
+
+    def test_normalise_produces_streamflow_reading_for_flow(self):
+        records = self.collector.normalise([SAMPLE_FLOW_RAW])
+
+        assert len(records) == 1
+        assert isinstance(records[0], StreamflowReading)
+        assert records[0].source == DataSource.SCOTLAND_SEPA
+        assert records[0].station_id == "133171"
+        assert records[0].station_name == "Newton Stewart"
+        assert records[0].discharge_cms == 8.315
+        assert records[0].source_type == "in_situ"
+        assert records[0].unit == "m³/s"
+
+    def test_normalise_produces_water_level_reading_for_level(self):
+        records = self.collector.normalise([SAMPLE_LEVEL_RAW])
+
+        assert len(records) == 1
+        assert isinstance(records[0], WaterLevelReading)
+        assert records[0].source == DataSource.SCOTLAND_SEPA
+        assert records[0].water_level == 0.708
+        assert records[0].unit == "m"
+
+    def test_normalise_parses_location(self):
+        records = self.collector.normalise([SAMPLE_FLOW_RAW])
+
+        assert records[0].location is not None
+        assert abs(records[0].location.latitude - 54.95726338) < 0.001
+        assert abs(records[0].location.longitude - (-4.480525846)) < 0.001
+
+    def test_normalise_preserves_quality_code(self):
+        records = self.collector.normalise([SAMPLE_FLOW_RAW])
+
+        assert records[0].remark == "Quality Code: 254"
+
+    def test_normalise_skips_missing_values(self):
+        raw = [
+            {
+                "station_no": "133171",
+                "parameter": FLOW_PARAMETER,
+                "unit": "m³/s",
+                "timestamp": "2026-09-10T00:30:00.000Z",
+                "value": "",
+                "quality_code": "255",
+            }
+        ]
+
+        assert self.collector.normalise(raw) == []
+
+    def test_normalise_empty_input(self):
+        assert self.collector.normalise([]) == []
+
+    def test_normalise_falls_back_to_default_flow_unit(self):
+        raw = [
+            {
+                "station_no": "133171",
+                "parameter": FLOW_PARAMETER,
+                "unit": "",
+                "timestamp": "2026-09-10T00:00:00.000Z",
+                "value": "8.315",
+            }
+        ]
+
+        records = self.collector.normalise(raw)
+
+        assert records[0].unit == PARAMETER_UNITS[FLOW_PARAMETER]
+
+    def test_normalise_falls_back_to_default_level_unit(self):
+        raw = [
+            {
+                "station_no": "133171",
+                "parameter": LEVEL_PARAMETER,
+                "unit": "",
+                "timestamp": "2026-09-10T00:00:00.000Z",
+                "value": "0.708",
+            }
+        ]
+
+        records = self.collector.normalise(raw)
+
+        assert records[0].unit == PARAMETER_UNITS[LEVEL_PARAMETER]
+
+
+class TestScotlandSepaConstants:
+    def test_parameter_codes(self):
+        assert FLOW_PARAMETER == "Q"
+        assert LEVEL_PARAMETER == "SG"
+
+    def test_default_units(self):
+        assert PARAMETER_UNITS[FLOW_PARAMETER] == "m3/s"
+        assert PARAMETER_UNITS[LEVEL_PARAMETER] == "m"


### PR DESCRIPTION
Adds support for Scotland's SEPA hydrometric time-series API.

Changes:

* new `ScotlandSepaCollector` using SEPA's KiWIS API
* support for river flow (`Q`) and river level (`SG`)
* mapping to `StreamflowReading` and `WaterLevelReading`
* 15-minute time-series discovery and collection
* `DataSource.SCOTLAND_SEPA`
* collector registration in `aquascope.collectors`
* mocked collector tests covering fetch and normalisation behaviour
* SEPA documentation in `docs/data_sources.md`

Testing:

* `ruff check aquascope/ tests/` — passed
* `pytest tests/test_collectors/test_scotland_sepa.py` — 22 passed
* `mypy aquascope/collectors/scotland_sepa.py --follow-imports=skip --ignore-missing-imports` — passed
* Full `pytest` currently stops during collection on Windows because `tests/test_collectors/test_taiwan_cwa.py` reads `cwa_station_list.json` using the system `cp1252` encoding, causing an unrelated `UnicodeDecodeError`.

Closes #317
