### PR TITLE
README: state a station floor instead of a count that goes stale weekly

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ AquaScope unifies **36 global water-data sources** behind one Python schema, the
 ## 🌍 Try it without installing anything
 
 **[AquaScope Explorer](https://rekin226-aquascope-explorer.static.hf.space/)**: every public gauge we can reach on one map
-(62,613 stations from USGS, Australia BOM, UK EA, Hub'Eau, Taiwan CWA, PEGELONLINE and Ireland OPW;
-Greece and Brazil land with the next weekly rebuild). Click one and get the observed record,
+(more than 60,000 stations from USGS, Brazil ANA, UK EA, Australia BOM, Hub'Eau, Taiwan CWA,
+PEGELONLINE, Greece and Ireland OPW; the dataset below carries the live count). Click one and get the observed record,
 flood frequency with confidence limits, flow duration and trend, computed in your browser by aquascope on Pyodide.
 The catalog behind it is an open GeoParquet dataset, [`Rekin226/aquascope-gauges`](https://huggingface.co/datasets/Rekin226/aquascope-gauges), harvested weekly.
 Press **Ask ✨** to type a question in plain language (bring your own key, Groq and Hugging Face are free): the model picks the


### PR DESCRIPTION
The Explorer paragraph carried an exact station count. It is wrong within a week of every release, and it was wrong again the moment the harvest ran last night.

| stated | reality |
| :--- | :--- |
| 45,919 before 0.16.0 | catalogue held 62,613 |
| 62,613 at 0.16.0 | catalogue holds 67,099 after Greece and Brazil landed |

The deeper problem is that the total is not stable even between harvests. BOM returned 16,669 stations on 7 September and 8,973 on 11 September, because its KiWIS gateway 500s on some parameter types and the collector publishes a partial catalogue while reporting healthy. That is #289, which I have reopened with the evidence: the fix that closed it handled total failure, not the partial case in its title.

Quoting a precise total on the front page bakes that swing in. So the sentence now:

- states a floor, "more than 60,000 stations", which survives a BOM run going bad
- names the sources actually in the published catalogue, which now includes Brazil ANA and Greece and did not before
- points at the Hugging Face dataset for the live figure, where it is derived rather than typed

`tests/test_docs_counts.py` passes. No other claim touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o4g9fEkVchE97ZkWNqPBD